### PR TITLE
Add Application Initialization for search web site

### DIFF
--- a/src/NuGet.Services.BasicSearch/Web.config
+++ b/src/NuGet.Services.BasicSearch/Web.config
@@ -32,6 +32,9 @@
     <!-- END Serilog logging configuration -->
   </appSettings>
   <system.webServer>
+    <applicationInitialization>
+      <add initializationPage="/search/diag" />
+    </applicationInitialization>
     <validation validateIntegratedModeConfiguration="false" />
     <modules>
       <remove name="ApplicationInsightsWebTracking" />


### PR DESCRIPTION
This one preloads the `/search/diag` endpoint, which in turn reads the entire index.

Do we need other URL's hit during warmup? I figure loading the full index is probably the only thing we want to do here, which should work with this change.