### PR TITLE
Fix Web.Release.config

### DIFF
--- a/src/NuGet.Services.BasicSearch/Web.Release.config
+++ b/src/NuGet.Services.BasicSearch/Web.Release.config
@@ -3,7 +3,7 @@
 <!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
 
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
-  <system.web>
+  <system.webServer>
     <!-- add custom rule to recycle app pool if memory is more than 4 GB -->
     <monitoring xdt:Transform="Insert">
       <triggers>
@@ -11,6 +11,8 @@
       </triggers>
       <actions value="Recycle" />
     </monitoring>
+  </system.webServer>
+  <system.web>
     <compilation xdt:Transform="RemoveAttributes(debug)" />
   </system.web>
 </configuration>


### PR DESCRIPTION
This was causing an error on app startup. The `<monitoring>` tag should be under `<system.webServer>`, not `<system.web>`.