### PR TITLE
Add first functional test for the search service

### DIFF
--- a/src/NuGet.Services.BasicSearch/Startup.cs
+++ b/src/NuGet.Services.BasicSearch/Startup.cs
@@ -171,16 +171,16 @@ namespace NuGet.Services.BasicSearch
             {
                 if (_searcherManager == null)
                 {
-                    await context.Response.WriteAsync("UNINITIALIZED");
                     context.Response.StatusCode = (int)HttpStatusCode.OK;
+                    await context.Response.WriteAsync("UNINITIALIZED");
                 }
                 else
                 {
                     switch (context.Request.Path.Value)
                     {
                         case "/":
-                            await context.Response.WriteAsync("READY");
                             context.Response.StatusCode = (int)HttpStatusCode.OK;
+                            await context.Response.WriteAsync("READY");
                             break;
                         case "/find":
                             await ServiceHelpers.WriteResponse(context, HttpStatusCode.OK, ServiceImpl.Find(context, _searcherManager));
@@ -204,8 +204,8 @@ namespace NuGet.Services.BasicSearch
                             break;
 
                         default:
-                            await context.Response.WriteAsync("unrecognized");
                             context.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                            await context.Response.WriteAsync("UNRECOGNIZED");
                             break;
                     }
                 }

--- a/tests/NuGet.Services.BasicSearchTests/Models/AtContext.cs
+++ b/tests/NuGet.Services.BasicSearchTests/Models/AtContext.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+
+namespace NuGet.Services.BasicSearchTests.Models
+{
+    public class AtContext
+    {
+        [JsonProperty("@vocab")]
+        public string AtVocab { get; set; }
+
+        [JsonProperty("@base")]
+        public string AtBase { get; set; }
+    }
+}

--- a/tests/NuGet.Services.BasicSearchTests/Models/AutocompleteResult.cs
+++ b/tests/NuGet.Services.BasicSearchTests/Models/AutocompleteResult.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace NuGet.Services.BasicSearchTests.Models
+{
+    public class AutocompleteResult
+    {
+        [JsonProperty("@context")]
+        public AtContext AtContext { get; set; }
+
+        public int? TotalHits { get; set; }
+
+        public DateTime? LastReopen { get; set; }
+
+        public string Index { get; set; }
+
+        public IEnumerable<string> Data { get; set; }
+    }
+}

--- a/tests/NuGet.Services.BasicSearchTests/Models/GalleryPackage.cs
+++ b/tests/NuGet.Services.BasicSearchTests/Models/GalleryPackage.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.BasicSearchTests.Models
+{
+    public class GalleryPackage
+    {
+        public PackageRegistration PackageRegistration { get; set; }
+
+        public string Version { get; set; }
+
+        public string NormalizedVersion { get; set; }
+
+        public string Title { get; set; }
+
+        public string Description { get; set; }
+
+        public string Summary { get; set; }
+
+        public string Authors { get; set; }
+
+        public string Copyright { get; set; }
+
+        public string Language { get; set; }
+
+        public string Tags { get; set; }
+
+        public string ReleaseNotes { get; set; }
+
+        public string ProjectUrl { get; set; }
+
+        public string IconUrl { get; set; }
+
+        public bool IsLatestStable { get; set; }
+
+        public bool IsLatest { get; set; }
+
+        public bool Listed { get; set; }
+
+        public string Created { get; set; }
+
+        public string Published { get; set; }
+
+        public string LastUpdated { get; set; }
+
+        public string LastEdited { get; set; }
+
+        public int DownloadCount { get; set; }
+
+        public string FlattenedDependencies { get; set; }
+
+        public string MinClientVersion { get; set; }
+
+        public string Hash { get; set; }
+
+        public string HashAlgorithm { get; set; }
+
+        public int PackageFileSize { get; set; }
+
+        public string LicenseUrl { get; set; }
+
+        public bool RequiresLicenseAcceptance { get; set; }
+
+        public string LicenseNames { get; set; }
+
+        public string LicenseReportUrl { get; set; }
+
+        public bool HideLicenseReport { get; set; }
+    }
+}

--- a/tests/NuGet.Services.BasicSearchTests/Models/GalleryQueryResult.cs
+++ b/tests/NuGet.Services.BasicSearchTests/Models/GalleryQueryResult.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.Services.BasicSearchTests.Models
+{
+    public class GalleryQueryResult
+    {
+        public int? TotalHits { get; set; }
+
+        public DateTime? IndexTimestamp { get; set; }
+
+        public string Index { get; set; }
+
+        public IEnumerable<GalleryPackage> Data { get; set; }
+    }
+}

--- a/tests/NuGet.Services.BasicSearchTests/Models/Package.cs
+++ b/tests/NuGet.Services.BasicSearchTests/Models/Package.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace NuGet.Services.BasicSearchTests.Models
+{
+    public class Package
+    {
+        [JsonProperty("@id")]
+        public string AtId { get; set; }
+
+        [JsonProperty("@type")]
+        public string AtType { get; set; }
+
+        public string Registration { get; set; }
+
+        public string Id { get; set; }
+
+        public string Version { get; set; }
+
+        public string Domain { get; set; }
+
+        public string Description { get; set; }
+
+        public string Summary { get; set; }
+
+        public string Title { get; set; }
+
+        public string IconUrl { get; set; }
+
+        public string LicenseUrl { get; set; }
+
+        public string ProjectUrl { get; set; }
+
+        public IEnumerable<string> Tags { get; set; }
+
+        public IEnumerable<string> Authors { get; set; } 
+
+        public int TotalDownloads { get; set; }
+
+        public IEnumerable<PackageVersion> Versions { get; set; }
+    }
+}

--- a/tests/NuGet.Services.BasicSearchTests/Models/PackageRegistration.cs
+++ b/tests/NuGet.Services.BasicSearchTests/Models/PackageRegistration.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGet.Services.BasicSearchTests.Models
+{
+    public class PackageRegistration
+    {
+        public string Id { get; set; }
+
+        public int DownloadCount { get; set; }
+
+        public IEnumerable<string> Owners { get; set; }
+    }
+}

--- a/tests/NuGet.Services.BasicSearchTests/Models/PackageVersion.cs
+++ b/tests/NuGet.Services.BasicSearchTests/Models/PackageVersion.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+
+namespace NuGet.Services.BasicSearchTests.Models
+{
+    public class PackageVersion
+    {
+        public string Version { get; set; }
+
+        public int Downloads { get; set; }
+
+        [JsonProperty("@id")]
+        public string AtId { get; set; }
+    }
+}

--- a/tests/NuGet.Services.BasicSearchTests/Models/QueryResult.cs
+++ b/tests/NuGet.Services.BasicSearchTests/Models/QueryResult.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace NuGet.Services.BasicSearchTests.Models
+{
+    public class QueryResult
+    {
+        [JsonProperty("@context")]
+        public AtContext AtContext { get; set; }
+
+        public int? TotalHits { get; set; }
+
+        public DateTime? LastReopen { get; set; }
+
+        public string Index { get; set; }
+
+        public IEnumerable<Package> Data { get; set; }
+
+        public Package GetPackage(string id)
+        {
+            return Data.FirstOrDefault(p => p.Id.Equals(id, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public bool ContainsPackage(string id)
+        {
+            return GetPackage(id) != null;
+        }
+
+        public string GetPackageVersion(string id)
+        {
+            return GetPackage(id)?.Version;
+        }
+    }
+}

--- a/tests/NuGet.Services.BasicSearchTests/NuGet.Services.BasicSearchTests.csproj
+++ b/tests/NuGet.Services.BasicSearchTests/NuGet.Services.BasicSearchTests.csproj
@@ -34,6 +34,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
       <Private>True</Private>
@@ -46,6 +54,14 @@
       <HintPath>..\..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
       <Private>True</Private>
@@ -53,12 +69,19 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -73,13 +96,34 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TestSupport\QueryBuilder.cs" />
+    <Compile Include="TestSupport\TestSettings.cs" />
+    <Compile Include="TestSupport\DataDirectoryInitializer.cs" />
+    <Compile Include="TestSupport\LuceneDirectoryInitializer.cs" />
+    <Compile Include="Models\AtContext.cs" />
+    <Compile Include="Models\AutocompleteResult.cs" />
+    <Compile Include="Models\GalleryPackage.cs" />
+    <Compile Include="Models\GalleryQueryResult.cs" />
+    <Compile Include="Models\Package.cs" />
+    <Compile Include="Models\PackageRegistration.cs" />
+    <Compile Include="Models\PackageVersion.cs" />
+    <Compile Include="Models\QueryResult.cs" />
+    <Compile Include="TestSupport\NupkgDownloader.cs" />
+    <Compile Include="TestSupport\PackageVersion.cs" />
+    <Compile Include="TestSupport\StartedWebApp.cs" />
+    <Compile Include="StartupTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestSupport\PortReserver.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\NuGet.Indexing\NuGet.Indexing.csproj">
+      <Project>{DDB34145-870F-42C3-9663-A9390CEE1E35}</Project>
+      <Name>NuGet.Indexing</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\NuGet.Services.BasicSearch\NuGet.Services.BasicSearch.csproj">
       <Project>{1460DE86-6DF4-49A3-822C-E52F8DA834F5}</Project>
       <Name>NuGet.Services.BasicSearch</Name>
@@ -87,6 +131,11 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="TestSettings.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/tests/NuGet.Services.BasicSearchTests/StartupTests.cs
+++ b/tests/NuGet.Services.BasicSearchTests/StartupTests.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Specialized;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NuGet.Services.BasicSearchTests.Models;
+using NuGet.Services.BasicSearchTests.TestSupport;
+using Xunit;
+
+namespace NuGet.Services.BasicSearchTests
+{
+    public class StartupTests
+    {
+        [Fact]
+        public async Task PrereleaseParameterIsObserved()
+        {
+            // Arrange
+            var packages = new[]
+            {
+                new TestSupport.PackageVersion("Antlr", "3.1.3.42154"),
+                new TestSupport.PackageVersion("Antlr", "3.4.1.9004-pre"),
+                new TestSupport.PackageVersion("angularjs", "1.2.0-RC1"),
+                new TestSupport.PackageVersion("WebGrease", "1.6.0")
+            };
+
+            using (var app = await StartedWebApp.StartAsync(packages))
+            {
+                string query = "Id:angularjs Id:Antlr Id:WebGrease";
+
+                // Act
+                var withPrereleaseResponse = await app.Client.GetAsync(new QueryBuilder { Query = query, Prerelease = true }.RequestUri);
+                var withPrerelease = await withPrereleaseResponse.Content.ReadAsAsync<QueryResult>();
+
+                var withoutPrereleaseResponse = await app.Client.GetAsync(new QueryBuilder { Query = query, Prerelease = false }.RequestUri);
+                var withoutPrerelease = await withoutPrereleaseResponse.Content.ReadAsAsync<QueryResult>();
+
+                // Assert
+                Assert.Equal("1.2.0-RC1", withPrerelease.GetPackageVersion("angularjs"));  // the only version available is prerelease
+                Assert.Equal("3.4.1.9004-pre", withPrerelease.GetPackageVersion("Antlr")); // the latest version is prerelease
+                Assert.Equal("1.6.0", withPrerelease.GetPackageVersion("WebGrease"));      // the only version available is non-prerelease
+
+                Assert.False(withoutPrerelease.ContainsPackage("angularjs"));              // the only version available is prerelease and is therefore excluded
+                Assert.Equal("3.1.3.42154", withoutPrerelease.GetPackageVersion("Antlr")); // this is the latest non-release version
+                Assert.Equal("1.6.0", withoutPrerelease.GetPackageVersion("WebGrease"));   // the only version available is non-prerelease
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.BasicSearchTests/TestSettings.xml
+++ b/tests/NuGet.Services.BasicSearchTests/TestSettings.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TestSettings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <PackageDirectory>BasicSearchTests\Packages</PackageDirectory>
+  <DataDirectory>BasicSearchTests\Data</DataDirectory>
+  <RegistrationBaseAddress>http://api.nuget.org/v3/registration0/</RegistrationBaseAddress>
+  <ApiIndexUrl>https://api.nuget.org/v3/index.json</ApiIndexUrl>
+  <BaseLuceneDirectory>BasicSearchTests\Lucene</BaseLuceneDirectory>
+</TestSettings>

--- a/tests/NuGet.Services.BasicSearchTests/TestSupport/DataDirectoryInitializer.cs
+++ b/tests/NuGet.Services.BasicSearchTests/TestSupport/DataDirectoryInitializer.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.BasicSearchTests.TestSupport
+{
+    public class DataDirectoryInitializer
+    {
+        private readonly TestSettings _settings;
+
+        public DataDirectoryInitializer(TestSettings settings)
+        {
+            _settings = settings;
+        }
+        
+        public async Task<string> GetInitializedDirectoryAsync()
+        {
+            Directory.CreateDirectory(_settings.DataDirectory);
+            await WriteFileAsync("downloads.v1.json", "[]");
+            await WriteFileAsync("curatedfeeds.json", "[]");
+            await WriteFileAsync("owners.json", "[]");
+            await WriteFileAsync("rankings.v1.json", "{\"Rank\": []}");
+            return _settings.DataDirectory;
+        }
+
+        private async Task WriteFileAsync(string name, string content)
+        {
+            string path = Path.Combine(_settings.DataDirectory, name);
+
+            using (var fileStream = new FileStream(path, FileMode.Create, FileAccess.Write))
+            using (var writer = new StreamWriter(fileStream, new UTF8Encoding(false)))
+            {
+                await writer.WriteAsync(content);
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.BasicSearchTests/TestSupport/LuceneDirectoryInitializer.cs
+++ b/tests/NuGet.Services.BasicSearchTests/TestSupport/LuceneDirectoryInitializer.cs
@@ -1,0 +1,84 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Lucene.Net.Store;
+using NuGet.Indexing;
+
+namespace NuGet.Services.BasicSearchTests.TestSupport
+{
+    public class LuceneDirectoryInitializer
+    {
+        private readonly TestSettings _settings;
+        private readonly INupkgDownloader _nupkgDownloader;
+
+        public LuceneDirectoryInitializer(TestSettings settings, INupkgDownloader nupkgDownloader)
+        {
+            _settings = settings;
+            _nupkgDownloader = nupkgDownloader;
+        }
+
+        public string GetInitializedDirectory(IEnumerable<PackageVersion> packages)
+        {
+            string directory = Path.Combine(GetBaseLuceneDirectory(), Guid.NewGuid().ToString());
+            CreateLuceneIndex(packages, directory);
+            return directory;
+        }
+
+        private string GetBaseLuceneDirectory()
+        {
+            if (_settings.BaseLuceneDirectory == null)
+            {
+                return System.IO.Directory.GetCurrentDirectory();
+            }
+
+            if (!Path.IsPathRooted(_settings.BaseLuceneDirectory))
+            {
+                return Path.Combine(System.IO.Directory.GetCurrentDirectory(), _settings.BaseLuceneDirectory);
+            }
+
+            return _settings.BaseLuceneDirectory;
+        }
+
+        private void CreateLuceneIndex(IEnumerable<PackageVersion> packages, string directory)
+        {
+            var directoryInfo = new DirectoryInfo(directory);
+            directoryInfo.Create();
+
+            using (var indexWriter = DocumentCreator.CreateIndexWriter(new SimpleFSDirectory(directoryInfo), true))
+            {
+                foreach (var version in packages)
+                {
+                    var metadata = GetPackageMetadata(version);
+                    var document = DocumentCreator.CreateDocument(metadata);
+                    indexWriter.AddDocument(document);
+                }
+
+                indexWriter.Commit();
+            }
+        }
+
+        private IDictionary<string, string> GetPackageMetadata(PackageVersion version)
+        {
+            var path = _nupkgDownloader.GetPackagePath(version);
+
+            using (var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read))
+            {
+                var errors = new List<string>();
+                var metadata = PackageMetadataExtraction.MakePackageMetadata(fileStream, errors);
+
+                if (errors.Any())
+                {
+                    throw new InvalidOperationException(
+                        $"NuGet package for '{version.Id}' (version '{version.Version}') could not be read for metadata. " +
+                        $"Errors: {string.Join(", ", errors)}");
+                }
+
+                return metadata;
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.BasicSearchTests/TestSupport/NupkgDownloader.cs
+++ b/tests/NuGet.Services.BasicSearchTests/TestSupport/NupkgDownloader.cs
@@ -1,0 +1,101 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace NuGet.Services.BasicSearchTests.TestSupport
+{
+    public interface INupkgDownloader
+    {
+        Task DownloadPackagesAsync(IEnumerable<PackageVersion> packages);
+
+        string GetPackagePath(PackageVersion version);
+    }
+
+    public class NupkgDownloader : INupkgDownloader
+    {
+        private const string PackageBaseAddressType = "PackageBaseAddress/3.0.0";
+        private readonly TestSettings _settings;
+        private readonly HttpClient _client;
+        private string _packageBaseAddress;
+
+        public NupkgDownloader(TestSettings settings)
+        {
+            _settings = settings;
+            _client = new HttpClient();
+            _client.DefaultRequestHeaders.Add("User-Agent", "NuGet Test Client");
+        }
+
+        public async Task DownloadPackagesAsync(IEnumerable<PackageVersion> packages)
+        {
+            Directory.CreateDirectory(_settings.PackageDirectory);
+            await Task.WhenAll(packages.Select(DownloadPackageAsync));
+        }
+
+        public string GetPackagePath(PackageVersion version)
+        {
+            return Path.Combine(_settings.PackageDirectory, $"{version.Id}.{version.Version}.nupkg".ToLower());
+        }
+
+        private async Task DownloadPackageAsync(PackageVersion version)
+        {
+            var path = GetPackagePath(version);
+            if (File.Exists(path))
+            {
+                return;
+            }
+
+            // Synchronization is not a concern here. If multiple threads execute this the result should be the same.
+            if (_packageBaseAddress == null)
+            {
+                _packageBaseAddress = await GetPackageBaseAddressAsync();
+            }
+            
+            string relativeUri = $"{version.Id}/{version.Version}/{version.Id}.{version.Version}.nupkg".ToLower();
+            var requestUri = new Uri(new Uri(_packageBaseAddress, UriKind.Absolute), relativeUri);
+            var response = await _client.GetAsync(requestUri);
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                throw new InvalidOperationException($"HTTP {(int)response.StatusCode} {response.ReasonPhrase} was encountered when fetching package '{version.Id}' (version '{version.Version}').");
+            }
+
+            var packageStream = await response.Content.ReadAsStreamAsync();
+            using (var fileStream = new FileStream(path, FileMode.Create, FileAccess.Write))
+            {
+                await packageStream.CopyToAsync(fileStream);
+            }
+        }
+
+        private async Task<string> GetPackageBaseAddressAsync()
+        {
+            var serializer = new JsonSerializer();
+            JObject apiIndex;
+            using (var stream = await _client.GetStreamAsync(_settings.ApiIndexUrl))
+            using (var streamReader = new StreamReader(stream))
+            using (var jsonTextReader = new JsonTextReader(streamReader))
+            {
+                apiIndex = serializer.Deserialize<JObject>(jsonTextReader);
+            }
+
+            var resource = apiIndex["resources"]
+                .AsJEnumerable()
+                .Select(t => t.ToObject<JObject>())
+                .FirstOrDefault(r => r["@type"].Value<string>() == PackageBaseAddressType);
+
+            if (resource == null)
+            {
+                throw new InvalidOperationException($"The resource with @type '{PackageBaseAddressType}' could not be found in '{_settings.ApiIndexUrl}'.");
+            }
+
+            return resource["@id"].Value<string>();
+        }
+    }
+}

--- a/tests/NuGet.Services.BasicSearchTests/TestSupport/PackageVersion.cs
+++ b/tests/NuGet.Services.BasicSearchTests/TestSupport/PackageVersion.cs
@@ -1,0 +1,53 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Xml.Serialization;
+
+namespace NuGet.Services.BasicSearchTests.TestSupport
+{
+    public class PackageVersion
+    {
+        public PackageVersion()
+        {
+        }
+
+        public PackageVersion(string id, string version)
+        {
+            Id = id;
+            Version = version;
+        }
+        
+        public string Id { get; set; }
+        
+        public string Version { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is PackageVersion))
+            {
+                return false;
+            }
+
+            var other = (PackageVersion)obj;
+
+            return
+                Id.Equals(other.Id, StringComparison.OrdinalIgnoreCase) &&
+                Version.Equals(other.Version, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override string ToString()
+        {
+            return
+                "{" +
+                $"Id: {Id}, " +
+                $"Version: {Version}" +
+                "}";
+        }
+
+        public override int GetHashCode()
+        {
+            return ToString().ToLower().GetHashCode();
+        }
+    }
+}

--- a/tests/NuGet.Services.BasicSearchTests/TestSupport/PortReserver.cs
+++ b/tests/NuGet.Services.BasicSearchTests/TestSupport/PortReserver.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Threading;
+
+namespace NuGet.Services.BasicSearchTests.TestSupport
+{
+    /// <summary>
+    /// This class allocates ports while ensuring that:
+    /// 1. Ports that are permanentaly taken (or taken for the duration of the test) are not being attempted to be used.
+    /// 2. Ports are not shared across different tests (but you can allocate two different ports in the same test).
+    /// 
+    /// Gotcha: If another application grabs a port during the test, we have a race condition.
+    /// 
+    /// Note that this code was copied from ASP.NET on CodePlex:
+    /// http://aspnetwebstack.codeplex.com/SourceControl/latest#test/Microsoft.TestCommon/PortReserver.cs
+    /// </summary>
+    [DebuggerDisplay("Port: {PortNumber}, Port count for this app domain: {_appDomainOwnedPorts.Count}")]
+    public class PortReserver : IDisposable
+    {
+        private Mutex _portMutex;
+
+        // We use this list to hold on to all the ports used because the Mutex will be blown through on the same thread.
+        // Theoretically we can do a thread local hashset, but that makes dispose thread dependant, or requires more complicated concurrency checks.
+        // Since practically there is no perf issue or concern here, this keeps the code the simplest possible.
+        private static HashSet<int> _appDomainOwnedPorts = new HashSet<int>();
+
+        public int PortNumber
+        {
+            get;
+            private set;
+        }
+
+        public PortReserver(int basePort = 50231)
+        {
+            if (basePort <= 0)
+            {
+                throw new InvalidOperationException();
+            }
+
+            // Grab a cross appdomain/cross process/cross thread lock, to ensure only one port is reserved at a time.
+            using (Mutex mutex = GetGlobalMutex())
+            {
+                try
+                {
+                    int port = basePort - 1;
+
+                    while (true)
+                    {
+                        port++;
+
+                        if (port > 65535)
+                        {
+                            throw new InvalidOperationException("Exceeded port range");
+                        }
+
+                        // AppDomainOwnedPorts check enables reserving two ports from the same thread in sequence.
+                        // ListUsedTCPPort prevents port contention with other apps.
+                        if (_appDomainOwnedPorts.Contains(port) ||
+                            ListUsedTCPPort().Any(endPoint => endPoint.Port == port))
+                        {
+                            continue;
+                        }
+
+                        string mutexName = "WebStack-Port-" + port.ToString(CultureInfo.InvariantCulture); // Create a well known mutex
+                        _portMutex = new Mutex(initiallyOwned: false, name: mutexName);
+
+                        // If no one else is using this port grab it.
+                        if (_portMutex.WaitOne(millisecondsTimeout: 0))
+                        {
+                            break;
+                        }
+
+                        // dispose this mutex since the port it represents is not available.
+                        _portMutex.Dispose();
+                        _portMutex = null;
+                    }
+
+                    PortNumber = port;
+                    _appDomainOwnedPorts.Add(port);
+                }
+                finally
+                {
+                    mutex.ReleaseMutex();
+                }
+            }
+        }
+
+        public string BaseUri
+        {
+            get
+            {
+                return String.Format(CultureInfo.InvariantCulture, "http://localhost:{0}/", PortNumber);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (PortNumber == -1)
+            {
+                // Object already disposed
+                return;
+            }
+
+            using (Mutex mutex = GetGlobalMutex())
+            {
+                _portMutex.Dispose();
+                _appDomainOwnedPorts.Remove(PortNumber);
+                PortNumber = -1;
+            }
+        }
+
+        private static Mutex GetGlobalMutex()
+        {
+            Mutex mutex = new Mutex(initiallyOwned: false, name: "WebStack-RandomPortAcquisition");
+            if (!mutex.WaitOne(30000))
+            {
+                throw new InvalidOperationException();
+            }
+
+            return mutex;
+        }
+
+        private static IPEndPoint[] ListUsedTCPPort()
+        {
+            var usedPort = new HashSet<int>();
+            IPGlobalProperties ipGlobalProperties = IPGlobalProperties.GetIPGlobalProperties();
+
+            return ipGlobalProperties.GetActiveTcpListeners();
+        }
+    }
+}

--- a/tests/NuGet.Services.BasicSearchTests/TestSupport/QueryBuilder.cs
+++ b/tests/NuGet.Services.BasicSearchTests/TestSupport/QueryBuilder.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace NuGet.Services.BasicSearchTests.TestSupport
+{
+    public class QueryBuilder
+    {
+        public string Query { get; set; }
+        public bool Prerelease { get; set; }
+
+        public Uri RequestUri
+        {
+            get
+            {
+                var queryString = System.Web.HttpUtility.ParseQueryString(string.Empty);
+                queryString["q"] = Query;
+                queryString["prerelease"] = Prerelease.ToString();
+
+                return new Uri("/query?" + queryString, UriKind.Relative);
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.BasicSearchTests/TestSupport/StartedWebApp.cs
+++ b/tests/NuGet.Services.BasicSearchTests/TestSupport/StartedWebApp.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+using Microsoft.Owin.Hosting;
+using NuGet.Services.BasicSearch;
+
+namespace NuGet.Services.BasicSearchTests.TestSupport
+{
+    public class StartedWebApp : IDisposable
+    {
+        private TestSettings _settings;
+        private INupkgDownloader _nupkgDownloader;
+        private LuceneDirectoryInitializer _luceneDirectoryInitializer;
+        private DataDirectoryInitializer _dataDirectoryInitializer;
+        private PortReserver _portReserver;
+        private IDisposable _webApp;
+
+        private StartedWebApp()
+        {
+        }
+
+        public static async Task<StartedWebApp> StartAsync(IEnumerable<PackageVersion> packages = null)
+        {
+            var startedWebApp = new StartedWebApp();
+            await startedWebApp.InitializeAsync(packages);
+            return startedWebApp;
+        }
+
+        private async Task InitializeAsync(IEnumerable<PackageVersion> packages = null)
+        {
+            // establish the settings
+            _settings = ReadFromXml<TestSettings>("TestSettings.xml");
+            _nupkgDownloader = new NupkgDownloader(_settings);
+            _luceneDirectoryInitializer = new LuceneDirectoryInitializer(_settings, _nupkgDownloader);
+            _dataDirectoryInitializer = new DataDirectoryInitializer(_settings);
+            _portReserver = new PortReserver();
+
+            // set up the data
+            var enumeratedPackages = packages?.ToArray() ?? new PackageVersion[0];
+            await _nupkgDownloader.DownloadPackagesAsync(enumeratedPackages);
+            string luceneDirectory = _luceneDirectoryInitializer.GetInitializedDirectory(enumeratedPackages);
+            string dataDirectory = await _dataDirectoryInitializer.GetInitializedDirectoryAsync();
+
+            // set up the configuration
+            ConfigurationManager.AppSettings.Set("Local.Lucene.Directory", luceneDirectory);
+            ConfigurationManager.AppSettings.Set("Local.Data.Directory", dataDirectory);
+            ConfigurationManager.AppSettings.Set("Search.RegistrationBaseAddress", _settings.RegistrationBaseAddress);
+
+            // start the app
+            _webApp = WebApp.Start<Startup>(_portReserver.BaseUri);
+            Client = new HttpClient { BaseAddress = new Uri(_portReserver.BaseUri) };
+        }
+
+        public HttpClient Client { get; private set; }
+
+        public void Dispose()
+        {
+            Client?.Dispose();
+            _webApp?.Dispose();
+            _portReserver?.Dispose();
+        }
+
+        private static T ReadFromXml<T>(string path)
+        {
+            var xmlSerializer = new XmlSerializer(typeof(T));
+            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read))
+            {
+                return (T)xmlSerializer.Deserialize(stream);
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.BasicSearchTests/TestSupport/TestSettings.cs
+++ b/tests/NuGet.Services.BasicSearchTests/TestSupport/TestSettings.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.BasicSearchTests.TestSupport
+{
+    public class TestSettings
+    {
+        public string PackageDirectory { get; set; }
+        
+        public string DataDirectory { get; set; }
+        
+        public string RegistrationBaseAddress { get; set; }
+        
+        public string ApiIndexUrl { get; set; }
+
+        public string BaseLuceneDirectory { get; set; }
+    }
+}

--- a/tests/NuGet.Services.BasicSearchTests/packages.config
+++ b/tests/NuGet.Services.BasicSearchTests/packages.config
@@ -1,9 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Lucene.Net" version="3.0.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net45" />
+  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
   <package id="xunit" version="2.0.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.0.0" targetFramework="net45" />


### PR DESCRIPTION
1. Add stitch together code that downloads packages, builds a Lucene index, and starts the server.
2. Add simple functional test for NuGet/Home#833.

Please give me any feedback you can on this framework. I am still pretty ignorant about this stuff. Areas in particular that need review:

- Should we download packages from nuget.org? I am `DataServicePackageRepository` to do this. Alternatives are reading .nupkgs from a share or checking them in maybe?
- Should each test start and stop the service on its own? Right now I use a class fixture to do all of the setup once per *test run*. That is, all tests share the same service, Lucene index, and data directory.
- Are the directories for the test data okay? I am using `Directory.GetCurrentDirectory()` as the base. I think TeamCity cleans this up automatically.
- Should I explicitly clean up the test data? Always? On successful tests (this one may be tricky)?

@johnataylor @joyhui @maartenba @xavierdecoster @yishaigalatzer 