### PR TITLE
V3 search and autocomplete throw NullReferenceException on index swap

### DIFF
--- a/src/NuGet.Indexing/GalleryServiceImpl.cs
+++ b/src/NuGet.Indexing/GalleryServiceImpl.cs
@@ -76,10 +76,10 @@ namespace NuGet.Indexing
 
         public static JToken QuerySearch(NuGetSearcherManager searcherManager, string q, bool countOnly, string projectType, string supportedFramework, bool includePrerelease, string sortBy, int skip, int take, bool ignoreFilter)
         {
-            IndexSearcher searcher = searcherManager.Get();
+            var searcher = searcherManager.Get();
             try
             {
-                Filter filter = ignoreFilter ? null : searcherManager.GetFilter(includePrerelease, null);
+                Filter filter = ignoreFilter ? null : searcherManager.GetFilter(searcher, includePrerelease, null);
 
                 Query query = LuceneQueryCreator.Parse(q, false);
 
@@ -113,7 +113,7 @@ namespace NuGet.Indexing
             return MakeCountResult(topDocs.TotalHits);
         }
 
-        private static JToken ListDocumentsImpl(IndexSearcher searcher, Query query, IDictionary<string, int> rankings, Filter filter, string sortBy, int skip, int take, NuGetSearcherManager manager)
+        private static JToken ListDocumentsImpl(NuGetIndexSearcher searcher, Query query, IDictionary<string, int> rankings, Filter filter, string sortBy, int skip, int take, NuGetSearcherManager manager)
         {
             Query boostedQuery = new RankingScoreQuery(query, rankings);
 
@@ -153,11 +153,11 @@ namespace NuGet.Indexing
             return new JObject { { "totalHits", totalHits } };
         }
 
-        private static JToken MakeResults(IndexSearcher searcher, TopDocs topDocs, int skip, int take, Query boostedQuery, IDictionary<string, int> rankings, NuGetSearcherManager manager)
+        private static JToken MakeResults(NuGetIndexSearcher searcher, TopDocs topDocs, int skip, int take, Query boostedQuery, IDictionary<string, int> rankings, NuGetSearcherManager manager)
         {
             JArray array = new JArray();
 
-            Tuple<OpenBitSet, OpenBitSet> latestBitSets = manager.GetBitSets(null);
+            Tuple<OpenBitSet, OpenBitSet> latestBitSets = manager.GetBitSets(searcher, null);
 
             for (int i = skip; i < Math.Min(skip + take, topDocs.ScoreDocs.Length); i++)
             {

--- a/src/NuGet.Indexing/ISearchIndexInfo.cs
+++ b/src/NuGet.Indexing/ISearchIndexInfo.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.Indexing
+{
+    public interface ISearchIndexInfo
+    {
+        string IndexName { get; }
+        DateTime LastReopen { get; }
+        int NumDocs { get; }
+        IDictionary<string, string> CommitUserData { get; }
+    }
+}

--- a/src/NuGet.Indexing/IndexTask.cs
+++ b/src/NuGet.Indexing/IndexTask.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Lucene.Net.Store;
 using Lucene.Net.Store.Azure;
 using Microsoft.WindowsAzure.Storage;

--- a/src/NuGet.Indexing/NuGet.Indexing.csproj
+++ b/src/NuGet.Indexing/NuGet.Indexing.csproj
@@ -151,10 +151,13 @@
     <Compile Include="Facets.cs" />
     <Compile Include="GalleryServiceImpl.cs" />
     <Compile Include="IdentifierAutocompleteAnalyzer.cs" />
+    <Compile Include="ISearchIndexInfo.cs" />
     <Compile Include="LatestVersionFilter.cs" />
     <Compile Include="LocalFrameworksList.cs" />
     <Compile Include="MetadataImpl.cs" />
+    <Compile Include="NuGetIndexSearcher.cs" />
     <Compile Include="PackageTenantId.cs" />
+    <Compile Include="SearcherManagerT.cs" />
     <Compile Include="SecureSearcherManager.cs" />
     <Compile Include="PackageVersions.cs" />
     <Compile Include="SecureQueryImpl.cs" />
@@ -212,6 +215,7 @@
     <Compile Include="TagsAnalyzer.cs" />
     <Compile Include="TokenizingHelper.cs" />
     <Compile Include="VersionAnalyzer.cs" />
+    <Compile Include="VersionDownloads.cs" />
     <Compile Include="WarehousePackageRanking.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Indexing/NuGetIndexSearcher.cs
+++ b/src/NuGet.Indexing/NuGetIndexSearcher.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Lucene.Net.Index;
+using Lucene.Net.Search;
+using Lucene.Net.Util;
+using Newtonsoft.Json.Linq;
+
+namespace NuGet.Indexing
+{
+    public class NuGetIndexSearcher : IndexSearcher
+    {
+        public NuGetIndexSearcher(IndexReader reader, Tuple<IDictionary<string, Filter>, IDictionary<string, Filter>> filters, IDictionary<string, Tuple<OpenBitSet, OpenBitSet>> latestBitSets, JArray[] versionListsByDoc, JArray[] versionsByDoc) 
+            : base(reader)
+        {
+            Filters = filters;
+            LatestBitSets = latestBitSets;
+            VersionListsByDoc = versionListsByDoc;
+            VersionsByDoc = versionsByDoc;
+        }
+
+        public Tuple<IDictionary<string, Filter>, IDictionary<string, Filter>> Filters { get; private set; }
+        public IDictionary<string, Tuple<OpenBitSet, OpenBitSet>> LatestBitSets { get; private set; }
+        public JArray[] VersionListsByDoc { get; private set; }
+        public JArray[] VersionsByDoc { get; private set; }
+    }
+}

--- a/src/NuGet.Indexing/OpenBitSetLookupFilter.cs
+++ b/src/NuGet.Indexing/OpenBitSetLookupFilter.cs
@@ -1,15 +1,16 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using Lucene.Net.Index;
 using Lucene.Net.Search;
 using Lucene.Net.Util;
-using System.Collections.Generic;
 
 namespace NuGet.Indexing
 {
     public class OpenBitSetLookupFilter : Filter
     {
-        IDictionary<string, OpenBitSet> _bitSetLookup;
+        readonly IDictionary<string, OpenBitSet> _bitSetLookup;
 
         public OpenBitSetLookupFilter(IDictionary<string, OpenBitSet> bitSetLookup)
         {
@@ -19,7 +20,13 @@ namespace NuGet.Indexing
         public override DocIdSet GetDocIdSet(IndexReader segmentReader)
         {
             string segmentName = ((SegmentReader)segmentReader).SegmentName;
-            return _bitSetLookup[segmentName];
+
+            OpenBitSet docIdSet;
+            if (_bitSetLookup.TryGetValue(segmentName, out docIdSet))
+            {
+                return docIdSet;
+            }
+            return null;
         }
     }
 }

--- a/src/NuGet.Indexing/PackageVersions.cs
+++ b/src/NuGet.Indexing/PackageVersions.cs
@@ -1,19 +1,18 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
 using Newtonsoft.Json.Linq;
 using NuGet.Versioning;
-using System;
-using System.Linq;
-using System.Collections.Generic;
 
 namespace NuGet.Indexing
 {
     public class PackageVersions
     {
-        IndexReader _reader;
-        IDictionary<string, List<NuGetVersion>> _registrations;
+        readonly IndexReader _reader;
+        readonly IDictionary<string, List<NuGetVersion>> _registrations;
 
         public PackageVersions(IndexReader reader)
         {
@@ -71,7 +70,7 @@ namespace NuGet.Indexing
             return (id == null) ?  null : id.ToLowerInvariant();
         }
 
-        public JArray[] CreateVersionsLookUp(IDictionary<string, IDictionary<string, int>> downloadLookup, Uri registrationBaseAddress)
+        public JArray[] CreateVersionsLookUp(IDictionary<string, IDictionary<string, int>> downloadLookup)
         {
             IDictionary<string, JArray> versionsById = new Dictionary<string, JArray>();
 
@@ -99,8 +98,7 @@ namespace NuGet.Indexing
                     }
                     versionObj.Add("downloads", downloads);
 
-                    Uri versionUri = new Uri(registrationBaseAddress, string.Format("{0}/{1}.json", registration.Key, version).ToLowerInvariant());
-                    versionObj.Add("@id", versionUri.AbsoluteUri);
+                    versionObj.Add("@id", string.Format("{0}/{1}.json", registration.Key, version).ToLowerInvariant()); // relative URL here
 
                     versions.Add(versionObj);
                 }

--- a/src/NuGet.Indexing/SearcherManager.cs
+++ b/src/NuGet.Indexing/SearcherManager.cs
@@ -4,110 +4,20 @@
 using Lucene.Net.Index;
 using Lucene.Net.Search;
 using Lucene.Net.Store;
-using System.Threading;
 
 namespace NuGet.Indexing
 {
-    public class SearcherManager
+    public class SearcherManager 
+        : SearcherManager<IndexSearcher>
     {
-        private readonly object _sync = new object();
-        private bool _reopening;
-        private IndexSearcher _currentSearcher;
-
-        public Directory Directory { get; private set; }
-
-        public SearcherManager(Directory directory)
-        {
-            Directory = directory;
-            _currentSearcher = new IndexSearcher(IndexReader.Open(Directory, true));
-        }
-
-        public void Open()
-        {
-            Warm(_currentSearcher);
-        }
-
-        protected virtual void Warm(IndexSearcher searcher)
+        public SearcherManager(Directory directory) 
+            : base(directory)
         {
         }
 
-        private void StartReopen()
+        protected override IndexSearcher CreateSearcher(IndexReader reader)
         {
-            lock (_sync)
-            {
-                while (_reopening)
-                {
-                    Monitor.Wait(_sync);
-                }
-                _reopening = true;
-            }
-        }
-
-        private void DoneReopen()
-        {
-            lock (_sync)
-            {
-                _reopening = false;
-                Monitor.PulseAll(_sync);
-            }
-        }
-        public void MaybeReopen()
-        {
-            StartReopen();
-
-            try
-            {
-                IndexSearcher searcher = Get();
-                try
-                {
-                    IndexReader newReader = _currentSearcher.IndexReader.Reopen();
-                    if (newReader != _currentSearcher.IndexReader)
-                    {
-                        IndexSearcher newSearcher = new IndexSearcher(newReader);
-                        Warm(newSearcher);
-                        SwapSearcher(newSearcher);
-                    }
-                }
-                finally
-                {
-                    Release(searcher);
-                }
-            }
-            finally
-            {
-                DoneReopen();
-            }
-        }
-
-        public IndexSearcher Get()
-        {
-            lock (_sync)
-            {
-                _currentSearcher.IndexReader.IncRef();
-                return _currentSearcher;
-            }
-        }
-
-        public void Release(IndexSearcher searcher)
-        {
-            lock (_sync)
-            {
-                searcher.IndexReader.DecRef();
-            }
-        }
-
-        private void SwapSearcher(IndexSearcher newSearcher)
-        {
-            lock (_sync)
-            {
-                Release(_currentSearcher);
-                _currentSearcher = newSearcher;
-            }
-        }
-
-        public void Close()
-        {
-            SwapSearcher(null);
+            return new IndexSearcher(reader);
         }
     }
 }

--- a/src/NuGet.Indexing/SearcherManagerT.cs
+++ b/src/NuGet.Indexing/SearcherManagerT.cs
@@ -1,0 +1,125 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using Lucene.Net.Index;
+using Lucene.Net.Search;
+using Lucene.Net.Store;
+
+namespace NuGet.Indexing
+{
+    public abstract class SearcherManager<TIndexSearcher>
+        where TIndexSearcher : IndexSearcher
+    {
+        private readonly object _sync = new object();
+        private bool _reopening;
+        private TIndexSearcher _currentSearcher;
+
+        public Directory Directory { get; private set; }
+
+        public SearcherManager(Directory directory)
+        {
+            Directory = directory;
+        }
+
+        public void Open()
+        {
+            if (_currentSearcher == null)
+            {
+                lock (_sync)
+                {
+                    if (_currentSearcher == null)
+                    {
+                        _currentSearcher = CreateSearcher(IndexReader.Open(Directory, true));
+                    }
+                }
+            }
+            Warm(_currentSearcher);
+        }
+
+        protected abstract TIndexSearcher CreateSearcher(IndexReader reader);
+
+        protected virtual void Warm(TIndexSearcher searcher)
+        {
+        }
+
+        private void StartReopen()
+        {
+            lock (_sync)
+            {
+                while (_reopening)
+                {
+                    Monitor.Wait(_sync);
+                }
+                _reopening = true;
+            }
+        }
+
+        private void DoneReopen()
+        {
+            lock (_sync)
+            {
+                _reopening = false;
+                Monitor.PulseAll(_sync);
+            }
+        }
+        public void MaybeReopen()
+        {
+            StartReopen();
+
+            try
+            {
+                TIndexSearcher searcher = Get();
+                try
+                {
+                    var newReader = _currentSearcher.IndexReader.Reopen();
+                    if (newReader != _currentSearcher.IndexReader)
+                    {
+                        var newSearcher = CreateSearcher(newReader);
+                        Warm(newSearcher);
+                        SwapSearcher(newSearcher);
+                    }
+                }
+                finally
+                {
+                    Release(searcher);
+                }
+            }
+            finally
+            {
+                DoneReopen();
+            }
+        }
+
+        public TIndexSearcher Get()
+        {
+            lock (_sync)
+            {
+                _currentSearcher.IndexReader.IncRef();
+                return _currentSearcher;
+            }
+        }
+
+        public void Release(TIndexSearcher searcher)
+        {
+            lock (_sync)
+            {
+                searcher.IndexReader.DecRef();
+            }
+        }
+
+        private void SwapSearcher(TIndexSearcher newSearcher)
+        {
+            lock (_sync)
+            {
+                Release(_currentSearcher);
+                _currentSearcher = newSearcher;
+            }
+        }
+
+        public void Close()
+        {
+            SwapSearcher(null);
+        }
+    }
+}

--- a/src/NuGet.Indexing/SecureQueryImpl.cs
+++ b/src/NuGet.Indexing/SecureQueryImpl.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
 using Lucene.Net.Search;
 using Microsoft.Owin;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Net;
-using System.Threading.Tasks;
 
 namespace NuGet.Indexing
 {
@@ -39,7 +40,7 @@ namespace NuGet.Indexing
                 includePrerelease = false;
             }
 
-            bool includeExplanation = false;
+            bool includeExplanation;
             if (!bool.TryParse(context.Request.Query["explanation"], out includeExplanation))
             {
                 includeExplanation = false;
@@ -59,7 +60,7 @@ namespace NuGet.Indexing
             IndexSearcher searcher = searcherManager.Get();
             try
             {
-                Filter filter = searcherManager.GetFilter(tenantId, new string [] { "http://schema.nuget.org/schema#ApiAppPackage" }, includePrerelease, false);
+                Filter filter = searcherManager.GetFilter(tenantId, new[] { "http://schema.nuget.org/schema#ApiAppPackage" }, includePrerelease, false);
 
                 Query query = MakeQuery(q);
 
@@ -188,7 +189,7 @@ namespace NuGet.Indexing
                 includePrerelease = false;
             }
 
-            bool includeExplanation = false;
+            bool includeExplanation;
             if (!bool.TryParse(context.Request.Query["explanation"], out includeExplanation))
             {
                 includeExplanation = false;
@@ -206,7 +207,7 @@ namespace NuGet.Indexing
             IndexSearcher searcher = searcherManager.Get();
             try
             {
-                Filter filter = searcherManager.GetFilter(tenantId, new string[] { "http://schema.nuget.org/schema#ApiAppPackage" }, includePrerelease, true);
+                Filter filter = searcherManager.GetFilter(tenantId, new[] { "http://schema.nuget.org/schema#ApiAppPackage" }, includePrerelease, true);
 
                 Query query = new TermQuery(new Term("Owner", currentOwner));
 

--- a/src/NuGet.Indexing/VersionDownloads.cs
+++ b/src/NuGet.Indexing/VersionDownloads.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Indexing
+{
+    public class VersionDownloads
+    {
+        public VersionDownloads(string normalizedVersion, int downloads)
+        {
+            NormalizedVersion = normalizedVersion;
+            Downloads = downloads;
+        }
+
+        public string NormalizedVersion { get; private set; }
+        public int Downloads { get; private set; }
+    }
+}

--- a/src/NuGet.Services.BasicSearch/NuGet.Services.BasicSearch.csproj
+++ b/src/NuGet.Services.BasicSearch/NuGet.Services.BasicSearch.csproj
@@ -41,6 +41,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.ApplicationInsights">
       <HintPath>..\..\packages\Microsoft.ApplicationInsights.0.12.0-build17386\lib\net40\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>

--- a/src/NuGet.Services.BasicSearch/Startup.cs
+++ b/src/NuGet.Services.BasicSearch/Startup.cs
@@ -139,10 +139,10 @@ namespace NuGet.Services.BasicSearch
                     await ServiceHelpers.WriteResponse(context, HttpStatusCode.OK, GalleryServiceImpl.Query(context, _searcherManager));
                     break;
                 case "/targetframeworks":
-                    await ServiceInfoImpl.TargetFrameworks(context, _searcherManager);
+                    await ServiceInfoImpl.TargetFrameworks(context, _searcherManager.GetTargetFrameworks());
                     break;
                 case "/segments":
-                    await ServiceInfoImpl.Segments(context, _searcherManager);
+                    await ServiceInfoImpl.Segments(context, _searcherManager.GetSegments());
                     break;
                 case "/stats":
                     await ServiceInfoImpl.Stats(context, _searcherManager);

--- a/src/NuGet.Services.BasicSearch/packages.config
+++ b/src/NuGet.Services.BasicSearch/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Lucene.Net" version="3.0.3" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights" version="0.12.0-build17386" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights.PerformanceCollector" version="0.12.0-build17386" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights.RuntimeTelemetry" version="0.12.0-build17386" targetFramework="net45" />
@@ -20,6 +21,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/src/NuGet.Services.Metadata/NuGet.Services.Metadata.csproj
+++ b/src/NuGet.Services.Metadata/NuGet.Services.Metadata.csproj
@@ -38,6 +38,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/NuGet.Services.Metadata/Startup.cs
+++ b/src/NuGet.Services.Metadata/Startup.cs
@@ -229,10 +229,11 @@ namespace NuGet.Services.Metadata
                         break;
 
                     case "/segments":
-                        await ServiceInfoImpl.Segments(context, _searcherManager);
+                        await ServiceInfoImpl.Segments(context, _searcherManager.GetSegments());
                         break;
 
                     case "/stats":
+                        _searcherManager.MaybeReopen();
                         await ServiceInfoImpl.Stats(context, _searcherManager);
                         break;
 

--- a/src/NuGet.Services.Metadata/packages.config
+++ b/src/NuGet.Services.Metadata/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="jQuery" version="2.1.3" targetFramework="net45" />
+  <package id="Lucene.Net" version="3.0.3" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
@@ -17,6 +18,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.2.202250711" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />


### PR DESCRIPTION
This PR fixes https://github.com/NuGet/NuGetGallery/issues/2520:
* Adds support for SearcherManager-specific IndexSearcher implementation
* Updates NuGetSearcherManager to use a NuGetIndexSearcher
* Adds all lookups and auxiliary data that is specific to the loaded index on NuGetIndexSearcher instead of NuGetSearcherManager
* Removes a lock while loading auxiliary data (can now be safely done as it is part of the NuGetIndexSearcher)
* Reduces memory usage for auxiliary data (e.g. versions by document lookup) as it no longer stores all data for bot http and https scheme

@bhuvak @johnataylor @xavierdecoster Can you review code changes?