### PR TITLE
remove unnessary space/tab in json file

### DIFF
--- a/src/Catalog/Helpers/Utils.cs
+++ b/src/Catalog/Helpers/Utils.cs
@@ -184,7 +184,7 @@ namespace NuGet.Services.Metadata.Catalog
                 JObject framed = JsonLdProcessor.Frame(flattened, frame, new JsonLdOptions());
                 JObject compacted = JsonLdProcessor.Compact(framed, frame["@context"], new JsonLdOptions());
 
-                return compacted.ToString();
+                return compacted.ToString(Newtonsoft.Json.Formatting.None, new Newtonsoft.Json.JsonConverter[0]);
             }
         }
 
@@ -228,7 +228,7 @@ namespace NuGet.Services.Metadata.Catalog
 
             IRdfReader rdfReader = new JsonLdReader();
             IGraph graph = new Graph();
-            rdfReader.Load(graph, new StringReader(flattened.ToString()));
+            rdfReader.Load(graph, new StringReader(flattened.ToString(Newtonsoft.Json.Formatting.None, new Newtonsoft.Json.JsonConverter[0])));
 
             return graph;
         }

--- a/src/Catalog/JsonLdIntegration/JsonLdWriter.cs
+++ b/src/Catalog/JsonLdIntegration/JsonLdWriter.cs
@@ -24,7 +24,7 @@ namespace NuGet.Services.Metadata.Catalog.JsonLDIntegration
         {
             JToken flattened = MakeExpandedForm(g);
 
-            output.Write(flattened.ToString());
+            output.Write(flattened.ToString(Formatting.None, new JsonConverter[0]));
             output.Flush();
         }
 


### PR DESCRIPTION
Remove unnessary space/tab in generated json file: registration. 

Example: 10% size of this file
https://nugetdev0.blob.core.windows.net/v3-registration0/log4net/index.json  19.9k
https://nugetdev0.blob.core.windows.net/v3-registration02022016/log4net/index.json 2.6k

Tried V3 client, and it is working file.