### PR TITLE
NuGetQuery unit test

### DIFF
--- a/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
+++ b/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
@@ -70,6 +70,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CamelCaseFilterTests.cs" />
+    <Compile Include="NuGetQueryTests.cs" />
     <Compile Include="VersionAnalyzerTests.cs" />
     <Compile Include="OwnerAnalyzerTests.cs" />
     <Compile Include="TagsAnalyzerTests.cs" />


### PR DESCRIPTION
These are unit tests for John's new query parser. It takes query strings (i.e. what the user types into the search box) against expected Lucene query trees.

@johnataylor @joyhui @yishaigalatzer 