### PR TITLE
Add tests for CamelCaseFilter and PackageAnalyzer

### DIFF
--- a/src/NuGet.Indexing/PackageAnalyzer.cs
+++ b/src/NuGet.Indexing/PackageAnalyzer.cs
@@ -24,7 +24,7 @@ namespace NuGet.Indexing
                 { "Description", new DescriptionAnalyzer() },
                 { "Summary", new DescriptionAnalyzer() },
                 { "Authors", new DescriptionAnalyzer() },
-                { "Owners", new OwnerAnalyzer() },
+                { "Owner", new OwnerAnalyzer() },
                 { "Tags", new TagsAnalyzer() },
                 { "__default", new KeywordAnalyzer() } // this is just used by the LuceneQueryCreator 
             };

--- a/tests/NuGet.IndexingTests/CamelCaseFilterTests.cs
+++ b/tests/NuGet.IndexingTests/CamelCaseFilterTests.cs
@@ -1,0 +1,165 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Lucene.Net.Analysis.Standard;
+using Lucene.Net.Analysis.Tokenattributes;
+using NuGet.Indexing;
+using Xunit;
+using Lucene.Net.Util;
+using NuGet.IndexingTests.TestSupport;
+
+namespace NuGet.IndexingTests
+{
+    public class CamelCaseFilterTests
+    {
+        [Theory, MemberData("TheoryData")]
+        public void Theory(string text, TokenAttributes[] expected)
+        {
+            // ARRANGE, ACT
+            var actual = this.GetTokenAttributes(text).ToArray();
+
+            // ASSERT
+            Assert.Equal(expected.Length, actual.Length);
+            for (int i = 0; i < expected.Length; i++)
+            {
+                Assert.Equal(expected[i].Term, actual[i].Term);
+                Assert.Equal(expected[i].StartOffset, actual[i].StartOffset);
+                Assert.Equal(expected[i].EndOffset, actual[i].EndOffset);
+                Assert.Equal(expected[i].PositionIncrement, actual[i].PositionIncrement);
+            }
+        }
+
+        private IEnumerable<TokenAttributes> GetTokenAttributes(string text)
+        {
+            var textReader = new StringReader(text);
+            var tokenStream = new StandardTokenizer(Version.LUCENE_30, textReader);
+            var filter = new CamelCaseFilter(tokenStream);
+
+            var termAttribute = filter.GetAttribute<ITermAttribute>();
+            var offsetAttribute = filter.GetAttribute<IOffsetAttribute>();
+            var positionIncrementAttribute = filter.GetAttribute<IPositionIncrementAttribute>();
+
+            while (filter.IncrementToken())
+            {
+                yield return new TokenAttributes
+                {
+                    Term = termAttribute.Term,
+                    StartOffset = offsetAttribute.StartOffset,
+                    EndOffset = offsetAttribute.EndOffset,
+                    PositionIncrement = positionIncrementAttribute.PositionIncrement
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> TheoryData
+        {
+            get
+            {
+                yield return new object[]
+                {
+                    "AaBbCcDd",
+                    new[]
+                    {
+                        new TokenAttributes("AaBbCcDd", 0, 8, 1),
+                        new TokenAttributes("Aa", 0, 2, 0),
+                        new TokenAttributes("AaBb", 0, 4, 0),
+                        new TokenAttributes("Bb", 2, 4, 1),
+                        new TokenAttributes("BbCc", 2, 6, 0),
+                        new TokenAttributes("Cc", 4, 6, 1),
+                        new TokenAttributes("CcDd", 4, 8, 0),
+                        new TokenAttributes("Dd", 6, 8, 1)
+                    }
+                };
+
+                yield return new object[]
+                {
+                    "AaBbCc",
+                    new[]
+                    {
+                        new TokenAttributes("AaBbCc", 0, 6, 1),
+                        new TokenAttributes("Aa", 0, 2, 0),
+                        new TokenAttributes("AaBb", 0, 4, 0),
+                        new TokenAttributes("Bb", 2, 4, 1),
+                        new TokenAttributes("BbCc", 2, 6, 0),
+                        new TokenAttributes("Cc", 4, 6, 1)
+                    }
+                };
+
+                yield return new object[]
+                {
+                    "AaBb",
+                    new[]
+                    {
+                        new TokenAttributes("AaBb", 0, 4, 1),
+                        new TokenAttributes("Aa", 0, 2, 0),
+                        new TokenAttributes("Bb", 2, 4, 1)
+                    }
+                };
+
+                yield return new object[]
+                {
+                    "Aa",
+                    new[]
+                    {
+                        new TokenAttributes("Aa", 0, 2, 1)
+                    }
+                };
+
+                yield return new object[]
+                {
+                    string.Empty,
+                    new object[0]
+                };
+
+                yield return new object[]
+                {
+                    "ABCD",
+                    new[]
+                    {
+                        new TokenAttributes("ABCD", 0, 4, 1)
+                    }
+                };
+
+                yield return new object[]
+                {
+                    "ABCde",
+                    new[]
+                    {
+                        new TokenAttributes("ABCde", 0, 5, 1)
+                    }
+                };
+
+                yield return new object[]
+                {
+                    "AaB",
+                    new[]
+                    {
+                        new TokenAttributes("AaB", 0, 3, 1),
+                        new TokenAttributes("Aa", 0, 2, 0),
+                        new TokenAttributes("B", 2, 3, 1)
+                    }
+                };
+
+                yield return new object[]
+                {
+                    "Abcd",
+                    new[]
+                    {
+                        new TokenAttributes("Abcd", 0, 4, 1)
+                    }
+                };
+
+                yield return new object[]
+                {
+                    "A1a2B3b",
+                    new[]
+                    {
+                        new TokenAttributes("A1a2B3b", 0, 7, 1)
+                    }
+                };
+            }
+        }
+    }
+}

--- a/tests/NuGet.IndexingTests/DescriptionAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/DescriptionAnalyzerTests.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Indexing;
+using NuGet.IndexingTests.TestSupport;
+using Xunit;
+
+namespace NuGet.IndexingTests
+{
+    public class DescriptionAnalyzerTests
+    {
+        [Theory]
+        [MemberData(nameof(TokenizerLowercasesCamelCasesAndRemovesStopWordsInputData))]
+        public void TokenizerLowercasesCamelCasesAndRemovesStopWordsInput(string text, TokenAttributes[] expected)
+        {
+            // arrange, act
+            var actual = new DescriptionAnalyzer().Tokenize(text);
+
+            // assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(TokenizerRemovesCorrectStopWordsData))]
+        public void TokenizerRemovesCorrectStopWords(string stopWord)
+        {
+            // arrange, act
+            var text = $"stop {stopWord} word";
+            var actual = new DescriptionAnalyzer().Tokenize(text);
+            var expected = new[]
+            {
+                new TokenAttributes("stop", 0, 4, 1),
+                new TokenAttributes("word", 6 + stopWord.Length, 10 + stopWord.Length, 2)
+            };
+
+            // assert
+            Assert.Equal(expected, actual);
+        }
+
+        public static IEnumerable<object[]> TokenizerLowercasesCamelCasesAndRemovesStopWordsInputData
+        {
+            get
+            {
+                // split by DotTokenizer
+                yield return new object[]
+                {
+                    "Split sentence.",
+                    new[]
+                    {
+                        new TokenAttributes("split", 0, 5, 1),
+                        new TokenAttributes("sentence", 6, 14, 1)
+                    }
+                };
+
+                // split on camel case
+                yield return new object[]
+                {
+                    "DotNet",
+                    new[]
+                    {
+                        new TokenAttributes("dotnet", 0, 6, 1),
+                        new TokenAttributes("dot", 0, 3, 0),
+                        new TokenAttributes("net", 3, 6, 1)
+                    }
+                };
+
+                // lower case 
+                yield return new object[]
+                {
+                    "D",
+                    new[]
+                    {
+                        new TokenAttributes("d", 0, 1, 1)
+                    }
+                };
+
+                // remove stop words
+                yield return new object[]
+                {
+                    "This is a sentence full of stop words.",
+                    new[]
+                    {
+                        new TokenAttributes("sentence", 10, 18, 4),
+                        new TokenAttributes("full", 19, 23, 1),
+                        new TokenAttributes("stop", 27, 31, 2),
+                        new TokenAttributes("words", 32, 37, 1)
+                    }
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> TokenizerRemovesCorrectStopWordsData
+        {
+            get
+            {
+                yield return new object[] { "a" };
+                yield return new object[] { "an" };
+                yield return new object[] { "and" };
+                yield return new object[] { "are" };
+                yield return new object[] { "as" };
+                yield return new object[] { "at" };
+                yield return new object[] { "be" };
+                yield return new object[] { "but" };
+                yield return new object[] { "by" };
+                yield return new object[] { "for" };
+                yield return new object[] { "i" };
+                yield return new object[] { "if" };
+                yield return new object[] { "in" };
+                yield return new object[] { "into" };
+                yield return new object[] { "is" };
+                yield return new object[] { "it" };
+                yield return new object[] { "its" };
+                yield return new object[] { "no" };
+                yield return new object[] { "not" };
+                yield return new object[] { "of" };
+                yield return new object[] { "on" };
+                yield return new object[] { "or" };
+                yield return new object[] { "s" };
+                yield return new object[] { "such" };
+                yield return new object[] { "that" };
+                yield return new object[] { "the" };
+                yield return new object[] { "their" };
+                yield return new object[] { "then" };
+                yield return new object[] { "there" };
+                yield return new object[] { "these" };
+                yield return new object[] { "they" };
+                yield return new object[] { "this" };
+                yield return new object[] { "to" };
+                yield return new object[] { "was" };
+                yield return new object[] { "we" };
+                yield return new object[] { "will" };
+                yield return new object[] { "with" };
+            }
+        }
+    }
+}

--- a/tests/NuGet.IndexingTests/DescriptionAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/DescriptionAnalyzerTests.cs
@@ -87,6 +87,22 @@ namespace NuGet.IndexingTests
                         new TokenAttributes("words", 32, 37, 1)
                     }
                 };
+
+                // combined
+                yield return new object[]
+                {
+                    "This is a half-baked sentence is describing DotNet.",
+                    new[]
+                    {
+                        new TokenAttributes("half", 10, 14, 4),
+                        new TokenAttributes("baked", 15, 20, 1),
+                        new TokenAttributes("sentence", 21, 29, 1),
+                        new TokenAttributes("describing", 33, 43, 2),
+                        new TokenAttributes("dotnet", 44, 50, 1),
+                        new TokenAttributes("dot", 44, 47, 0),
+                        new TokenAttributes("net", 47, 50, 1)
+                    }
+                };
             }
         }
 

--- a/tests/NuGet.IndexingTests/DotTokenizerTests.cs
+++ b/tests/NuGet.IndexingTests/DotTokenizerTests.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NuGet.Indexing;
+using NuGet.IndexingTests.TestSupport;
+using Xunit;
+
+namespace NuGet.IndexingTests
+{
+    public class DotTokenizerTests
+    {
+        [Theory]
+        [MemberData(nameof(SplitsTextIntoTokensOnCorrectCharactersData))]
+        public void SplitsTextIntoTokensOnCorrectCharacters(char seperator)
+        {
+            // arrange
+            var text = $"Dot{seperator}NET";
+            var tokenizer = new DotTokenizer(new StringReader(text));
+            var expected = new[] { new TokenAttributes("Dot", 0, 3), new TokenAttributes("NET", 4, 7) };
+
+            // act
+            var actual = tokenizer.Tokenize().ToArray();
+
+            // assert
+            Assert.Equal(expected, actual);
+        }
+
+        public static IEnumerable<object[]> SplitsTextIntoTokensOnCorrectCharactersData
+        {
+            get
+            {
+                yield return new object[] { ' ' };
+                yield return new object[] { '\t' };
+                yield return new object[] { '\r' };
+                yield return new object[] { '\n' };
+                yield return new object[] { '.' };
+                yield return new object[] { '-' };
+                yield return new object[] { ',' };
+                yield return new object[] { ';' };
+                yield return new object[] { ':' };
+                yield return new object[] { '\'' };
+                yield return new object[] { '*' };
+                yield return new object[] { '#' };
+                yield return new object[] { '!' };
+                yield return new object[] { '~' };
+                yield return new object[] { '+' };
+                yield return new object[] { '-' };
+                yield return new object[] { '(' };
+                yield return new object[] { ')' };
+                yield return new object[] { '[' };
+                yield return new object[] { ']' };
+                yield return new object[] { '{' };
+                yield return new object[] { '}' };
+            }
+        }
+        
+    }
+}

--- a/tests/NuGet.IndexingTests/IdentifierAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/IdentifierAnalyzerTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Indexing;
+using NuGet.IndexingTests.TestSupport;
+using Xunit;
+
+namespace NuGet.IndexingTests
+{
+    public class IdentifierAnalyzerTests
+    {
+        [Theory]
+        [MemberData(nameof(TokenizerLowercasesAndCamelCasesInputData))]
+        public void TokenizerLowercasesAndCamelCasesInput(string text, TokenAttributes[] expected)
+        {
+            // arrange, act
+            var actual = new IdentifierAnalyzer().Tokenize(text);
+
+            // assert
+            Assert.Equal(expected, actual);
+        }
+
+        public static IEnumerable<object[]> TokenizerLowercasesAndCamelCasesInputData
+        {
+            get
+            {
+                // split by DotTokenizer
+                yield return new object[]
+                {
+                    "a.b",
+                    new[]
+                    {
+                        new TokenAttributes("a", 0, 1, 1),
+                        new TokenAttributes("b", 2, 3, 1)
+                    }
+                };
+
+                // split on camel case
+                yield return new object[]
+                {
+                    "DotNet",
+                    new[]
+                    {
+                        new TokenAttributes("dotnet", 0, 6, 1),
+                        new TokenAttributes("dot", 0, 3, 0),
+                        new TokenAttributes("net", 3, 6, 1)
+                    }
+                };
+
+                // lower case 
+                yield return new object[]
+                {
+                    "D",
+                    new[]
+                    {
+                        new TokenAttributes("d", 0, 1, 1)
+                    }
+                };
+            }
+        }
+    }
+}

--- a/tests/NuGet.IndexingTests/IdentifierAutocompleteAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/IdentifierAutocompleteAnalyzerTests.cs
@@ -87,7 +87,6 @@ namespace NuGet.IndexingTests
                     }
                 };
             }
-
         }
     }
 }

--- a/tests/NuGet.IndexingTests/IdentifierAutocompleteAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/IdentifierAutocompleteAnalyzerTests.cs
@@ -86,6 +86,33 @@ namespace NuGet.IndexingTests
                         new TokenAttributes("net", 10, 13, 1)
                     }
                 };
+
+                // combined
+                yield return new object[]
+                {
+                    "DotNet.ZIP-new",
+                    new[]
+                    {
+                        new TokenAttributes("d", 0, 1, 1),
+                        new TokenAttributes("do", 0, 2, 1),
+                        new TokenAttributes("dot", 0, 3, 1),
+                        new TokenAttributes("dotn", 0, 4, 1),
+                        new TokenAttributes("dotne", 0, 5, 1),
+                        new TokenAttributes("dotnet", 0, 6, 1),
+                        new TokenAttributes("d", 0, 1, 1),
+                        new TokenAttributes("do", 0, 2, 1),
+                        new TokenAttributes("dot", 0, 3, 1),
+                        new TokenAttributes("n", 3, 4, 1),
+                        new TokenAttributes("ne", 3, 5, 1),
+                        new TokenAttributes("net", 3, 6, 1),
+                        new TokenAttributes("z", 7, 8, 1),
+                        new TokenAttributes("zi", 7, 9, 1),
+                        new TokenAttributes("zip", 7, 10, 1),
+                        new TokenAttributes("n", 11, 12, 1),
+                        new TokenAttributes("ne", 11, 13, 1),
+                        new TokenAttributes("new", 11, 14, 1)
+                    }
+                };
             }
         }
     }

--- a/tests/NuGet.IndexingTests/IdentifierAutocompleteAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/IdentifierAutocompleteAnalyzerTests.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Indexing;
+using NuGet.IndexingTests.TestSupport;
+using Xunit;
+
+namespace NuGet.IndexingTests
+{
+    public class IdentifierAutocompleteAnalyzerTests
+    {
+        [Theory]
+        [MemberData(nameof(TokenizerLowercasesNGramsAndCamelCasesInputData))]
+        public void TokenizerLowercasesNGramsAndCamelCasesInput(string text, TokenAttributes[] expected)
+        {
+            // arrange, act
+            var actual = new IdentifierAutocompleteAnalyzer().Tokenize(text);
+
+            // assert
+            Assert.Equal(expected, actual);
+        }
+
+        public static IEnumerable<object[]> TokenizerLowercasesNGramsAndCamelCasesInputData
+        {
+            get
+            {
+                // split by DotTokenizer
+                yield return new object[]
+                {
+                    "a.b",
+                    new[]
+                    {
+                        new TokenAttributes("a", 0, 1, 1),
+                        new TokenAttributes("b", 2, 3, 1)
+                    }
+                };
+
+                // split on camel case
+                yield return new object[]
+                {
+                    "DotNet",
+                    new[]
+                    {
+                        new TokenAttributes("d", 0, 1, 1),
+                        new TokenAttributes("do", 0, 2, 1),
+                        new TokenAttributes("dot", 0, 3, 1),
+                        new TokenAttributes("dotn", 0, 4, 1),
+                        new TokenAttributes("dotne", 0, 5, 1),
+                        new TokenAttributes("dotnet", 0, 6, 1),
+                        new TokenAttributes("d", 0, 1, 1),
+                        new TokenAttributes("do", 0, 2, 1),
+                        new TokenAttributes("dot", 0, 3, 1),
+                        new TokenAttributes("n", 3, 4, 1),
+                        new TokenAttributes("ne", 3, 5, 1),
+                        new TokenAttributes("net", 3, 6, 1)
+                    }
+                };
+
+                // lower case 
+                yield return new object[]
+                {
+                    "D",
+                    new[]
+                    {
+                        new TokenAttributes("d", 0, 1, 1)
+                    }
+                };
+
+                // ngram size one to eight
+                yield return new object[]
+                {
+                    "DOTNETZIP NET",
+                    new[]
+                    {
+                        new TokenAttributes("d", 0, 1, 1),
+                        new TokenAttributes("do", 0, 2, 1),
+                        new TokenAttributes("dot", 0, 3, 1),
+                        new TokenAttributes("dotn", 0, 4, 1),
+                        new TokenAttributes("dotne", 0, 5, 1),
+                        new TokenAttributes("dotnet", 0, 6, 1),
+                        new TokenAttributes("dotnetz", 0, 7, 1),
+                        new TokenAttributes("dotnetzi", 0, 8, 1),
+                        new TokenAttributes("n", 10, 11, 1),
+                        new TokenAttributes("ne", 10, 12, 1),
+                        new TokenAttributes("net", 10, 13, 1)
+                    }
+                };
+            }
+
+        }
+    }
+}

--- a/tests/NuGet.IndexingTests/IdentifierKeywordAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/IdentifierKeywordAnalyzerTests.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using NuGet.Indexing;
 using NuGet.IndexingTests.TestSupport;
 using Xunit;
@@ -16,12 +14,8 @@ namespace NuGet.IndexingTests
         [MemberData(nameof(TokenizerOnlyLowercasesInputData))]
         public void TokenizerOnlyLowercasesInput(string text, TokenAttributes expected)
         {
-            // arrange
-            var analyzer = new IdentifierKeywordAnalyzer();
-            var tokenStream = analyzer.TokenStream(null, new StringReader(text));
-
-            // act
-            var actual = tokenStream.Tokenize().ToArray();
+            // arrange, act
+            var actual = new IdentifierKeywordAnalyzer().Tokenize(text);
 
             // assert
             Assert.Equal(new[] { expected }, actual);

--- a/tests/NuGet.IndexingTests/IdentifierKeywordAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/IdentifierKeywordAnalyzerTests.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NuGet.Indexing;
+using NuGet.IndexingTests.TestSupport;
+using Xunit;
+
+namespace NuGet.IndexingTests
+{
+    public class IdentifierKeywordAnalyzerTests
+    {
+        [Theory]
+        [MemberData(nameof(TokenizerOnlyLowercasesInputData))]
+        public void TokenizerOnlyLowercasesInput(string text, TokenAttributes expected)
+        {
+            // arrange
+            var analyzer = new IdentifierKeywordAnalyzer();
+            var tokenStream = analyzer.TokenStream(null, new StringReader(text));
+
+            // act
+            var actual = tokenStream.Tokenize().ToArray();
+
+            // assert
+            Assert.Equal(new[] { expected }, actual);
+        }
+
+        public static IEnumerable<object[]> TokenizerOnlyLowercasesInputData
+        {
+            get
+            {
+                // all uppercase
+                yield return new object[] { "DOTNET", new TokenAttributes("dotnet", 0, 6) };
+
+                // camel case
+                yield return new object[] { "DotNet", new TokenAttributes("dotnet", 0, 6) };
+
+                // lower case
+                yield return new object[] { "dotnet", new TokenAttributes("dotnet", 0, 6) };
+
+                // stop words and spaces
+                yield return new object[] { "A BAD identifier.", new TokenAttributes("a bad identifier.", 0, 17) };
+
+                // mixed
+                yield return new object[] { "DotNet.ZIP-Unofficial is a BAD identifier.", new TokenAttributes("dotnet.zip-unofficial is a bad identifier.", 0, 42) };
+            }
+
+        }
+    }
+}

--- a/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
+++ b/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
@@ -70,7 +70,9 @@
   <ItemGroup>
     <Compile Include="CamelCaseFilterTests.cs" />
     <Compile Include="DotTokenizerTests.cs" />
+    <Compile Include="ShingledIdentifierAnalyzerTests.cs" />
     <Compile Include="IdentifierAutocompleteAnalyzerTests.cs" />
+    <Compile Include="IdentifierAnalyzerTests.cs" />
     <Compile Include="IdentifierKeywordAnalyzerTests.cs" />
     <Compile Include="PackageAnalyzerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
+++ b/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
@@ -69,6 +69,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CamelCaseFilterTests.cs" />
+    <Compile Include="DotTokenizerTests.cs" />
+    <Compile Include="IdentifierAutocompleteAnalyzerTests.cs" />
     <Compile Include="IdentifierKeywordAnalyzerTests.cs" />
     <Compile Include="PackageAnalyzerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
+++ b/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
@@ -69,6 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CamelCaseFilterTests.cs" />
+    <Compile Include="TagsAnalyzerTests.cs" />
     <Compile Include="DescriptionAnalyzerTests.cs" />
     <Compile Include="DotTokenizerTests.cs" />
     <Compile Include="ShingledIdentifierAnalyzerTests.cs" />

--- a/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
+++ b/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
@@ -69,6 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CamelCaseFilterTests.cs" />
+    <Compile Include="DescriptionAnalyzerTests.cs" />
     <Compile Include="DotTokenizerTests.cs" />
     <Compile Include="ShingledIdentifierAnalyzerTests.cs" />
     <Compile Include="IdentifierAutocompleteAnalyzerTests.cs" />

--- a/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
+++ b/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
@@ -69,6 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CamelCaseFilterTests.cs" />
+    <Compile Include="VersionAnalyzerTests.cs" />
     <Compile Include="OwnerAnalyzerTests.cs" />
     <Compile Include="TagsAnalyzerTests.cs" />
     <Compile Include="DescriptionAnalyzerTests.cs" />

--- a/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
+++ b/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
@@ -69,6 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CamelCaseFilterTests.cs" />
+    <Compile Include="OwnerAnalyzerTests.cs" />
     <Compile Include="TagsAnalyzerTests.cs" />
     <Compile Include="DescriptionAnalyzerTests.cs" />
     <Compile Include="DotTokenizerTests.cs" />

--- a/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
+++ b/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
@@ -34,6 +34,18 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -56,9 +68,14 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CamelCaseFilterTests.cs" />
+    <Compile Include="PackageAnalyzerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestSupport\TokenAttributes.cs" />
+    <Compile Include="TestSupport\TokenStreamExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -66,6 +83,9 @@
       <Project>{ddb34145-870f-42c3-9663-a9390cee1e35}</Project>
       <Name>NuGet.Indexing</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
+++ b/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
@@ -69,6 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CamelCaseFilterTests.cs" />
+    <Compile Include="IdentifierKeywordAnalyzerTests.cs" />
     <Compile Include="PackageAnalyzerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestSupport\TokenAttributes.cs" />

--- a/tests/NuGet.IndexingTests/NuGetQueryTests.cs
+++ b/tests/NuGet.IndexingTests/NuGetQueryTests.cs
@@ -1,0 +1,85 @@
+﻿using System.Collections.Generic;
+using Lucene.Net.Index;
+using Lucene.Net.Search;
+using NuGet.Indexing;
+using Xunit;
+
+namespace NuGet.IndexingTests
+{
+    public class NuGetQueryTests
+    {
+        [Theory, MemberData("MakeQueryTheoryData")]
+        public void MakeQueryTheory(string input, Query expected)
+        {
+            var actual = NuGetQuery.MakeQuery(input);
+            Assert.Equal(expected, actual);
+        }
+
+        public static IEnumerable<object[]> MakeQueryTheoryData
+        {
+            get
+            {
+                yield return new object[]
+                {
+                    "id:Aa id:Bb",
+                    new BooleanQuery
+                    {
+                        new BooleanClause(new BooleanQuery
+                        {
+                            new BooleanClause(new BooleanQuery
+                            {
+                                new BooleanClause(new TermQuery(new Term("Id", "aa")), Occur.SHOULD),
+                                new BooleanClause(new TermQuery(new Term("Id", "bb")), Occur.SHOULD)
+                            }, Occur.SHOULD),
+                            new BooleanClause(new BooleanQuery
+                            {
+                                new BooleanClause(new TermQuery(new Term("ShingledId", "aa")), Occur.SHOULD),
+                                new BooleanClause(new TermQuery(new Term("ShingledId", "bb")), Occur.SHOULD)
+                            }, Occur.SHOULD),
+                            new BooleanClause(new BooleanQuery
+                            {
+                                new BooleanClause(new TermQuery(new Term("TokenizedId", "aa")), Occur.SHOULD),
+                                new BooleanClause(new TermQuery(new Term("TokenizedId", "bb")), Occur.SHOULD)
+                            }, Occur.SHOULD),
+                            new BooleanClause(new BooleanQuery
+                            {
+                                Clauses =
+                                {
+                                    new BooleanClause(new TermQuery(new Term("TokenizedId", "aa")), Occur.MUST),
+                                    new BooleanClause(new TermQuery(new Term("TokenizedId", "bb")), Occur.MUST)
+                                },
+                                Boost = 4
+                            }, Occur.SHOULD)
+                        }, Occur.MUST)
+                    }
+                };
+
+                yield return new object[]
+                {
+                    "Version:1.02.003 Version:04.5",
+                    new BooleanQuery
+                    {
+                        new BooleanClause(new BooleanQuery
+                        {
+                            new BooleanClause(new TermQuery(new Term("Owner", "abc-def")), Occur.SHOULD),
+                            new BooleanClause(new TermQuery(new Term("Owner", "ghi")), Occur.SHOULD)
+                        }, Occur.MUST)
+                    }
+                };
+
+                yield return new object[]
+                {
+                    "OWNER:\"ABC-DEF\" OWNER:GHI",
+                    new BooleanQuery
+                    {
+                        new BooleanClause(new BooleanQuery
+                        {
+                            new BooleanClause(new TermQuery(new Term("Owner", "abc-def")), Occur.SHOULD),
+                            new BooleanClause(new TermQuery(new Term("Owner", "ghi")), Occur.SHOULD)
+                        }, Occur.MUST)
+                    }
+                };
+            }
+        }
+    }
+}

--- a/tests/NuGet.IndexingTests/OwnerAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/OwnerAnalyzerTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Indexing;
+using NuGet.IndexingTests.TestSupport;
+using Xunit;
+
+namespace NuGet.IndexingTests
+{
+    public class OwnerAnalyzerTests
+    {
+        [Theory]
+        [MemberData(nameof(TokenizerOnlyLowercasesOwnerInputData))]
+        public void TokenizerOnlyLowercasesOwnerInput(string text, TokenAttributes expected)
+        {
+            // arrange, act
+            var actual = new OwnerAnalyzer().Tokenize(text);
+
+            // assert
+            Assert.Equal(new[] { expected }, actual);
+        }
+
+        public static IEnumerable<object[]> TokenizerOnlyLowercasesOwnerInputData
+        {
+            get
+            {
+                // all upper case
+                yield return new object[] { "MICROSOFT-OWNER", new TokenAttributes("microsoft-owner", 0, 15) };
+
+                // title case
+                yield return new object[] { "Microsoft.Owner", new TokenAttributes("microsoft.owner", 0, 15) };
+
+                // camel case
+                yield return new object[] { "MicrosoftOwner", new TokenAttributes("microsoftowner", 0, 14) };
+
+                // mixed
+                yield return new object[] { "a Microsoft OWNER.", new TokenAttributes("a microsoft owner.", 0, 18) };
+            }
+
+        }
+    }
+}

--- a/tests/NuGet.IndexingTests/PackageAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/PackageAnalyzerTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -11,58 +12,66 @@ namespace NuGet.IndexingTests
 {
     public class PackageAnalyzerTests
     {
-        [Theory, MemberData("TheoryData")]
+        [Theory]
+        [MemberData(nameof(AddsCorrectFieldAnalyzersData))]
         public void AddsCorrectFieldAnalyzers(string field, string text, TokenAttributes[] expected)
         {
-            // ARRANGE
+            // arrange
             var analyzer = new PackageAnalyzer();
 
-            // ACT
+            // act
             var tokenStream = analyzer.TokenStream(field, new StringReader(text));
-            var tokenAttributes = tokenStream.GetTokenAttributes().ToArray();
+            var actual = tokenStream.Tokenize().ToArray();
 
-            // ASSERT
-            Assert.Equal(expected, tokenAttributes);
+            // assert
+            Assert.Equal(expected, actual);
         }
 
-        public static IEnumerable<object[]> TheoryData
+        public static IEnumerable<object[]> AddsCorrectFieldAnalyzersData
         {
             get
             {
                 yield return new object[]
                 {
                     "Id",
-                    "AaBbCc",
+                    "DotNetZip",
                     new[]
                     {
-                        new TokenAttributes("aabbcc", 0, 6)
+                        new TokenAttributes("dotnetzip", 0, 9)
                     }
                 };
-
+                
                 yield return new object[]
                 {
                     "IdAutocomplete",
-                    "AaB",
+                    "DotNet",
                     new[]
                     {
-                        new TokenAttributes("a", 0, 1, 1),
-                        new TokenAttributes("aa", 0, 2, 1),
-                        new TokenAttributes("aab", 0, 3, 1),
-                        new TokenAttributes("a", 0, 1, 1),
-                        new TokenAttributes("aa", 0, 2, 1),
-                        new TokenAttributes("b", 2, 3, 1)
+                        new TokenAttributes("d", 0, 1, 1),
+                        new TokenAttributes("do", 0, 2, 1),
+                        new TokenAttributes("dot", 0, 3, 1),
+                        new TokenAttributes("dotn", 0, 4, 1),
+                        new TokenAttributes("dotne", 0, 5, 1),
+                        new TokenAttributes("dotnet", 0, 6, 1),
+                        new TokenAttributes("d", 0, 1, 1),
+                        new TokenAttributes("do", 0, 2, 1),
+                        new TokenAttributes("dot", 0, 3, 1),
+                        new TokenAttributes("n", 3, 4, 1),
+                        new TokenAttributes("ne", 3, 5, 1),
+                        new TokenAttributes("net", 3, 6, 1),
+
                     }
                 };
-
+                
                 yield return new object[]
                 {
                     "TokenizedId",
-                    "AaBb",
+                    "DotNet",
                     new[]
                     {
-                        new TokenAttributes("aabb", 0, 4, 1),
-                        new TokenAttributes("aa", 0, 2, 0),
-                        new TokenAttributes("bb", 2, 4, 1)
+                        new TokenAttributes("dotnet", 0, 6, 1),
+                        new TokenAttributes("dot", 0, 3, 0),
+                        new TokenAttributes("net", 3, 6, 1)
                     }
                 };
 
@@ -84,22 +93,22 @@ namespace NuGet.IndexingTests
                 yield return new object[]
                 {
                     "Owner",
-                    "AAA Bbb",
+                    "Microsoft",
                     new[]
                     {
-                        new TokenAttributes("aaa bbb", 0, 7)
+                        new TokenAttributes("microsoft", 0, 9)
                     }
                 };
 
                 yield return new object[]
                 {
                     "Tags",
-                    "AAA Bbb ccc",
+                    "DOT Net zip",
                     new[]
                     {
-                        new TokenAttributes("aaa", 0, 3, null),
-                        new TokenAttributes("bbb", 4, 7, null),
-                        new TokenAttributes("ccc", 8, 11, null),
+                        new TokenAttributes("dot", 0, 3, null),
+                        new TokenAttributes("net", 4, 7, null),
+                        new TokenAttributes("zip", 8, 11, null),
                     }
                 };
             }
@@ -110,14 +119,17 @@ namespace NuGet.IndexingTests
             return new object[]
             {
                 field,
-                "There is a package called AaBb.",
+                "There is a package called DotNetZip.",
                 new[]
                 {
                     new TokenAttributes("package", 11, 18, 4),
                     new TokenAttributes("called", 19, 25, 1),
-                    new TokenAttributes("aabb", 26, 30, 1),
-                    new TokenAttributes("aa", 26, 28, 0),
-                    new TokenAttributes("bb", 28, 30, 1)
+                    new TokenAttributes("dotnetzip", 26, 35, 1),
+                    new TokenAttributes("dot", 26, 29, 0),
+                    new TokenAttributes("dotnet", 26, 32, 0),
+                    new TokenAttributes("net", 29, 32, 1),
+                    new TokenAttributes("netzip", 29, 35, 0),
+                    new TokenAttributes("zip", 32, 35, 1)
                 }
             };
         }

--- a/tests/NuGet.IndexingTests/PackageAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/PackageAnalyzerTests.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NuGet.Indexing;
+using NuGet.IndexingTests.TestSupport;
+using Xunit;
+
+namespace NuGet.IndexingTests
+{
+    public class PackageAnalyzerTests
+    {
+        [Theory, MemberData("TheoryData")]
+        public void AddsCorrectFieldAnalyzers(string field, string text, TokenAttributes[] expected)
+        {
+            // ARRANGE
+            var analyzer = new PackageAnalyzer();
+
+            // ACT
+            var tokenStream = analyzer.TokenStream(field, new StringReader(text));
+            var tokenAttributes = tokenStream.GetTokenAttributes().ToArray();
+
+            // ASSERT
+            Assert.Equal(expected, tokenAttributes);
+        }
+
+        public static IEnumerable<object[]> TheoryData
+        {
+            get
+            {
+                yield return new object[]
+                {
+                    "Id",
+                    "AaBbCc",
+                    new[]
+                    {
+                        new TokenAttributes("aabbcc", 0, 6)
+                    }
+                };
+
+                yield return new object[]
+                {
+                    "IdAutocomplete",
+                    "AaB",
+                    new[]
+                    {
+                        new TokenAttributes("a", 0, 1, 1),
+                        new TokenAttributes("aa", 0, 2, 1),
+                        new TokenAttributes("aab", 0, 3, 1),
+                        new TokenAttributes("a", 0, 1, 1),
+                        new TokenAttributes("aa", 0, 2, 1),
+                        new TokenAttributes("b", 2, 3, 1)
+                    }
+                };
+
+                yield return new object[]
+                {
+                    "TokenizedId",
+                    "AaBb",
+                    new[]
+                    {
+                        new TokenAttributes("aabb", 0, 4, 1),
+                        new TokenAttributes("aa", 0, 2, 0),
+                        new TokenAttributes("bb", 2, 4, 1)
+                    }
+                };
+
+                yield return new object[]
+                {
+                    "Version",
+                    "01.002.0003",
+                    new[]
+                    {
+                        new TokenAttributes("1.2.3", 0, 11)
+                    }
+                };
+
+                yield return GetDescriptionTestCase("Title");
+                yield return GetDescriptionTestCase("Description");
+                yield return GetDescriptionTestCase("Summary");
+                yield return GetDescriptionTestCase("Authors");
+                
+                yield return new object[]
+                {
+                    "Owner",
+                    "AAA Bbb",
+                    new[]
+                    {
+                        new TokenAttributes("aaa bbb", 0, 7)
+                    }
+                };
+
+                yield return new object[]
+                {
+                    "Tags",
+                    "AAA Bbb ccc",
+                    new[]
+                    {
+                        new TokenAttributes("aaa", 0, 3, null),
+                        new TokenAttributes("bbb", 4, 7, null),
+                        new TokenAttributes("ccc", 8, 11, null),
+                    }
+                };
+            }
+        }
+
+        private static object[] GetDescriptionTestCase(string field)
+        {
+            return new object[]
+            {
+                field,
+                "There is a package called AaBb.",
+                new[]
+                {
+                    new TokenAttributes("package", 11, 18, 4),
+                    new TokenAttributes("called", 19, 25, 1),
+                    new TokenAttributes("aabb", 26, 30, 1),
+                    new TokenAttributes("aa", 26, 28, 0),
+                    new TokenAttributes("bb", 28, 30, 1)
+                }
+            };
+        }
+    }
+}

--- a/tests/NuGet.IndexingTests/ShingledIdentifierAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/ShingledIdentifierAnalyzerTests.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Indexing;
+using NuGet.IndexingTests.TestSupport;
+using Xunit;
+
+namespace NuGet.IndexingTests
+{
+    public class ShingledIdentifierAnalyzerTests
+    {
+        [Theory]
+        [MemberData(nameof(TokenizerShinglesAndLowercasesInputData))]
+        public void TokenizerShinglesAndLowercasesInput(string text, TokenAttributes[] expected)
+        {
+            // arrange, act
+            var actual = new ShingledIdentifierAnalyzer().Tokenize(text);
+
+            // assert
+            Assert.Equal(expected, actual);
+        }
+
+        public static IEnumerable<object[]> TokenizerShinglesAndLowercasesInputData
+        {
+            get
+            {
+                // split by DotTokenizer
+                yield return new object[]
+                {
+                    "a.b",
+                    new[]
+                    {
+                        new TokenAttributes("a", 0, 1, 1),
+                        new TokenAttributes("a b", 0, 3, 0),
+                        new TokenAttributes("b", 2, 3, 1)
+                    }
+                };
+
+                // lower case 
+                yield return new object[]
+                {
+                    "D",
+                    new[]
+                    {
+                        new TokenAttributes("d", 0, 1, 1)
+                    }
+                };
+
+                // consecutive seperators
+                yield return new object[]
+                {
+                    "a.....b",
+                    new[]
+                    {
+                        new TokenAttributes("a", 0, 1, 1),
+                        new TokenAttributes("a b", 0, 7, 0),
+                        new TokenAttributes("b", 6, 7, 1)
+                    }
+                };
+
+                // shingle up to two
+                yield return new object[]
+                {
+                    "a.b.c.d",
+                    new[]
+                    {
+                        new TokenAttributes("a", 0, 1, 1),
+                        new TokenAttributes("a b", 0, 3, 0),
+                        new TokenAttributes("b", 2, 3, 1),
+                        new TokenAttributes("b c", 2, 5, 0),
+                        new TokenAttributes("c", 4, 5, 1),
+                        new TokenAttributes("c d", 4, 7, 0),
+                        new TokenAttributes("d", 6, 7, 1),
+                    }
+                };
+            }
+        }
+    }
+}

--- a/tests/NuGet.IndexingTests/TagsAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/TagsAnalyzerTests.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Indexing;
+using NuGet.IndexingTests.TestSupport;
+using Xunit;
+
+namespace NuGet.IndexingTests
+{
+    public class TagsAnalyzerTests
+    {
+        [Theory]
+        [MemberData(nameof(TokenizerLowercasesAndSplitsInputData))]
+        public void TokenizerLowercasesAndSplitsInput(string text, TokenAttributes[] expected)
+        {
+            // arrange, act
+            var actual = new TagsAnalyzer().Tokenize(text);
+
+            // assert
+            Assert.Equal(expected, actual);
+        }
+
+        public static IEnumerable<object[]> TokenizerLowercasesAndSplitsInputData
+        {
+            get
+            {
+                // split by DotTokenizer
+                yield return new object[]
+                {
+                    "Split sentence.",
+                    new[]
+                    {
+                        new TokenAttributes("split", 0, 5),
+                        new TokenAttributes("sentence", 6, 14)
+                    }
+                };
+
+                // lower case 
+                yield return new object[]
+                {
+                    "D",
+                    new[]
+                    {
+                        new TokenAttributes("d", 0, 1)
+                    }
+                };
+
+                // leaves stop words
+                yield return new object[]
+                {
+                    "This is a sentence full of stop words.",
+                    new[]
+                    {
+                        new TokenAttributes("this", 0, 4),
+                        new TokenAttributes("is", 5, 7),
+                        new TokenAttributes("a", 8, 9),
+                        new TokenAttributes("sentence", 10, 18),
+                        new TokenAttributes("full", 19, 23),
+                        new TokenAttributes("of", 24, 26),
+                        new TokenAttributes("stop", 27, 31),
+                        new TokenAttributes("words", 32, 37)
+                    }
+                };
+            }
+        }
+    }
+}

--- a/tests/NuGet.IndexingTests/TestSupport/TokenAttributes.cs
+++ b/tests/NuGet.IndexingTests/TestSupport/TokenAttributes.cs
@@ -5,20 +5,12 @@ namespace NuGet.IndexingTests.TestSupport
 {
     public class TokenAttributes
     {
-        public TokenAttributes()
+        public TokenAttributes(string term, int startOffset, int endOffset, int? positionIncrement = null)
         {
-        }
-
-        public TokenAttributes(string term, int startOffset, int endOffset) : this(term, startOffset, endOffset, null)
-        {
-        }
-
-        public TokenAttributes(string term, int startOffset, int endOffset, int? positionIncrement)
-        {
-            this.Term = term;
-            this.StartOffset = startOffset;
-            this.EndOffset = endOffset;
-            this.PositionIncrement = positionIncrement;
+            Term = term;
+            StartOffset = startOffset;
+            EndOffset = endOffset;
+            PositionIncrement = positionIncrement;
         }
 
         public string Term { get; set; }
@@ -28,22 +20,21 @@ namespace NuGet.IndexingTests.TestSupport
 
         public override string ToString()
         {
-            return string.Format(
-                "{{Term: '{0}', Offset: ({1}, {2}), PositionIncrement: {3}}}",
-                this.Term,
-                this.StartOffset,
-                this.EndOffset,
-                this.PositionIncrement.HasValue ? this.PositionIncrement.Value.ToString() : "null");
+            return "{" +
+                   $"Term: '{this.Term}', " +
+                   $"Offset: ({this.StartOffset}, {this.EndOffset}), " +
+                   $"PositionIncrement: {this.PositionIncrement?.ToString() ?? "null"}" +
+                   "}";
         }
 
         public override bool Equals(object obj)
         {
             var other = obj as TokenAttributes;
+
             if (other == null)
             {
                 return false;
             }
- 
 
             return string.Equals(Term, other.Term) &&
                 StartOffset == other.StartOffset &&
@@ -53,7 +44,7 @@ namespace NuGet.IndexingTests.TestSupport
 
         public override int GetHashCode()
         {
-            return this.ToString().GetHashCode();
+            return ToString().GetHashCode();
         }
     }
 }

--- a/tests/NuGet.IndexingTests/TestSupport/TokenAttributes.cs
+++ b/tests/NuGet.IndexingTests/TestSupport/TokenAttributes.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.IndexingTests.TestSupport
+{
+    public class TokenAttributes
+    {
+        public TokenAttributes()
+        {
+        }
+
+        public TokenAttributes(string term, int startOffset, int endOffset) : this(term, startOffset, endOffset, null)
+        {
+        }
+
+        public TokenAttributes(string term, int startOffset, int endOffset, int? positionIncrement)
+        {
+            this.Term = term;
+            this.StartOffset = startOffset;
+            this.EndOffset = endOffset;
+            this.PositionIncrement = positionIncrement;
+        }
+
+        public string Term { get; set; }
+        public int StartOffset { get; set; }
+        public int EndOffset { get; set; }
+        public int? PositionIncrement { get; set; }
+
+        public override string ToString()
+        {
+            return string.Format(
+                "{{Term: '{0}', Offset: ({1}, {2}), PositionIncrement: {3}}}",
+                this.Term,
+                this.StartOffset,
+                this.EndOffset,
+                this.PositionIncrement.HasValue ? this.PositionIncrement.Value.ToString() : "null");
+        }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as TokenAttributes;
+            if (other == null)
+            {
+                return false;
+            }
+ 
+
+            return string.Equals(Term, other.Term) &&
+                StartOffset == other.StartOffset &&
+                EndOffset == other.EndOffset &
+                PositionIncrement == other.PositionIncrement;
+        }
+
+        public override int GetHashCode()
+        {
+            return this.ToString().GetHashCode();
+        }
+    }
+}

--- a/tests/NuGet.IndexingTests/TestSupport/TokenStreamExtensions.cs
+++ b/tests/NuGet.IndexingTests/TestSupport/TokenStreamExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System.Collections.Generic;
+using Lucene.Net.Analysis;
+using Lucene.Net.Analysis.Tokenattributes;
+
+namespace NuGet.IndexingTests.TestSupport
+{
+    public static class TokenStreamExtensions
+    {
+        public static IEnumerable<TokenAttributes> GetTokenAttributes(this TokenStream tokenStream)
+        {
+            var term = tokenStream.GetAttribute<ITermAttribute>();
+            var offset = tokenStream.GetAttribute<IOffsetAttribute>();
+
+            IPositionIncrementAttribute positionIncrement = null;
+            if (tokenStream.HasAttribute<IPositionIncrementAttribute>())
+            {
+                positionIncrement = tokenStream.GetAttribute<IPositionIncrementAttribute>();
+            }
+
+            while (tokenStream.IncrementToken())
+            {
+                var tokenAttributes = new TokenAttributes(term.Term, offset.StartOffset, offset.EndOffset);
+                if (positionIncrement != null)
+                {
+                    tokenAttributes.PositionIncrement = positionIncrement.PositionIncrement;
+                }
+
+                yield return tokenAttributes;
+            }
+        }
+    }
+}

--- a/tests/NuGet.IndexingTests/TestSupport/TokenStreamExtensions.cs
+++ b/tests/NuGet.IndexingTests/TestSupport/TokenStreamExtensions.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.Tokenattributes;
 
@@ -32,6 +34,12 @@ namespace NuGet.IndexingTests.TestSupport
 
                 yield return tokenAttributes;
             }
+        }
+
+        public static TokenAttributes[] Tokenize(this Analyzer analyzer, string text)
+        {
+            var tokenStream = analyzer.TokenStream(null, new StringReader(text));
+            return tokenStream.Tokenize().ToArray();
         }
     }
 }

--- a/tests/NuGet.IndexingTests/TestSupport/TokenStreamExtensions.cs
+++ b/tests/NuGet.IndexingTests/TestSupport/TokenStreamExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.Tokenattributes;
@@ -8,12 +9,13 @@ namespace NuGet.IndexingTests.TestSupport
 {
     public static class TokenStreamExtensions
     {
-        public static IEnumerable<TokenAttributes> GetTokenAttributes(this TokenStream tokenStream)
+        public static IEnumerable<TokenAttributes> Tokenize(this TokenStream tokenStream)
         {
             var term = tokenStream.GetAttribute<ITermAttribute>();
             var offset = tokenStream.GetAttribute<IOffsetAttribute>();
 
             IPositionIncrementAttribute positionIncrement = null;
+
             if (tokenStream.HasAttribute<IPositionIncrementAttribute>())
             {
                 positionIncrement = tokenStream.GetAttribute<IPositionIncrementAttribute>();
@@ -22,6 +24,7 @@ namespace NuGet.IndexingTests.TestSupport
             while (tokenStream.IncrementToken())
             {
                 var tokenAttributes = new TokenAttributes(term.Term, offset.StartOffset, offset.EndOffset);
+
                 if (positionIncrement != null)
                 {
                     tokenAttributes.PositionIncrement = positionIncrement.PositionIncrement;

--- a/tests/NuGet.IndexingTests/VersionAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/VersionAnalyzerTests.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Indexing;
+using NuGet.IndexingTests.TestSupport;
+using Xunit;
+
+namespace NuGet.IndexingTests
+{
+    public class VersionAnalyzerTests
+    {
+        [Theory]
+        [MemberData(nameof(TokenizerNormalizesVersionInputData))]
+        public void TokenizerNormalizesVersionInput(string text, TokenAttributes expected)
+        {
+            // arrange, act
+            var actual = new VersionAnalyzer().Tokenize(text);
+
+            // assert
+            Assert.Equal(new[] { expected }, actual);
+        }
+
+        public static IEnumerable<object[]> TokenizerNormalizesVersionInputData
+        {
+            get
+            {
+                // one dot
+                yield return new object[] { "1.0", new TokenAttributes("1.0.0", 0, 3) };
+
+                // extra zeros
+                yield return new object[] { "2.003.1", new TokenAttributes("2.3.1", 0, 7) };
+
+                // empty
+                yield return new object[] { string.Empty, new TokenAttributes(string.Empty, 0, 0) };
+
+                // lots of digits
+                yield return new object[] { "1.02.3456789", new TokenAttributes("1.2.3456789", 0, 12) };
+
+                // trim
+                yield return new object[] { " 1.02.03    ", new TokenAttributes("1.2.3", 0, 12) };
+            }
+
+        }
+    }
+}

--- a/tests/NuGet.IndexingTests/app.config
+++ b/tests/NuGet.IndexingTests/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/NuGet.IndexingTests/packages.config
+++ b/tests/NuGet.IndexingTests/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Lucene.Net" version="3.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
   <package id="xunit" version="2.0.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.0.0" targetFramework="net45" />


### PR DESCRIPTION
1. The `Owners` field in `PackageAnalyzer` is not referenced by the `NuGetQuery` code and it should be renamed to `Owner`.
2. Add unit tests for `CamelCaseFilter`.
2. Add unit tests for `PackageAnalyzer`.
