### PR TITLE
Hook up Serilog logging into ng.exe jobs

### DIFF
--- a/NgTests/NgTests.csproj
+++ b/NgTests/NgTests.csproj
@@ -34,6 +34,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.1.0.0-rc1-final\lib\net451\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/NgTests/TestableFeed2Catalog.cs
+++ b/NgTests/TestableFeed2Catalog.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Ng;
 using NuGet.Services.Metadata.Catalog.Persistence;
 
@@ -13,6 +14,7 @@ namespace NgTests
         private readonly HttpMessageHandler _handler;
 
         public TestableFeed2Catalog(HttpMessageHandler handler)
+            : base(new TestLoggerFactory())
         {
             _handler = handler;
         }
@@ -25,6 +27,52 @@ namespace NgTests
         public async Task InvokeProcessFeed(string gallery, Storage catalogStorage, Storage auditingStorage, DateTime? startDate, TimeSpan timeout, int top, bool verbose, CancellationToken cancellationToken)
         {
             await ProcessFeed(gallery, catalogStorage, auditingStorage, startDate, timeout, top, verbose, cancellationToken);
+        }
+    }
+
+    internal class TestLoggerFactory
+        : ILoggerFactory
+    {
+        public void Dispose()
+        {
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new TestLogger();
+        }
+
+        public void AddProvider(ILoggerProvider provider)
+        {
+        }
+
+        public LogLevel MinimumLevel { get; set; }
+    }
+
+    internal class TestLogger
+        : ILogger
+    {
+        public void Log(LogLevel logLevel, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)
+        {
+            Console.WriteLine($"{logLevel}: {formatter(state, exception)}");
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public IDisposable BeginScopeImpl(object state)
+        {
+            return new TestLoggerScoper();
+        }
+
+        private class TestLoggerScoper
+            : IDisposable
+        {
+            public void Dispose()
+            {
+            }
         }
     }
 }

--- a/NgTests/app.config
+++ b/NgTests/app.config
@@ -25,6 +25,14 @@
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0" />
+	  </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Serilog.FullNetFx" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/NgTests/packages.config
+++ b/NgTests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="1.0.0-rc1-final" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="xunit" version="2.0.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />

--- a/src/Ng/App.config
+++ b/src/Ng/App.config
@@ -45,12 +45,16 @@
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="NuGet.Versioning" publicKeyToken="2e465378e3b1a8dd" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.0.7.0" newVersion="1.0.7.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Serilog.FullNetFx" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
@@ -64,8 +68,8 @@
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
- <system.diagnostics>
-   <trace autoflush="true" indentsize="4">
+  <system.diagnostics>
+    <trace autoflush="true" indentsize="4">
       <listeners>
         <add name="myListener" type="System.Diagnostics.TextWriterTraceListener" initializeData="TextWriterOutput.log" traceOutputOptions="DateTime" />
         <remove name="Default" />

--- a/src/Ng/Catalog2Dnx.cs
+++ b/src/Ng/Catalog2Dnx.cs
@@ -1,18 +1,26 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using NuGet.Services.Metadata.Catalog;
 using NuGet.Services.Metadata.Catalog.Persistence;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace Ng
 {
     public class Catalog2Dnx
     {
+        private readonly ILogger _logger;
+
+        public Catalog2Dnx(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<Catalog2Registration>();
+        }
+
         public async Task Loop(string source, StorageFactory storageFactory, string contentBaseAddress, bool verbose, int interval, CancellationToken cancellationToken)
         {
             CommitCollector collector = new DnxCatalogCollector(new Uri(source), storageFactory, CommandHelpers.GetHttpMessageHandlerFactory(verbose))

--- a/src/Ng/Catalog2Registration.cs
+++ b/src/Ng/Catalog2Registration.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using NuGet.Services.Metadata.Catalog;
 using NuGet.Services.Metadata.Catalog.Persistence;
 using NuGet.Services.Metadata.Catalog.Registration;
@@ -8,11 +9,19 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace Ng
 {
     public class Catalog2Registration
     {
+        private readonly ILogger _logger;
+
+        public Catalog2Registration(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<Catalog2Registration>();
+        }
+
         public async Task Loop(string source, StorageFactory storageFactory, string contentBaseAddress, bool unlistShouldDelete, bool verbose, int interval, CancellationToken cancellationToken)
         {
             CommitCollector collector = new RegistrationCollector(new Uri(source), storageFactory, CommandHelpers.GetHttpMessageHandlerFactory(verbose))

--- a/src/Ng/CommandHelpers.cs
+++ b/src/Ng/CommandHelpers.cs
@@ -39,7 +39,7 @@ namespace Ng
             return result;
         }
 
-        static void TraceRequiredArgument(string name)
+        private static void TraceRequiredArgument(string name)
         {
             Console.WriteLine("Required argument \"{0}\" not provided", name);
             Trace.TraceError("Required argument \"{0}\" not provided", name);
@@ -458,7 +458,7 @@ namespace Ng
             Func<HttpMessageHandler> handlerFunc = null;
             if (verbose)
             {
-                handlerFunc = () => 
+                handlerFunc = () =>
                 {
                     if (catalogBaseAddress != null)
                     {
@@ -491,6 +491,39 @@ namespace Ng
             }
 
             return path;
+        }
+
+        public static string GetElasticsearchEndpoint(IDictionary<string, string> arguments)
+        {
+            string endpoint;
+            if (arguments == null || !arguments.TryGetValue("-elasticsearchendpoint", out endpoint))
+            {
+                return null;
+            }
+
+            return endpoint;
+        }
+
+        public static string GetElasticsearchUsername(IDictionary<string, string> arguments)
+        {
+            string value;
+            if (arguments == null || !arguments.TryGetValue("-elasticsearchusername", out value))
+            {
+                return null;
+            }
+
+            return value;
+        }
+
+        public static string GetElasticsearchPassword(IDictionary<string, string> arguments)
+        {
+            string value;
+            if (arguments == null || !arguments.TryGetValue("-elasticsearchpassword", out value))
+            {
+                return null;
+            }
+
+            return value;
         }
     }
 }

--- a/src/Ng/Db2Lucene.cs
+++ b/src/Ng/Db2Lucene.cs
@@ -1,24 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using NuGet.Indexing;
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace Ng
 {
-    class Db2Lucene
+    internal class Db2Lucene
     {
-        static void PrintUsage()
-        {
-            Console.WriteLine("Usage: ng db2lucene -connectionString <connectionString> -path <folder> [-verbose true|false]");
-        }
-
-        public static void Run(string[] args, CancellationToken cancellationToken)
+        public static void Run(string[] args, CancellationToken cancellationToken, ILoggerFactory loggerFactory)
         {
             IDictionary<string, string> arguments = CommandHelpers.GetArguments(args, 1);
             if (arguments == null || arguments.Count == 0)
@@ -27,7 +20,7 @@ namespace Ng
                 return;
             }
 
-            string connectionString = CommandHelpers.GetConnectionString(arguments);
+            var connectionString = CommandHelpers.GetConnectionString(arguments);
             if (connectionString == null)
             {
                 PrintUsage();
@@ -41,11 +34,12 @@ namespace Ng
                 return;
             }
 
-            bool verbose = CommandHelpers.GetVerbose(arguments);
+            Sql2Lucene.Export(connectionString, path, loggerFactory);
+        }
 
-            TextWriter log = verbose ? Console.Out : new StringWriter();
-
-            Sql2Lucene.Export(connectionString, path, log);
+        private static void PrintUsage()
+        {
+            Console.WriteLine("Usage: ng db2lucene -connectionString <connectionString> -path <folder> [-verbose true|false]");
         }
     }
 }

--- a/src/Ng/Ng.csproj
+++ b/src/Ng/Ng.csproj
@@ -57,6 +57,10 @@
       <HintPath>..\..\packages\dotnetrdf.1.0.8.3533\lib\net40\dotNetRDF.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Elasticsearch.Net, Version=1.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Elasticsearch.Net.1.7.1\lib\net45\Elasticsearch.Net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="HtmlAgilityPack, Version=1.4.9.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\HtmlAgilityPack.1.4.9\lib\Net45\HtmlAgilityPack.dll</HintPath>
       <Private>True</Private>
@@ -125,6 +129,18 @@
       <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0-rc1-final\lib\net451\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.1.0.0-rc1-final\lib\net451\Microsoft.Extensions.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.1.0.0-rc1-final\lib\net451\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
       <Private>True</Private>
@@ -149,8 +165,22 @@
       <HintPath>..\..\packages\NuGet.Versioning.3.4.0-beta-515\lib\net45\NuGet.Versioning.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Elasticsearch, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Sinks.Elasticsearch.2.0.70\lib\net45\Serilog.Sinks.Elasticsearch.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
@@ -169,6 +199,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\NuGet.Services.BasicSearch\Logging.cs">
+      <Link>Logging.cs</Link>
+    </Compile>
     <Compile Include="Catalog2Dnx.cs" />
     <Compile Include="Db2Lucene.cs" />
     <Compile Include="DnxCatalogCollector.cs" />

--- a/src/Ng/Ng.csproj.DotSettings
+++ b/src/Ng/Ng.csproj.DotSettings
@@ -1,2 +1,2 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String></wpf:ResourceDictionary>

--- a/src/Ng/Program.cs
+++ b/src/Ng/Program.cs
@@ -1,30 +1,43 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-using NuGet.Services.Metadata.Catalog;
+
 using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Microsoft.Extensions.Logging;
+using NuGet.Services;
 
 namespace Ng
 {
-    class Program
+    public class Program
     {
-        static void PrintUsage()
+        private static ILogger _logger;
+
+        private static void PrintUsage()
         {
             Console.WriteLine("Usage: ng [package2catalog|feed2catalog|catalog2registration|catalog2lucene|catalog2dnx|frameworkcompatibility|copylucene|checklucene|clearlucene|db2lucene]");
         }
 
-        static void Main(string[] args)
+        public static void Main(string[] args)
         {
-            if (args.Length > 0 && String.Equals("dbg", args[0], StringComparison.OrdinalIgnoreCase))
+            if (args.Length > 0 && string.Equals("dbg", args[0], StringComparison.OrdinalIgnoreCase))
             {
                 args = args.Skip(1).ToArray();
                 Debugger.Launch();
             }
 
-            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            // create an ILoggerFactory
+            var arguments = CommandHelpers.GetArguments(args, 0);
+            var elasticsearchEndpoint = CommandHelpers.GetElasticsearchEndpoint(arguments);
+            var elasticsearchUsername = CommandHelpers.GetElasticsearchUsername(arguments);
+            var elasticsearchPassword = CommandHelpers.GetElasticsearchPassword(arguments);
+            var loggerFactory = Logging.CreateLoggerFactory(elasticsearchEndpoint, elasticsearchUsername, elasticsearchPassword);
 
+            // create a logger that is scoped to this class (only)
+            _logger = loggerFactory.CreateLogger<Program>();
+
+            var cancellationTokenSource = new CancellationTokenSource();
             try
             {
                 if (args.Length == 0)
@@ -36,22 +49,22 @@ namespace Ng
                 switch (args[0])
                 {
                     case "package2catalog":
-                        var packageToCatalog = new Feed2Catalog();
+                        var packageToCatalog = new Feed2Catalog(loggerFactory);
                         packageToCatalog.Package(args, cancellationTokenSource.Token);
                         break;
                     case "feed2catalog":
-                        var feedToCatalog = new Feed2Catalog();
+                        var feedToCatalog = new Feed2Catalog(loggerFactory);
                         feedToCatalog.Run(args, cancellationTokenSource.Token);
                         break;
                     case "catalog2registration":
-                        var catalog2Registration = new Catalog2Registration();
+                        var catalog2Registration = new Catalog2Registration(loggerFactory);
                         catalog2Registration.Run(args, cancellationTokenSource.Token);
                         break;
                     case "catalog2lucene":
                         Catalog2Lucene.Run(args, cancellationTokenSource.Token);
                         break;
                     case "catalog2dnx":
-                        var catalogToDnx = new Catalog2Dnx();
+                        var catalogToDnx = new Catalog2Dnx(loggerFactory);
                         catalogToDnx.Run(args, cancellationTokenSource.Token);
                         break;
                     case "copylucene":
@@ -64,7 +77,7 @@ namespace Ng
                         ResetLucene.Run(args);
                         break;
                     case "db2lucene":
-                        Db2Lucene.Run(args, cancellationTokenSource.Token);
+                        Db2Lucene.Run(args, cancellationTokenSource.Token, loggerFactory);
                         break;
                     default:
                         PrintUsage();
@@ -73,8 +86,9 @@ namespace Ng
             }
             catch (Exception e)
             {
-                Utils.TraceException(e);
+                _logger.LogCritical("A critical exception occured in ng.exe!", e);
             }
+
             Trace.Close();
         }
     }

--- a/src/Ng/Scripts/Catalog2DnxV3.cmd
+++ b/src/Ng/Scripts/Catalog2DnxV3.cmd
@@ -9,7 +9,7 @@ cd Ng
 
 	title #{Jobs.ngcatalog2dnx.Title}
 	
-    start /w Ng.exe catalog2dnx -source #{Jobs.ngcatalog2dnx.Catalog.Source} -contentBaseAddress #{Jobs.ngcatalog2dnx.ContentBaseAddress} -storageBaseAddress #{Jobs.ngcatalog2dnx.StorageBaseAddress} -storageType azure -storageAccountName #{Jobs.ngcatalog2dnx.StorageAccount.Name} -storageKeyValue #{Jobs.ngcatalog2dnx.StorageAccount.Key} -storageContainer #{Jobs.ngcatalog2dnx.Container} -verbose true -interval #{Jobs.ngcatalog2dnx.Interval}
+    start /w Ng.exe catalog2dnx -source #{Jobs.ngcatalog2dnx.Catalog.Source} -contentBaseAddress #{Jobs.ngcatalog2dnx.ContentBaseAddress} -storageBaseAddress #{Jobs.ngcatalog2dnx.StorageBaseAddress} -storageType azure -storageAccountName #{Jobs.ngcatalog2dnx.StorageAccount.Name} -storageKeyValue #{Jobs.ngcatalog2dnx.StorageAccount.Key} -storageContainer #{Jobs.ngcatalog2dnx.Container} -elasticsearchendpoint #{Jobs.common.v3.Logging.ElasticsearchEndpoint} -elasticsearchusername #{Jobs.common.v3.Logging.ElasticsearchUsername} -elasticsearchpassword #{Jobs.common.v3.Logging.ElasticsearchPassword} -verbose true -interval #{Jobs.ngcatalog2dnx.Interval}
 	
 	echo "Finished #{Jobs.ngcatalog2dnx.Title}"
 

--- a/src/Ng/Scripts/Catalog2LuceneV3-Reg1-Secondary.cmd
+++ b/src/Ng/Scripts/Catalog2LuceneV3-Reg1-Secondary.cmd
@@ -9,7 +9,7 @@ cd Ng
 
 	title #{Jobs.catalog2lucenev3reg1secondary.Title}
 
-    start /w Ng.exe catalog2lucene -source #{Jobs.catalog2lucenev3reg1secondary.Source} -luceneDirectoryType azure -luceneStorageAccountName #{Jobs.common.v3.Storage.Secondary.Name} -luceneStorageKeyValue #{Jobs.common.v3.Storage.Secondary.Key} -luceneStorageContainer #{Jobs.catalog2lucenev3reg1secondary.LuceneContainer} -registration #{Jobs.catalog2lucenev3reg1secondary.Registration} -verbose true -interval #{Jobs.common.v3.Interval}
+    start /w Ng.exe catalog2lucene -source #{Jobs.catalog2lucenev3reg1secondary.Source} -luceneDirectoryType azure -luceneStorageAccountName #{Jobs.common.v3.Storage.Secondary.Name} -luceneStorageKeyValue #{Jobs.common.v3.Storage.Secondary.Key} -luceneStorageContainer #{Jobs.catalog2lucenev3reg1secondary.LuceneContainer} -registration #{Jobs.catalog2lucenev3reg1secondary.Registration} -elasticsearchendpoint #{Jobs.common.v3.Logging.ElasticsearchEndpoint} -elasticsearchusername #{Jobs.common.v3.Logging.ElasticsearchUsername} -elasticsearchpassword #{Jobs.common.v3.Logging.ElasticsearchPassword} -verbose true -interval #{Jobs.common.v3.Interval}
 
 	echo "Finished #{Jobs.catalog2lucenev3reg1secondary.Title}"
 

--- a/src/Ng/Scripts/Catalog2LuceneV3-Reg1.cmd
+++ b/src/Ng/Scripts/Catalog2LuceneV3-Reg1.cmd
@@ -9,7 +9,7 @@ cd Ng
 
 	title #{Jobs.catalog2lucenev3reg1.Title}
 
-    start /w Ng.exe catalog2lucene -source #{Jobs.common.v3.Source} -luceneDirectoryType azure -luceneStorageAccountName #{Jobs.common.v3.Storage.Primary.Name} -luceneStorageKeyValue #{Jobs.common.v3.Storage.Primary.Key} -luceneStorageContainer #{Jobs.catalog2lucenev3reg1.LuceneContainer} -registration #{Jobs.catalog2lucenev3reg1.Registration} -verbose true -interval #{Jobs.common.v3.Interval}
+    start /w Ng.exe catalog2lucene -source #{Jobs.common.v3.Source} -luceneDirectoryType azure -luceneStorageAccountName #{Jobs.common.v3.Storage.Primary.Name} -luceneStorageKeyValue #{Jobs.common.v3.Storage.Primary.Key} -luceneStorageContainer #{Jobs.catalog2lucenev3reg1.LuceneContainer} -registration #{Jobs.catalog2lucenev3reg1.Registration} -elasticsearchendpoint #{Jobs.common.v3.Logging.ElasticsearchEndpoint} -elasticsearchusername #{Jobs.common.v3.Logging.ElasticsearchUsername} -elasticsearchpassword #{Jobs.common.v3.Logging.ElasticsearchPassword} -verbose true -interval #{Jobs.common.v3.Interval}
 
 	echo "Finished #{Jobs.catalog2lucenev3reg1.Title}"
 

--- a/src/Ng/Scripts/Catalog2LuceneV3.cmd
+++ b/src/Ng/Scripts/Catalog2LuceneV3.cmd
@@ -9,7 +9,7 @@ cd Ng
 
 	title #{Jobs.catalog2lucenev3.Title}
 
-    start /w Ng.exe catalog2lucene -source #{Jobs.common.v3.Source} -luceneDirectoryType azure -luceneStorageAccountName #{Jobs.common.v3.Storage.Primary.Name} -luceneStorageKeyValue #{Jobs.common.v3.Storage.Primary.Key} -luceneStorageContainer #{Jobs.catalog2lucenev3.LuceneContainer} -registration #{Jobs.catalog2lucenev3.Registration} -verbose true -interval #{Jobs.common.v3.Interval}
+    start /w Ng.exe catalog2lucene -source #{Jobs.common.v3.Source} -luceneDirectoryType azure -luceneStorageAccountName #{Jobs.common.v3.Storage.Primary.Name} -luceneStorageKeyValue #{Jobs.common.v3.Storage.Primary.Key} -luceneStorageContainer #{Jobs.catalog2lucenev3.LuceneContainer} -registration #{Jobs.catalog2lucenev3.Registration} -elasticsearchendpoint #{Jobs.common.v3.Logging.ElasticsearchEndpoint} -elasticsearchusername #{Jobs.common.v3.Logging.ElasticsearchUsername} -elasticsearchpassword #{Jobs.common.v3.Logging.ElasticsearchPassword} -verbose true -interval #{Jobs.common.v3.Interval}
 
 	echo "Finished #{Jobs.catalog2lucenev3.Title}"
 

--- a/src/Ng/Scripts/Catalog2RegistrationV3-Reg1-Secondary.cmd
+++ b/src/Ng/Scripts/Catalog2RegistrationV3-Reg1-Secondary.cmd
@@ -9,7 +9,7 @@ cd Ng
 
 	title #{Jobs.catalog2registrationv3reg1secondary.Title}
 
-    start /w Ng.exe catalog2registration -source #{Jobs.catalog2registrationv3reg1secondary.Source} -contentBaseAddress #{Jobs.catalog2registrationv3reg1secondary.ContentBaseAddress} -storageBaseAddress #{Jobs.catalog2registrationv3reg1secondary.StorageBaseAddress} -storageType azure -storageAccountName #{Jobs.common.v3.Storage.Secondary.Name} -storageKeyValue #{Jobs.common.v3.Storage.Secondary.Key} -storageContainer #{Jobs.catalog2registrationv3reg1secondary.StorageContainer} -verbose true -interval #{Jobs.common.v3.Interval}
+    start /w Ng.exe catalog2registration -source #{Jobs.catalog2registrationv3reg1secondary.Source} -contentBaseAddress #{Jobs.catalog2registrationv3reg1secondary.ContentBaseAddress} -storageBaseAddress #{Jobs.catalog2registrationv3reg1secondary.StorageBaseAddress} -storageType azure -storageAccountName #{Jobs.common.v3.Storage.Secondary.Name} -storageKeyValue #{Jobs.common.v3.Storage.Secondary.Key} -storageContainer #{Jobs.catalog2registrationv3reg1secondary.StorageContainer} -elasticsearchendpoint #{Jobs.common.v3.Logging.ElasticsearchEndpoint} -elasticsearchusername #{Jobs.common.v3.Logging.ElasticsearchUsername} -elasticsearchpassword #{Jobs.common.v3.Logging.ElasticsearchPassword} -verbose true -interval #{Jobs.common.v3.Interval}
 
 	echo "Finished #{Jobs.catalog2registrationv3reg1secondary.Title}"
 

--- a/src/Ng/Scripts/Catalog2RegistrationV3-Reg1.cmd
+++ b/src/Ng/Scripts/Catalog2RegistrationV3-Reg1.cmd
@@ -9,7 +9,7 @@ cd Ng
 
 	title #{Jobs.catalog2registrationv3reg1.Title}
 
-    start /w Ng.exe catalog2registration -source #{Jobs.common.v3.Source} -contentBaseAddress #{Jobs.catalog2registrationv3reg1.ContentBaseAddress} -storageBaseAddress #{Jobs.catalog2registrationv3reg1.StorageBaseAddress} -storageType azure -storageAccountName #{Jobs.common.v3.c2r.StorageAccountName} -storageKeyValue #{Jobs.common.v3.c2r.StorageAccountKey} -storageContainer #{Jobs.catalog2registrationv3reg1.StorageContainer} -verbose true -interval #{Jobs.common.v3.Interval}
+    start /w Ng.exe catalog2registration -source #{Jobs.common.v3.Source} -contentBaseAddress #{Jobs.catalog2registrationv3reg1.ContentBaseAddress} -storageBaseAddress #{Jobs.catalog2registrationv3reg1.StorageBaseAddress} -storageType azure -storageAccountName #{Jobs.common.v3.c2r.StorageAccountName} -storageKeyValue #{Jobs.common.v3.c2r.StorageAccountKey} -storageContainer #{Jobs.catalog2registrationv3reg1.StorageContainer} -elasticsearchendpoint #{Jobs.common.v3.Logging.ElasticsearchEndpoint} -elasticsearchusername #{Jobs.common.v3.Logging.ElasticsearchUsername} -elasticsearchpassword #{Jobs.common.v3.Logging.ElasticsearchPassword} -verbose true -interval #{Jobs.common.v3.Interval}
 
 	echo "Finished #{Jobs.catalog2registrationv3reg1.Title}"
 

--- a/src/Ng/Scripts/Catalog2RegistrationV3.cmd
+++ b/src/Ng/Scripts/Catalog2RegistrationV3.cmd
@@ -9,7 +9,7 @@ cd Ng
 
 	title #{Jobs.catalog2registrationv3.Title}
 
-    start /w Ng.exe catalog2registration -source #{Jobs.catalog2registrationv3.Source} -contentBaseAddress #{Jobs.catalog2registrationv3.ContentBaseAddress} -storageBaseAddress #{Jobs.catalog2registrationv3.StorageBaseAddress} -storageType azure -storageAccountName #{Jobs.common.v3.c2r.StorageAccountName} -storageKeyValue #{Jobs.common.v3.c2r.StorageAccountKey} -storageContainer #{Jobs.catalog2registrationv3.StorageContainer} -verbose true -interval #{Jobs.common.v3.Interval}
+    start /w Ng.exe catalog2registration -source #{Jobs.catalog2registrationv3.Source} -contentBaseAddress #{Jobs.catalog2registrationv3.ContentBaseAddress} -storageBaseAddress #{Jobs.catalog2registrationv3.StorageBaseAddress} -storageType azure -storageAccountName #{Jobs.common.v3.c2r.StorageAccountName} -storageKeyValue #{Jobs.common.v3.c2r.StorageAccountKey} -storageContainer #{Jobs.catalog2registrationv3.StorageContainer} -elasticsearchendpoint #{Jobs.common.v3.Logging.ElasticsearchEndpoint} -elasticsearchusername #{Jobs.common.v3.Logging.ElasticsearchUsername} -elasticsearchpassword #{Jobs.common.v3.Logging.ElasticsearchPassword} -verbose true -interval #{Jobs.common.v3.Interval}
 
 	echo "Finished #{Jobs.catalog2registrationv3.Title}"
 

--- a/src/Ng/Scripts/Feed2CatalogV3-Secondary.cmd
+++ b/src/Ng/Scripts/Feed2CatalogV3-Secondary.cmd
@@ -10,7 +10,7 @@ cd Ng
 
 	title #{Jobs.feed2catalogv3secondary.Title}
 
-    start /w .\Ng.exe feed2catalog -gallery #{Jobs.common.v3.f2c.Gallery} -storageBaseAddress #{Jobs.feed2catalogv3secondary.StorageBaseAddress} -storageType azure -storageAccountName #{Jobs.common.v3.Storage.Secondary.Name} -storageKeyValue #{Jobs.common.v3.Storage.Secondary.Key} -storageContainer #{Jobs.feed2catalogv3secondary.StorageContainer} -storageTypeAuditing azure -storageAccountNameAuditing #{Jobs.common.v3.c2r.StorageAccountName} -storageKeyValueAuditing #{Jobs.common.v3.c2r.StorageAccountKey} -storageContainerAuditing auditing -storagePathAuditing package -verbose true -interval #{Jobs.common.v3.Interval}
+    start /w .\Ng.exe feed2catalog -gallery #{Jobs.common.v3.f2c.Gallery} -storageBaseAddress #{Jobs.feed2catalogv3secondary.StorageBaseAddress} -storageType azure -storageAccountName #{Jobs.common.v3.Storage.Secondary.Name} -storageKeyValue #{Jobs.common.v3.Storage.Secondary.Key} -storageContainer #{Jobs.feed2catalogv3secondary.StorageContainer} -storageTypeAuditing azure -storageAccountNameAuditing #{Jobs.common.v3.c2r.StorageAccountName} -storageKeyValueAuditing #{Jobs.common.v3.c2r.StorageAccountKey} -storageContainerAuditing auditing -storagePathAuditing package -elasticsearchendpoint #{Jobs.common.v3.Logging.ElasticsearchEndpoint} -elasticsearchusername #{Jobs.common.v3.Logging.ElasticsearchUsername} -elasticsearchpassword #{Jobs.common.v3.Logging.ElasticsearchPassword} -verbose true -interval #{Jobs.common.v3.Interval}
 
 	echo "Finished #{Jobs.feed2catalogv3secondary.Title}"
 

--- a/src/Ng/Scripts/Feed2CatalogV3.cmd
+++ b/src/Ng/Scripts/Feed2CatalogV3.cmd
@@ -9,7 +9,7 @@ cd Ng
 
 	title #{Jobs.feed2catalogv3.Title}
 
-    start /w .\Ng.exe feed2catalog -gallery #{Jobs.common.v3.f2c.Gallery} -storageBaseAddress #{Jobs.feed2catalogv3.StorageBaseAddress} -storageType azure -storageAccountName #{Jobs.common.v3.c2r.StorageAccountName} -storageKeyValue #{Jobs.common.v3.c2r.StorageAccountKey} -storageContainer #{Jobs.feed2catalogv3.StorageContainer} -storageTypeAuditing azure -storageAccountNameAuditing #{Jobs.common.v3.c2r.StorageAccountName} -storageKeyValueAuditing #{Jobs.common.v3.c2r.StorageAccountKey} -storageContainerAuditing auditing -storagePathAuditing package -verbose true -interval #{Jobs.common.v3.Interval}
+    start /w .\Ng.exe feed2catalog -gallery #{Jobs.common.v3.f2c.Gallery} -storageBaseAddress #{Jobs.feed2catalogv3.StorageBaseAddress} -storageType azure -storageAccountName #{Jobs.common.v3.c2r.StorageAccountName} -storageKeyValue #{Jobs.common.v3.c2r.StorageAccountKey} -storageContainer #{Jobs.feed2catalogv3.StorageContainer} -storageTypeAuditing azure -storageAccountNameAuditing #{Jobs.common.v3.c2r.StorageAccountName} -storageKeyValueAuditing #{Jobs.common.v3.c2r.StorageAccountKey} -storageContainerAuditing auditing -storagePathAuditing package -elasticsearchendpoint #{Jobs.common.v3.Logging.ElasticsearchEndpoint} -elasticsearchusername #{Jobs.common.v3.Logging.ElasticsearchUsername} -elasticsearchpassword #{Jobs.common.v3.Logging.ElasticsearchPassword} -verbose true -interval #{Jobs.common.v3.Interval}
 
 	echo "Finished #{Jobs.feed2catalogv3.Title}"
 

--- a/src/Ng/packages.config
+++ b/src/Ng/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="dotNetRDF" version="1.0.8.3533" targetFramework="net452" />
+  <package id="Elasticsearch.Net" version="1.7.1" targetFramework="net452" />
   <package id="HtmlAgilityPack" version="1.4.9" targetFramework="net452" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net452" />
   <package id="Lucene.Net.Contrib" version="3.0.3" targetFramework="net452" />
@@ -8,11 +9,16 @@
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net452" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net452" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net452" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0-rc1-final" targetFramework="net452" />
+  <package id="Microsoft.Extensions.Logging" version="1.0.0-rc1-final" targetFramework="net452" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="1.0.0-rc1-final" targetFramework="net452" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="NuGet.Core" version="2.8.5" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.4.0-beta-515" targetFramework="net452" />
+  <package id="Serilog" version="1.5.14" targetFramework="net452" />
+  <package id="Serilog.Sinks.Elasticsearch" version="2.0.70" targetFramework="net452" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net452" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net452" />
   <package id="VDS.Common" version="1.5.0" targetFramework="net452" />


### PR DESCRIPTION
The scope of this PR is to wire up the new logging infrastructure with the ng.exe based jobs.
Improving actual logging coverage (e.g. in `Catalog2Registration`, `Catalog2Dnx` and `Catalog2Lucene`) will be done in a separate PR depending on this one.

@joyhui @johnataylor @joelverhagen @maartenba 