### PR TITLE
Implement IRdfHandler route for JsonLdReader

### DIFF
--- a/src/JsonLDIntegration/JsonLDIntegration/JsonLdReader.cs
+++ b/src/JsonLDIntegration/JsonLDIntegration/JsonLdReader.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
 using VDS.RDF;
+using VDS.RDF.Parsing.Handlers;
 
 namespace JsonLDIntegration
 {
@@ -23,7 +24,87 @@ namespace JsonLDIntegration
 
         public void Load(IRdfHandler handler, TextReader input)
         {
-            throw new NotImplementedException();
+            bool finished = false;
+            try
+            {
+                // Tell handler we starting parsing
+                handler.StartRdf();
+
+                // Perform actual parsing
+                using (JsonReader jsonReader = new JsonTextReader(input))
+                {
+                    JToken json = JToken.Load(jsonReader);
+
+                    foreach (JObject subjectJObject in json)
+                    {
+                        string subject = subjectJObject["@id"].ToString();
+
+                        JToken type;
+                        if (subjectJObject.TryGetValue("@type", out type))
+                        {
+                            if (type is JArray)
+                            {
+                                foreach (JToken t in (JArray) type)
+                                {
+                                    if (!HandleTriple(handler, subject, "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", new Uri(t.ToString()), null)) return;
+                                }
+                            }
+                            else
+                            {
+                                if (!HandleTriple(handler, subject, "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", new Uri(type.ToString()), null)) return;
+                            }
+                        }
+
+                        foreach (JProperty property in subjectJObject.Properties())
+                        {
+                            if (property.Name == "@id" || property.Name == "@type")
+                            {
+                                continue;
+                            }
+
+                            foreach (JObject objectJObject in property.Value)
+                            {
+                                JToken id;
+                                JToken value;
+                                if (objectJObject.TryGetValue("@id", out id))
+                                {
+                                    if (!HandleTriple(handler, subject, property.Name, new Uri(id.ToString()), null)) return;
+                                }
+                                else if (objectJObject.TryGetValue("@value", out value))
+                                {
+                                    string datatype = null;
+                                    JToken datatypeJToken;
+                                    if (objectJObject.TryGetValue("@type", out datatypeJToken))
+                                    {
+                                        datatype = datatypeJToken.ToString();
+                                    }
+                                    if (!HandleTriple(handler, subject, property.Name, value.ToString(), datatype)) return;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Tell handler we've finished parsing
+                finished = true;
+                handler.EndRdf(true);
+            }
+            catch
+            {
+                // Catch all block to fulfill the IRdfHandler contract of informing the handler when the parsing has ended with failure
+                finished = true;
+                handler.EndRdf(false);
+                throw;
+            }
+            finally
+            {
+                // Finally block handles the case where we exit the parsing loop early because the handler indicated it did not want
+                // to receive further triples.  In this case finished will be set to false and we need to inform the handler we're are done
+                if (!finished)
+                {
+                    handler.EndRdf(true);
+                }
+            }
         }
 
         public void Load(IRdfHandler handler, StreamReader input)
@@ -38,60 +119,7 @@ namespace JsonLDIntegration
 
         public void Load(IGraph g, TextReader input)
         {
-            JToken json;
-            using (JsonReader jsonReader = new JsonTextReader(input))
-            {
-                json = JToken.Load(jsonReader);
-
-                foreach (JObject subjectJObject in json)
-                {
-                    string subject = subjectJObject["@id"].ToString();
-
-                    JToken type;
-                    if (subjectJObject.TryGetValue("@type", out type))
-                    {
-                        if (type is JArray)
-                        {
-                            foreach (JToken t in (JArray)type)
-                            {
-                                Assert(g, subject, "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", new Uri(t.ToString()), null);
-                            }
-                        }
-                        else
-                        {
-                            Assert(g, subject, "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", new Uri(type.ToString()), null);
-                        }
-                    }
-
-                    foreach (JProperty property in subjectJObject.Properties())
-                    {
-                        if (property.Name == "@id" || property.Name == "@type")
-                        {
-                            continue;
-                        }
-
-                        foreach (JObject objectJObject in property.Value)
-                        {
-                            JToken id;
-                            JToken value;
-                            if (objectJObject.TryGetValue("@id", out id))
-                            {
-                                Assert(g, subject, property.Name, new Uri(id.ToString()), null);
-                            }
-                            else if (objectJObject.TryGetValue("@value", out value))
-                            {
-                                string datatype = null;
-                                JToken datatypeJToken;
-                                if (objectJObject.TryGetValue("@type", out datatypeJToken))
-                                {
-                                    datatype = datatypeJToken.ToString();
-                                }
-                                Assert(g, subject, property.Name, value.ToString(), datatype);
-                            }
-                        }
-                    }
-                }
-            }
+            Load(new GraphHandler(g), input);
         }
 
         public void Load(IGraph g, StreamReader input)
@@ -101,33 +129,42 @@ namespace JsonLDIntegration
 
         public event RdfReaderWarning Warning;
 
-        void Assert(IGraph g, string subject, string predicate, object obj, string datatype)
+        /// <summary>
+        /// Creates and handles a triple
+        /// </summary>
+        /// <param name="handler">Handler</param>
+        /// <param name="subject">Subject</param>
+        /// <param name="predicate">Predicate</param>
+        /// <param name="obj">Object</param>
+        /// <param name="datatype">Object Datatype</param>
+        /// <returns>True if parsing should continue, false otherwise</returns>
+        bool HandleTriple(IRdfHandler handler, string subject, string predicate, object obj, string datatype)
         {
             INode subjectNode;
             if (subject.StartsWith("_"))
             {
                 string nodeId = subject.Substring(subject.IndexOf(":") + 1);
-                subjectNode = g.CreateBlankNode(nodeId);
+                subjectNode = handler.CreateBlankNode(nodeId);
             }
             else
             {
-                subjectNode = g.CreateUriNode(new Uri(subject));
+                subjectNode = handler.CreateUriNode(new Uri(subject));
             }
 
-            INode predicateNode = g.CreateUriNode(new Uri(predicate));
+            INode predicateNode = handler.CreateUriNode(new Uri(predicate));
             
             INode objNode;
 
             if (obj is Uri)
             {
-                objNode = g.CreateUriNode((Uri)obj);
+                objNode = handler.CreateUriNode((Uri)obj);
             }
             else
             {
-                objNode = (datatype == null) ? g.CreateLiteralNode((string)obj) : g.CreateLiteralNode((string)obj, new Uri(datatype));
+                objNode = (datatype == null) ? handler.CreateLiteralNode((string)obj) : handler.CreateLiteralNode((string)obj, new Uri(datatype));
             }
 
-            g.Assert(subjectNode, predicateNode, objNode);
+            return handler.HandleTriple(new Triple(subjectNode, predicateNode, objNode));
         }
     }
 }


### PR DESCRIPTION
This adds an implementation of the `IRdfHandler` route to the `JsonLdReader`

This follows the usage contract that `IRdfHandler` expects which allows for users to provide handles that halt parsing early if desired.  This also means the `JsonLdReader` will function in the same way as the standard dotNetRDF readers and thus can be dropped into existing dotNetRDF based applications.
