### PR TITLE
In progress - Improve catalog to registration performance

### DIFF
--- a/NgTests/RegistrationCollectorTests.cs
+++ b/NgTests/RegistrationCollectorTests.cs
@@ -35,8 +35,7 @@ namespace NgTests
             // Setup collector
             var target = new RegistrationCollector(new Uri("http://tempuri.org/index.json"), catalogToRegistrationStorageFactory, () => mockServer)
             {
-                ContentBaseAddress = new Uri("http://tempuri.org/packages"),
-                UnlistShouldDelete = false
+                ContentBaseAddress = new Uri("http://tempuri.org/packages")
             };
             ReadWriteCursor front = new DurableCursor(catalogToRegistrationStorage.ResolveUri("cursor.json"), catalogToRegistrationStorage, MemoryCursor.Min.Value);
             ReadCursor back = MemoryCursor.Max;

--- a/src/Catalog/CatalogWriterBase.cs
+++ b/src/Catalog/CatalogWriterBase.cs
@@ -98,8 +98,7 @@ namespace NuGet.Services.Metadata.Catalog
 
             int batchIndex = 0;
 
-            Task[] saveTasks = new Task[_batch.Count];
-
+            var saveTasks = new List<Task>();
             foreach (CatalogItem item in _batch)
             {
                 Uri resourceUri = null;
@@ -116,7 +115,7 @@ namespace NuGet.Services.Metadata.Catalog
 
                     if (content != null)
                     {
-                        saveTasks[batchIndex] = Storage.Save(resourceUri, content, cancellationToken);
+                        saveTasks.Add(Storage.Save(resourceUri, content, cancellationToken));
                     }
 
                     IGraph pageContent = item.CreatePageContent(Context);

--- a/src/Catalog/Registration/RegistrationCatalogEntry.cs
+++ b/src/Catalog/Registration/RegistrationCatalogEntry.cs
@@ -9,24 +9,25 @@ namespace NuGet.Services.Metadata.Catalog.Registration
 {
     public class RegistrationCatalogEntry
     {
-        public RegistrationCatalogEntry(string resourceUri, IGraph graph)
+        public RegistrationCatalogEntry(string resourceUri, IGraph graph, bool newItem)
         {
             ResourceUri = resourceUri;
             Graph = graph;
+            NewItem = newItem;
         }
+
         public string ResourceUri { get; set; }
         public IGraph Graph { get; set; }
+        public bool NewItem { get; set; }
 
-        public static KeyValuePair<RegistrationEntryKey, RegistrationCatalogEntry> Promote(string resourceUri, IGraph graph, bool unlistShouldDelete = false)
+        public static KeyValuePair<RegistrationEntryKey, RegistrationCatalogEntry> Promote(string resourceUri, IGraph graph, bool newItem)
         {
             INode subject = graph.CreateUriNode(new Uri(resourceUri));
             string version = graph.GetTriplesWithSubjectPredicate(subject, graph.CreateUriNode(Schema.Predicates.Version)).First().Object.ToString();
 
             RegistrationEntryKey registrationEntryKey = new RegistrationEntryKey(RegistrationKey.Promote(resourceUri, graph), version);
 
-            bool deleteByUnlisting = unlistShouldDelete & !IsListed(subject, graph);
-
-            RegistrationCatalogEntry registrationCatalogEntry = deleteByUnlisting | IsDelete(subject, graph) ? null : new RegistrationCatalogEntry(resourceUri, graph);
+            RegistrationCatalogEntry registrationCatalogEntry = IsDelete(subject, graph) ? null : new RegistrationCatalogEntry(resourceUri, graph, newItem);
 
             return new KeyValuePair<RegistrationEntryKey, RegistrationCatalogEntry>(registrationEntryKey, registrationCatalogEntry);
         }

--- a/src/Catalog/Registration/RegistrationCollector.cs
+++ b/src/Catalog/Registration/RegistrationCollector.cs
@@ -28,7 +28,6 @@ namespace NuGet.Services.Metadata.Catalog.Registration
         public Uri ContentBaseAddress { get; set; }
         public int PartitionSize { get; set; }
         public int PackageCountThreshold { get; set; }
-        public bool UnlistShouldDelete { get; set; }
 
         protected override Task ProcessGraphs(KeyValuePair<string, IDictionary<string, IGraph>> sortedGraphs, CancellationToken cancellationToken)
         {
@@ -39,7 +38,7 @@ namespace NuGet.Services.Metadata.Catalog.Registration
                 ContentBaseAddress,
                 PartitionSize,
                 PackageCountThreshold,
-                UnlistShouldDelete, cancellationToken);
+                cancellationToken);
         }
     }
 }

--- a/src/Catalog/Registration/RegistrationMaker.cs
+++ b/src/Catalog/Registration/RegistrationMaker.cs
@@ -12,7 +12,7 @@ namespace NuGet.Services.Metadata.Catalog.Registration
 {
     public static class RegistrationMaker
     {
-        public static async Task Process(RegistrationKey registrationKey, IDictionary<string, IGraph> newItems, StorageFactory storageFactory, Uri contentBaseAddress, int partitionSize, int packageCountThreshold, bool unlistShouldDelete, CancellationToken cancellationToken)
+        public static async Task Process(RegistrationKey registrationKey, IDictionary<string, IGraph> newItems, StorageFactory storageFactory, Uri contentBaseAddress, int partitionSize, int packageCountThreshold, CancellationToken cancellationToken)
         {
             Trace.TraceInformation("RegistrationMaker.Process: registrationKey = {0} newItems: {1}", registrationKey, newItems.Count);
 
@@ -22,7 +22,7 @@ namespace NuGet.Services.Metadata.Catalog.Registration
 
             Trace.TraceInformation("RegistrationMaker.Process: existing = {0}", existing.Count);
 
-            IDictionary<RegistrationEntryKey, RegistrationCatalogEntry> delta = PromoteRegistrationKey(newItems, unlistShouldDelete);
+            IDictionary<RegistrationEntryKey, RegistrationCatalogEntry> delta = PromoteRegistrationKey(newItems);
 
             Trace.TraceInformation("RegistrationMaker.Process: delta = {0}", delta.Count);
             
@@ -33,12 +33,12 @@ namespace NuGet.Services.Metadata.Catalog.Registration
             await registration.Save(resulting, cancellationToken);
         }
 
-        static IDictionary<RegistrationEntryKey, RegistrationCatalogEntry> PromoteRegistrationKey(IDictionary<string, IGraph> newItems, bool unlistShouldDelete)
+        static IDictionary<RegistrationEntryKey, RegistrationCatalogEntry> PromoteRegistrationKey(IDictionary<string, IGraph> newItems)
         {
             IDictionary<RegistrationEntryKey, RegistrationCatalogEntry> promoted = new Dictionary<RegistrationEntryKey, RegistrationCatalogEntry>();
             foreach (var newItem in newItems)
             {
-                promoted.Add(RegistrationCatalogEntry.Promote(newItem.Key, newItem.Value, unlistShouldDelete));
+                promoted.Add(RegistrationCatalogEntry.Promote(newItem.Key, newItem.Value, true));
             }
             return promoted;
         }

--- a/src/Catalog/Registration/RegistrationMakerCatalogItem.cs
+++ b/src/Catalog/Registration/RegistrationMakerCatalogItem.cs
@@ -20,20 +20,27 @@ namespace NuGet.Services.Metadata.Catalog.Registration
         Uri _packageContentBaseAddress;
         Uri _packageContentAddress;
         Uri _registrationBaseAddress;
+        bool _newItem;
         Uri _registrationAddress;
         DateTime _publishedDate;
         Boolean _listed;
 
-        public RegistrationMakerCatalogItem(Uri catalogUri, IGraph catalogItem, Uri registrationBaseAddress, Uri packageContentBaseAddress = null)
+        public RegistrationMakerCatalogItem(Uri catalogUri, IGraph catalogItem, Uri registrationBaseAddress, bool newItem, Uri packageContentBaseAddress = null)
         {
             _catalogUri = catalogUri;
             _catalogItem = catalogItem;
             _packageContentBaseAddress = packageContentBaseAddress;
             _registrationBaseAddress = registrationBaseAddress;
+            _newItem = newItem;
         }
 
         public override StorageContent CreateContent(CatalogContext context)
         {
+            if (!_newItem)
+            {
+                return null;
+            }
+
             IGraph graph = new Graph();
             INode subject = graph.CreateUriNode(GetItemAddress());
 

--- a/src/Catalog/Registration/RegistrationPersistence.cs
+++ b/src/Catalog/Registration/RegistrationPersistence.cs
@@ -144,51 +144,12 @@ namespace NuGet.Services.Metadata.Catalog.Registration
                 graph.Merge(task.Result, false);
             }
 
-            await LoadCatalogItems(storage, graph, cancellationToken);
-
             return graph;
         }
 
         static async Task<IGraph> LoadCatalogPage(IStorage storage, Uri pageUri, CancellationToken cancellationToken)
         {
             string json = await storage.LoadString(pageUri, cancellationToken);
-            IGraph graph = Utils.CreateGraph(json);
-            return graph;
-        }
-
-        static async Task LoadCatalogItems(IStorage storage, IGraph graph, CancellationToken cancellationToken)
-        {
-            Trace.TraceInformation("RegistrationPersistence.LoadCatalogItems");
-
-            IList<Uri> itemUris = new List<Uri>();
-
-            IEnumerable<Triple> pages = graph.GetTriplesWithPredicateObject(graph.CreateUriNode(Schema.Predicates.Type), graph.CreateUriNode(Schema.DataTypes.CatalogPage));
-
-            foreach (Triple page in pages)
-            {
-                IEnumerable<Triple> items = graph.GetTriplesWithSubjectPredicate(page.Subject, graph.CreateUriNode(Schema.Predicates.CatalogItem));
-
-                foreach (Triple item in items)
-                {
-                    itemUris.Add(((IUriNode)item.Object).Uri);
-                }
-            }
-
-            IList<Task<IGraph>> tasks = new List<Task<IGraph>>();
-
-            foreach (Uri itemUri in itemUris)
-            {
-                tasks.Add(LoadCatalogItem(storage, itemUri, cancellationToken));
-            }
-
-            await Task.WhenAll(tasks.ToArray());
-
-            //TODO: if we have details at the package level and not inlined on a page we will merge them in here
-        }
-
-        static async Task<IGraph> LoadCatalogItem(IStorage storage, Uri itemUri, CancellationToken cancellationToken)
-        {
-            string json = await storage.LoadString(itemUri, cancellationToken);
             IGraph graph = Utils.CreateGraph(json);
             return graph;
         }

--- a/src/Catalog/RegistrationCatalogCreator.cs
+++ b/src/Catalog/RegistrationCatalogCreator.cs
@@ -108,7 +108,6 @@ namespace NuGet.Services.Metadata.Catalog
             {
                 if (uri != storage.ResolveUri("index.json"))
                 {
-                    Console.WriteLine("DELETE: {0}", uri);
                     await storage.Delete(uri, cancellationToken);
                 }
             }

--- a/src/Ng/Catalog2Registration.cs
+++ b/src/Ng/Catalog2Registration.cs
@@ -24,7 +24,7 @@ namespace Ng
 
         public async Task Loop(string source, StorageFactory storageFactory, string contentBaseAddress, bool verbose, int interval, CancellationToken cancellationToken)
         {
-            CommitCollector collector = new RegistrationCollector(new Uri(source), storageFactory, CommandHelpers.GetHttpMessageHandlerFactory(verbose))
+            var collector = new RegistrationCatalogCollector(new Uri(source), storageFactory, CommandHelpers.GetHttpMessageHandlerFactory(verbose))
             {
                 ContentBaseAddress = contentBaseAddress == null ? null : new Uri(contentBaseAddress)
             };

--- a/src/Ng/Catalog2Registration.cs
+++ b/src/Ng/Catalog2Registration.cs
@@ -24,7 +24,7 @@ namespace Ng
 
         public async Task Loop(string source, StorageFactory storageFactory, string contentBaseAddress, bool verbose, int interval, CancellationToken cancellationToken)
         {
-            var collector = new RegistrationCatalogCollector(new Uri(source), storageFactory, CommandHelpers.GetHttpMessageHandlerFactory(verbose))
+            CommitCollector collector = new RegistrationCollector(new Uri(source), storageFactory, CommandHelpers.GetHttpMessageHandlerFactory(verbose))
             {
                 ContentBaseAddress = contentBaseAddress == null ? null : new Uri(contentBaseAddress)
             };

--- a/src/Ng/Catalog2Registration.cs
+++ b/src/Ng/Catalog2Registration.cs
@@ -22,12 +22,11 @@ namespace Ng
             _logger = loggerFactory.CreateLogger<Catalog2Registration>();
         }
 
-        public async Task Loop(string source, StorageFactory storageFactory, string contentBaseAddress, bool unlistShouldDelete, bool verbose, int interval, CancellationToken cancellationToken)
+        public async Task Loop(string source, StorageFactory storageFactory, string contentBaseAddress, bool verbose, int interval, CancellationToken cancellationToken)
         {
             CommitCollector collector = new RegistrationCollector(new Uri(source), storageFactory, CommandHelpers.GetHttpMessageHandlerFactory(verbose))
             {
-                ContentBaseAddress = contentBaseAddress == null ? null : new Uri(contentBaseAddress),
-                UnlistShouldDelete = unlistShouldDelete
+                ContentBaseAddress = contentBaseAddress == null ? null : new Uri(contentBaseAddress)
             };
 
             Storage storage = storageFactory.Create();
@@ -68,8 +67,6 @@ namespace Ng
                 return;
             }
 
-            bool unlistShouldDelete = CommandHelpers.GetUnlistShouldDelete(arguments);
-
             bool verbose = CommandHelpers.GetVerbose(arguments);
 
             int interval = CommandHelpers.GetInterval(arguments);
@@ -91,7 +88,7 @@ namespace Ng
 
             Trace.TraceInformation("CONFIG source: \"{0}\" storage: \"{1}\" interval: {2} seconds", source, storageFactory, interval);
 
-            Loop(source, storageFactory, contentBaseAddress, unlistShouldDelete, verbose, interval, cancellationToken).Wait();
+            Loop(source, storageFactory, contentBaseAddress, verbose, interval, cancellationToken).Wait();
         }
     }
 }

--- a/src/Ng/CommandHelpers.cs
+++ b/src/Ng/CommandHelpers.cs
@@ -116,17 +116,6 @@ namespace Ng
             return value;
         }
 
-        public static bool GetUnlistShouldDelete(IDictionary<string, string> arguments)
-        {
-            string unlistShouldDeleteStr = null;
-            if (arguments.TryGetValue("-unlistShouldDelete", out unlistShouldDeleteStr))
-            {
-                return unlistShouldDeleteStr.Equals("true", StringComparison.InvariantCultureIgnoreCase);
-            }
-
-            return false;
-        }
-
         public static bool GetVerbose(IDictionary<string, string> arguments)
         {
             string verboseStr = "false";

--- a/tests/CatalogTests/RegistrationMakerTests.cs
+++ b/tests/CatalogTests/RegistrationMakerTests.cs
@@ -71,7 +71,7 @@ namespace CatalogTests
             catalog.Add(CreateTestCatalogEntry("mypackage", "4.0.0"));
             catalog.Add(CreateTestCatalogEntry("mypackage", "5.0.0"));
             FileStorageFactory factory = new FileStorageFactory(new Uri("http://tempuri.org"), path);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), catalog, factory, new Uri("http://content/"), 2, 3, false, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), catalog, factory, new Uri("http://content/"), 2, 3, CancellationToken.None);
         }
 
         public static async Task Test1Async()
@@ -87,12 +87,12 @@ namespace CatalogTests
 
             FileStorageFactory factory = new FileStorageFactory(new Uri("http://tempuri.org"), path);
 
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "1.0.0"), factory, new Uri("http://content/"), 2, 3, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "2.0.0"), factory, new Uri("http://content/"), 2, 3, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "3.0.0"), factory, new Uri("http://content/"), 2, 3, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "4.0.0"), factory, new Uri("http://content/"), 2, 3, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "5.0.0"), factory, new Uri("http://content/"), 2, 3, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "6.0.0"), factory, new Uri("http://content/"), 2, 3, false, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "1.0.0"), factory, new Uri("http://content/"), 2, 3, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "2.0.0"), factory, new Uri("http://content/"), 2, 3, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "3.0.0"), factory, new Uri("http://content/"), 2, 3, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "4.0.0"), factory, new Uri("http://content/"), 2, 3, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "5.0.0"), factory, new Uri("http://content/"), 2, 3, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "6.0.0"), factory, new Uri("http://content/"), 2, 3, CancellationToken.None);
         }
 
         public static async Task Test2Async()
@@ -108,12 +108,12 @@ namespace CatalogTests
 
             FileStorageFactory factory = new FileStorageFactory(new Uri("http://tempuri.org"), path);
 
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "1.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "2.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "3.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "4.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "5.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "6.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "1.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "2.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "3.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "4.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "5.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "6.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
         }
 
         public static async Task Test3Async()
@@ -133,14 +133,14 @@ namespace CatalogTests
             catalog.Add(CreateTestCatalogEntry("mypackage", "1.0.0"));
             catalog.Add(CreateTestCatalogEntry("mypackage", "2.0.0"));
             catalog.Add(CreateTestCatalogEntry("mypackage", "3.0.0"));
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), catalog, factory, new Uri("http://content/"), 2, 3, false, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), catalog, factory, new Uri("http://content/"), 2, 3, CancellationToken.None);
 
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "3.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "4.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "5.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "6.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "3.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "4.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "5.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "6.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
 
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryDeleteBatch("mypackage", "4.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryDeleteBatch("mypackage", "4.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
         }
 
         public static async Task Test4Async()
@@ -162,7 +162,6 @@ namespace CatalogTests
 
             CollectorBase collector = new RegistrationCollector(catalogUri, factory)
             {
-                UnlistShouldDelete = true,
                 Concurrent = false
             };
 


### PR DESCRIPTION
1. Don't read the leaf nodes of the registration, only reading the index.json (and pages on large registration) is necessary.
2. Only write new registration leaf blobs. With this change, the new (that is added or updated) leaf nodes are updates along with the page and index.json blobs.