### PR TITLE
Switch to file system cache for AzureDirectory

### DIFF
--- a/src/NuGet.Indexing/NuGetSearcherManager.cs
+++ b/src/NuGet.Indexing/NuGetSearcherManager.cs
@@ -77,7 +77,7 @@ namespace NuGet.Indexing
 
                 searcherManager = new NuGetSearcherManager(
                     indexContainer,
-                    directory ?? new AzureDirectory(storageAccount, indexContainer, new RAMDirectory()),
+                    directory ?? new AzureDirectory(storageAccount, indexContainer),
                     loader ?? new StorageLoader(storageAccount, dataContainer));
             }
 


### PR DESCRIPTION
This is the change analogous to that of [Maarten's fix to V2](https://github.com/NuGet/NuGet.Services.Metadata/commit/e3431e8d91fd248e9fca956f5774a9dad63ebaa2), but for the V3 search service.

I've investigated file system limits for the TEMP folder on Azure Websites and found no hard limits aside that the one specified for the entire machine tier. In the case of of INT, Standard tier has 50 GB. In INT, the entire Lucene database is 1.1 GB.

@maartenba, @johnataylor, @xavierdecoster 