### PR TITLE
Improve V2 compatibility

### DIFF
--- a/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
+++ b/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
@@ -83,8 +83,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Versioning, Version=3.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\nuget.versioning.3.2.0\lib\net45\NuGet.Versioning.dll</HintPath>
+    <Reference Include="NuGet.Versioning, Version=3.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\nuget.versioning.3.3.0\lib\net45\NuGet.Versioning.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Catalog/PackageCatalogItem.cs
+++ b/src/Catalog/PackageCatalogItem.cs
@@ -100,7 +100,7 @@ namespace NuGet.Services.Metadata.Catalog
         private bool GetListed(DateTime published)
         {
             //If the published date is 1900/01/01, then the package is unlisted
-            if (published.ToUniversalTime() == Convert.ToDateTime("1900-01-01T00:00:00Z"))
+            if (published.ToUniversalTime() == Convert.ToDateTime("1900-01-01T00:00:00Z").ToUniversalTime())
             {
                 return false;
             }

--- a/src/Catalog/packages.config
+++ b/src/Catalog/packages.config
@@ -8,7 +8,7 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="nuget.versioning" version="3.2.0" targetFramework="net45" />
+  <package id="NuGet.Versioning" version="3.3.0" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
   <package id="VDS.Common" version="1.5.0" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />

--- a/src/Ng/Ng.csproj
+++ b/src/Ng/Ng.csproj
@@ -132,8 +132,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.Core.2.8.5\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Versioning, Version=3.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\nuget.versioning.3.2.0\lib\net45\NuGet.Versioning.dll</HintPath>
+    <Reference Include="NuGet.Versioning, Version=3.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\nuget.versioning.3.3.0\lib\net45\NuGet.Versioning.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Ng/packages.config
+++ b/src/Ng/packages.config
@@ -12,7 +12,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NuGet.Core" version="2.8.5" targetFramework="net45" />
-  <package id="nuget.versioning" version="3.2.0" targetFramework="net45" />
+  <package id="NuGet.Versioning" version="3.3.0" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
   <package id="VDS.Common" version="1.5.0" targetFramework="net45" />

--- a/src/NuGet.Indexing/Extraction/CatalogNuspecReader.cs
+++ b/src/NuGet.Indexing/Extraction/CatalogNuspecReader.cs
@@ -1,0 +1,60 @@
+using System.Xml.Linq;
+using Newtonsoft.Json.Linq;
+using NuGet.Packaging;
+
+namespace NuGet.Indexing
+{
+    public class CatalogNuspecReader : NuspecReader
+    {
+        private readonly JObject _catalogItem;
+
+        public CatalogNuspecReader(JObject catalogItem) : base(CreateXDocument(catalogItem))
+        {
+            _catalogItem = catalogItem;
+        }
+
+        private static XDocument CreateXDocument(JObject catalogItem)
+        {
+            var document = new XDocument();
+            var package = new XElement("metadata");
+            var metadata = new XElement("metadata");
+
+            // ID
+            var id = new XElement("id", (string)catalogItem["id"]);
+
+            // dependencies
+            var dependencies = new XElement("dependencies");
+            foreach (var group in catalogItem.GetJArray("dependencyGroups"))
+            {
+                var groupElement = new XElement("group");
+                groupElement.SetAttributeValue("targetFramework", (string)group["targetFramework"]);
+                foreach (var dependency in group.GetJArray("dependencies"))
+                {
+                    var dependencyElement = new XElement("dependency");
+                    dependencyElement.SetAttributeValue("id", (string)dependency["id"]);
+                    dependencyElement.SetAttributeValue("version", (string)dependency["range"]);
+                    groupElement.Add(dependencyElement);
+                }
+
+                dependencies.Add(groupElement);
+            }
+
+            // framework assemblies
+            var frameworkAssemblies = new XElement("frameworkAssemblies");
+            foreach (var group in catalogItem.GetJArray("frameworkAssemblyGroup"))
+            {
+                var element = new XElement("frameworkAssembly");
+                element.SetAttributeValue("targetFramework", (string)group["targetFramework"]);
+                frameworkAssemblies.Add(element);
+            }
+
+            metadata.Add(id);
+            metadata.Add(dependencies);
+            metadata.Add(frameworkAssemblies);
+            package.Add(metadata);
+            document.Add(package);
+
+            return document;
+        }
+    }
+}

--- a/src/NuGet.Indexing/Extraction/CatalogPackageReader.cs
+++ b/src/NuGet.Indexing/Extraction/CatalogPackageReader.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+
+namespace NuGet.Indexing
+{
+    public class CatalogPackageReader : PackageReaderBase
+    {
+        private readonly JObject _catalogItem;
+
+        public CatalogPackageReader(JObject catalogItem) : base(DefaultFrameworkNameProvider.Instance, DefaultCompatibilityProvider.Instance)
+        {
+            _catalogItem = catalogItem;
+        }
+
+        public override Stream GetStream(string path)
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override NuspecReader Nuspec => new CatalogNuspecReader(_catalogItem);
+
+        public override IEnumerable<string> GetFiles()
+        {
+            var array = _catalogItem.GetJArray("packageEntries");
+            if (array == null)
+            {
+                yield break;
+            }
+
+            foreach (var entry in array)
+            {
+                yield return (string)entry["fullName"];
+            }
+        }
+
+        protected override IEnumerable<string> GetFiles(string folder)
+        {
+            return GetFiles().Where(f => f.StartsWith(folder + "/", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/src/NuGet.Indexing/Extraction/JTokenExtensions.cs
+++ b/src/NuGet.Indexing/Extraction/JTokenExtensions.cs
@@ -1,0 +1,23 @@
+using Newtonsoft.Json.Linq;
+
+namespace NuGet.Indexing
+{
+    public static class JTokenExtensions
+    {
+        public static JArray GetJArray(this JToken token, string key)
+        {
+            var array = token[key];
+            if (array == null)
+            {
+                return new JArray();
+            }
+
+            if (!(array is JArray))
+            {
+                array = new JArray(array);
+            }
+
+            return (JArray)array;
+        }
+    }
+}

--- a/src/NuGet.Indexing/GalleryServiceImpl.cs
+++ b/src/NuGet.Indexing/GalleryServiceImpl.cs
@@ -43,21 +43,25 @@ namespace NuGet.Indexing
             {
                 take = 20;
             }
+            
+            bool ignoreFilter;
+            if (!bool.TryParse(context.Request.Query["ignoreFilter"], out ignoreFilter))
+            {
+                ignoreFilter = false;
+            }
 
-            //  currently not used 
-            //string projectType = context.Request.Query["projectType"] ?? string.Empty;
-            //string supportedFramework = context.Request.Query["supportedFramework"];
-
-            return QuerySearch(searcherManager, q, countOnly, includePrerelease, sortBy, skip, take, feed);
+            return QuerySearch(searcherManager, q, countOnly, includePrerelease, sortBy, skip, take, feed, ignoreFilter);
         }
 
-        public static string QuerySearch(NuGetSearcherManager searcherManager, string q, bool countOnly, bool includePrerelease, string sortBy, int skip, int take, string feed)
+        public static string QuerySearch(NuGetSearcherManager searcherManager, string q, bool countOnly, bool includePrerelease, string sortBy, int skip, int take, string feed, bool ignoreFilter)
         {
             var searcher = searcherManager.Get();
             try
             {
-                // TODO: this needs to parameterize listed = true | false to support search hijacking
-                Filter filter = searcher.GetFilter(false, includePrerelease, feed);
+                bool includeUnlisted = ignoreFilter;
+                includePrerelease = ignoreFilter || includePrerelease;
+                feed = ignoreFilter ? null : feed;
+                Filter filter = searcher.GetFilter(includeUnlisted, includePrerelease, feed);
 
                 Query query = NuGetQuery.MakeQuery(q);
 

--- a/src/NuGet.Indexing/NuGet.Indexing.csproj
+++ b/src/NuGet.Indexing/NuGet.Indexing.csproj
@@ -115,9 +115,29 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.Core.2.8.5\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Versioning, Version=3.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Versioning.3.2.0\lib\net45\NuGet.Versioning.dll</HintPath>
+    <Reference Include="NuGet.Frameworks, Version=3.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Frameworks.3.3.0\lib\net45\NuGet.Frameworks.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NuGet.Logging, Version=3.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Logging.3.3.0\lib\net45\NuGet.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NuGet.Packaging, Version=3.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.3.3.0\lib\net45\NuGet.Packaging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NuGet.Packaging.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.Core.3.3.0\lib\net45\NuGet.Packaging.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NuGet.Packaging.Core.Types, Version=3.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.Core.Types.3.3.0\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NuGet.Versioning, Version=3.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\nuget.versioning.3.3.0\lib\net45\NuGet.Versioning.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NuGetGallery.Core, Version=3.0.413.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -145,12 +165,15 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BitSetCollector.cs" />
+    <Compile Include="Extraction\CatalogNuspecReader.cs" />
     <Compile Include="Extraction\CatalogPackageMetadataExtraction.cs" />
     <Compile Include="ChainedFilter.cs" />
     <Compile Include="ClientException.cs" />
     <Compile Include="Compatibility.cs" />
     <Compile Include="CuratedFeedHandler.cs" />
+    <Compile Include="Extraction\CatalogPackageReader.cs" />
     <Compile Include="Extraction\DocumentCreator.cs" />
+    <Compile Include="Extraction\JTokenExtensions.cs" />
     <Compile Include="Extraction\PackageEntityMetadataExtraction.cs" />
     <Compile Include="IConfiguration.cs" />
     <Compile Include="OwnerAnalyzer.cs" />

--- a/src/NuGet.Indexing/ResponseFormatter.cs
+++ b/src/NuGet.Indexing/ResponseFormatter.cs
@@ -318,8 +318,7 @@ namespace NuGet.Indexing
             
             WriteDocumentValue(jsonWriter, "Id", document, "Id");
             WriteProperty(jsonWriter, "DownloadCount", downloadCount);
-
-            // TODO: missing owner in lucene
+            
             jsonWriter.WritePropertyName("Owners");
             jsonWriter.WriteStartArray();
             foreach (string owner in document.GetValues("Owner"))

--- a/src/NuGet.Indexing/ServiceImpl.cs
+++ b/src/NuGet.Indexing/ServiceImpl.cs
@@ -5,7 +5,6 @@ using Lucene.Net.Index;
 using Lucene.Net.QueryParsers;
 using Lucene.Net.Search;
 using Microsoft.Owin;
-using System;
 using System.Collections.Generic;
 using System.Net;
 
@@ -41,10 +40,6 @@ namespace NuGet.Indexing
                 includeExplanation = false;
             }
 
-            //  currently not used 
-            //string projectType = context.Request.Query["projectType"] ?? string.Empty;
-            //string supportedFramework = context.Request.Query["supportedFramework"];
-
             string q = context.Request.Query["q"] ?? string.Empty;
 
             string scheme = context.Request.Uri.Scheme;
@@ -61,10 +56,6 @@ namespace NuGet.Indexing
                 TopDocs topDocs;
 
                 Filter filter = searcher.GetFilter(false, includePrerelease, feed);
-
-                //TODO: uncomment these lines when we have an index that contains the appropriate @type field in every document
-                //Filter typeFilter = new CachingWrapperFilter(new TypeFilter("http://schema.nuget.org/schema#NuGetClassicPackage"));
-                //filter = new ChainedFilter(new Filter[] { filter, typeFilter }, ChainedFilter.Logic.AND);
 
                 topDocs = searcher.Search(query, filter, skip + take);
 

--- a/src/NuGet.Indexing/packages.config
+++ b/src/NuGet.Indexing/packages.config
@@ -12,7 +12,12 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NuGet.Core" version="2.8.5" targetFramework="net45" />
-  <package id="NuGet.Versioning" version="3.2.0" targetFramework="net45" />
+  <package id="NuGet.Frameworks" version="3.3.0" targetFramework="net45" />
+  <package id="NuGet.Logging" version="3.3.0" targetFramework="net45" />
+  <package id="NuGet.Packaging" version="3.3.0" targetFramework="net45" />
+  <package id="NuGet.Packaging.Core" version="3.3.0" targetFramework="net45" />
+  <package id="NuGet.Packaging.Core.Types" version="3.3.0" targetFramework="net45" />
+  <package id="NuGet.Versioning" version="3.3.0" targetFramework="net45" />
   <package id="NuGetGallery.Core" version="3.0.413-r-master" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />

--- a/tests/CatalogTests/CatalogTests.csproj
+++ b/tests/CatalogTests/CatalogTests.csproj
@@ -99,8 +99,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.CatalogPackaging.1.0.0-alpha003\lib\net45\NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Versioning, Version=3.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\nuget.versioning.3.2.0\lib\net45\NuGet.Versioning.dll</HintPath>
+    <Reference Include="NuGet.Versioning, Version=3.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\nuget.versioning.3.3.0\lib\net45\NuGet.Versioning.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/tests/CatalogTests/packages.config
+++ b/tests/CatalogTests/packages.config
@@ -10,7 +10,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NuGet.CatalogPackaging" version="1.0.0-alpha003" targetFramework="net45" />
-  <package id="nuget.versioning" version="3.2.0" targetFramework="net45" />
+  <package id="NuGet.Versioning" version="3.3.0" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
   <package id="VDS.Common" version="1.5.0" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />

--- a/tests/IndexingTests/IndexingTests.csproj
+++ b/tests/IndexingTests/IndexingTests.csproj
@@ -100,15 +100,15 @@
       <HintPath>..\..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Core, Version=2.8.60318.667, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.Core.2.8.5\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Versioning, Version=3.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\nuget.versioning.3.2.0\lib\net45\NuGet.Versioning.dll</HintPath>
+    <Reference Include="NuGet.Versioning, Version=3.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\nuget.versioning.3.3.0\lib\net45\NuGet.Versioning.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGetGallery.Core, Version=3.0.413.0, Culture=neutral, processorArchitecture=MSIL">

--- a/tests/IndexingTests/packages.config
+++ b/tests/IndexingTests/packages.config
@@ -10,9 +10,9 @@
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NuGet.Core" version="2.8.5" targetFramework="net45" />
-  <package id="nuget.versioning" version="3.2.0" targetFramework="net45" />
+  <package id="NuGet.Versioning" version="3.3.0" targetFramework="net45" />
   <package id="NuGetGallery.Core" version="3.0.413-r-master" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />


### PR DESCRIPTION
1. Detect supported frameworks from package entries as well as framework assembly groups.
2. Support the `ignoreFilter` parameter on V2 search which allows the search hijacker in the gallery to find unlisted packages.

@maartenba @joyhui @xavierdecoster @johnataylor 