### PR TITLE
Added namespace validation against AAD

### DIFF
--- a/src/NuGet.Services.Publish/IRegistrationOwnership.cs
+++ b/src/NuGet.Services.Publish/IRegistrationOwnership.cs
@@ -19,6 +19,7 @@ namespace NuGet.Services.Publish
         Task<bool> HasOwner(string ns, string id);
         Task<bool> HasRegistration(string ns, string id);
         Task<bool> HasVersion(string ns, string id, string version);
+        Task<bool> HasNamespace(string ns);
 
         string GetUserId();
         Task<string> GetUserName();

--- a/src/NuGet.Services.Publish/NoSecurityRegistrationOwnership.cs
+++ b/src/NuGet.Services.Publish/NoSecurityRegistrationOwnership.cs
@@ -50,6 +50,11 @@ namespace NuGet.Services.Publish
             return Task.FromResult<bool>(false);
         }
 
+        public Task<bool> HasNamespace(string ns)
+        {
+            return Task.FromResult<bool>(true);
+        }
+
         public string GetUserId()
         {
             return "unknown";

--- a/src/NuGet.Services.Publish/OwnershipHelpers.cs
+++ b/src/NuGet.Services.Publish/OwnershipHelpers.cs
@@ -12,6 +12,12 @@ namespace NuGet.Services.Publish
         {
             IList<string> errors = new List<string>();
 
+            if (!await registrationOwnership.HasNamespace(packageIdentity.Namespace))
+            {
+                errors.Add("user is not allowed to publish in this namespace");
+                return errors;
+            }
+
             if (await registrationOwnership.HasRegistration(packageIdentity.Namespace, packageIdentity.Id))
             {
                 if (!await registrationOwnership.HasOwner(packageIdentity.Namespace, packageIdentity.Id))
@@ -33,6 +39,12 @@ namespace NuGet.Services.Publish
         public static async Task<IList<string>> CheckRegistrationAuthorizationForEdit(IRegistrationOwnership registrationOwnership, PackageIdentity packageIdentity)
         {
             IList<string> errors = new List<string>();
+
+            if (!await registrationOwnership.HasNamespace(packageIdentity.Namespace))
+            {
+                errors.Add("user is not allowed to publish in this namespace");
+                return errors;
+            }
 
             if (await registrationOwnership.HasRegistration(packageIdentity.Namespace, packageIdentity.Id))
             {

--- a/src/NuGet.Services.Publish/StorageRegistrationOwnership.cs
+++ b/src/NuGet.Services.Publish/StorageRegistrationOwnership.cs
@@ -206,7 +206,7 @@ namespace NuGet.Services.Publish
         {
             IList<string> domains = new List<string>();
 
-            // If no userId caim is present, we are having a Microsoft Account (MSA) requesting the domains.
+            // If no userId claim is present, we are having a Microsoft Account (MSA) requesting the domains.
             // AAD has no notion of the domains supported there, and will fail the call. Instead of going in, just return an empty list.
             var userId = GetUserId();
             if (!string.IsNullOrEmpty(userId))

--- a/src/NuGet.Services.Publish/StorageRegistrationOwnership.cs
+++ b/src/NuGet.Services.Publish/StorageRegistrationOwnership.cs
@@ -2,12 +2,11 @@
 using Microsoft.Azure.ActiveDirectory.GraphClient.Extensions;
 using Microsoft.Owin;
 using Microsoft.WindowsAzure.Storage;
-using Newtonsoft.Json.Linq;
 using NuGet.Services.Metadata.Catalog.Ownership;
 using NuGet.Services.Metadata.Catalog.Persistence;
 using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 
@@ -142,6 +141,22 @@ namespace NuGet.Services.Publish
             return await _registration.HasVersion(new OwnershipRegistration { Namespace = ns, Id = id }, version);
         }
 
+        public async Task<bool> HasNamespace(string ns)
+        {
+            var domains = (await GetDomains()).ToList();
+            if (domains.Any())
+            {
+                // Check if the user can publish on the namespace
+                return domains.Any(d => d.Equals(ns, StringComparison.OrdinalIgnoreCase));
+            }
+
+            // TODO: What if the user has no allowed domains. Do we return true? False? Or something else?
+            // Example: foo@outlook.com makes this request and has 0 AAD namespaces. Do we return true/false here?
+            // In other words: do we allow publishing to this namespace or not?
+            // Went with true, so the registration records take over in further validation.
+            return true;
+        }
+
         async Task<IUser> GetUser()
         {
             ActiveDirectoryClient activeDirectoryClient = await GetActiveDirectoryClient();
@@ -187,42 +202,42 @@ namespace NuGet.Services.Publish
             return userId;
         }
 
-        public Task<IEnumerable<string>> GetDomains()
+        public async Task<IEnumerable<string>> GetDomains()
         {
             IList<string> domains = new List<string>();
 
-            domains.Add("domain1.com");
-            domains.Add("domain2.com");
-            domains.Add("domain3.com");
-
-            /*
-            ActiveDirectoryClient activeDirectoryClient = await GetActiveDirectoryClient();
-
-            string tenantId = GetTenantId();
-
-            ITenantDetail tenant = activeDirectoryClient.TenantDetails
-                .Where(tenantDetail => tenantDetail.ObjectId.Equals(tenantId))
-                .ExecuteAsync().Result.CurrentPage.FirstOrDefault();
-
-            if (tenant == null)
+            // If no userId caim is present, we are having a Microsoft Account (MSA) requesting the domains.
+            // AAD has no notion of the domains supported there, and will fail the call. Instead of going in, just return an empty list.
+            var userId = GetUserId();
+            if (!string.IsNullOrEmpty(userId))
             {
-                throw new Exception(string.Format("unable to find tenant with object id = {0}", tenantId));
+                ActiveDirectoryClient activeDirectoryClient = await GetActiveDirectoryClient();
+
+                string tenantId = GetTenantId();
+
+                ITenantDetail tenant = activeDirectoryClient.TenantDetails
+                    .Where(tenantDetail => tenantDetail.ObjectId.Equals(tenantId))
+                    .ExecuteAsync().Result.CurrentPage.FirstOrDefault();
+
+                if (tenant == null)
+                {
+                    throw new Exception(string.Format("unable to find tenant with object id = {0}", tenantId));
+                }
+
+                foreach (VerifiedDomain domain in tenant.VerifiedDomains)
+                {
+                    if (domain.@default.HasValue && domain.@default.Value)
+                    {
+                        domains.Insert(0, domain.Name);
+                    }
+                    else
+                    {
+                        domains.Add(domain.Name);
+                    }
+                }
             }
 
-            foreach (VerifiedDomain domain in tenant.VerifiedDomains)
-            {
-                if (domain.@default.HasValue && domain.@default.Value)
-                {
-                    domains.Insert(0, domain.Name);
-                }
-                else
-                {
-                    domains.Add(domain.Name);
-                }
-            }
-            */
-
-            return Task.FromResult<IEnumerable<string>>(domains);
+            return domains;
         }
 
         public Task<IEnumerable<string>> GetTenants()

--- a/tests/PowerShellPublishTests/MockIRegistrationOwnership.cs
+++ b/tests/PowerShellPublishTests/MockIRegistrationOwnership.cs
@@ -59,6 +59,11 @@ namespace PowerShellPublishTests
             throw new NotImplementedException();
         }
 
+        public Task<bool> HasNamespace(string ns)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<bool> IsTenantEnabled()
         {
             throw new NotImplementedException();


### PR DESCRIPTION
Added namespace validation against AAD. Check the StorageRegistrationOwnership class' HasNamespace method. There is a functional question in there as to what should happen with MSA accounts.