### PR TITLE
Add response output caching to search service

### DIFF
--- a/src/NuGet.Indexing/ConfigurationExtensions.cs
+++ b/src/NuGet.Indexing/ConfigurationExtensions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Indexing
+{
+    public static class ConfigurationExtensions
+    {
+        /// <summary>Tries to get a value from the configuration service.</summary>
+        /// <param name="configuration">The current IConfiguration instance.</param>
+        /// <param name="key">The configuration key to fetch the value for.</param>
+        /// <param name="defaultValue">The value that will be used if the key is not found.</param>
+        /// <returns>The boolean value.</returns>
+        public static bool Get(this IConfiguration configuration, string key, bool defaultValue)
+        {
+            string temp;
+            if (configuration.TryGet(key, out temp))
+            {
+                return string.IsNullOrEmpty(temp)
+                    ? defaultValue
+                    : string.Equals(temp, "true", StringComparison.OrdinalIgnoreCase);
+            }
+
+            return defaultValue;
+        }
+    }
+}

--- a/src/NuGet.Indexing/NuGet.Indexing.csproj
+++ b/src/NuGet.Indexing/NuGet.Indexing.csproj
@@ -178,6 +178,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BitSetCollector.cs" />
+    <Compile Include="ConfigurationExtensions.cs" />
     <Compile Include="DownloadRankings.cs" />
     <Compile Include="Extraction\CatalogNuspecReader.cs" />
     <Compile Include="Extraction\CatalogPackageMetadataExtraction.cs" />

--- a/src/NuGet.Services.BasicSearch/ApplicationInsights.config
+++ b/src/NuGet.Services.BasicSearch/ApplicationInsights.config
@@ -11,8 +11,8 @@
 <Add Type="Microsoft.ApplicationInsights.Extensibility.Web.WebApplicationLifecycleModule, Microsoft.ApplicationInsights.Extensibility.Web"/>
 <Add Type="Microsoft.ApplicationInsights.Extensibility.Web.RequestTracking.TelemetryModules.WebRequestTrackingTelemetryModule, Microsoft.ApplicationInsights.Extensibility.Web"/>
 <Add Type="Microsoft.ApplicationInsights.Extensibility.Web.RequestTracking.TelemetryModules.WebExceptionTrackingTelemetryModule, Microsoft.ApplicationInsights.Extensibility.Web"/>
-<Add Type="Microsoft.ApplicationInsights.Extensibility.Web.RequestTracking.TelemetryModules.WebSessionTrackingTelemetryModule, Microsoft.ApplicationInsights.Extensibility.Web"/>
-<Add Type="Microsoft.ApplicationInsights.Extensibility.Web.RequestTracking.TelemetryModules.WebUserTrackingTelemetryModule, Microsoft.ApplicationInsights.Extensibility.Web"/>
+<!--<Add Type="Microsoft.ApplicationInsights.Extensibility.Web.RequestTracking.TelemetryModules.WebSessionTrackingTelemetryModule, Microsoft.ApplicationInsights.Extensibility.Web"/>
+<Add Type="Microsoft.ApplicationInsights.Extensibility.Web.RequestTracking.TelemetryModules.WebUserTrackingTelemetryModule, Microsoft.ApplicationInsights.Extensibility.Web"/>-->
 </TelemetryModules>
 <ContextInitializers>
 <Add Type="Microsoft.ApplicationInsights.Extensibility.ComponentContextInitializer, Microsoft.ApplicationInsights"/>

--- a/src/NuGet.Services.BasicSearch/Caching/IResponseBodyCache.cs
+++ b/src/NuGet.Services.BasicSearch/Caching/IResponseBodyCache.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Owin;
+
+namespace NuGet.Services.BasicSearch.Caching
+{
+    public interface IResponseBodyCache
+    {
+        /// <summary>
+        /// Total requests to cache (not thread safe, not locked - to avoid blocking request paths)
+        /// </summary>
+        long TotalRequests { get; }
+
+        /// <summary>
+        /// Total cache hits (not thread safe, not locked - to avoid blocking request paths)
+        /// </summary>
+        long Hits { get; }
+
+        /// <summary>
+        /// Cache hit ratio percentage
+        /// </summary>
+        decimal HitRatio { get; }
+        
+        void Add(IOwinRequest request, byte[] content);
+        bool TryGet(IOwinRequest request, out byte[] contentBytes);
+        void Clear();
+    }
+}

--- a/src/NuGet.Services.BasicSearch/Caching/MemoryCacheResponseBodyCache.cs
+++ b/src/NuGet.Services.BasicSearch/Caching/MemoryCacheResponseBodyCache.cs
@@ -1,0 +1,108 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.Caching;
+using Microsoft.Owin;
+
+namespace NuGet.Services.BasicSearch.Caching
+{
+    public class MemoryCacheResponseBodyCache
+        : IResponseBodyCache
+    {
+        private static readonly MemoryCache Cache = new MemoryCache("SearchResponse");
+        private readonly TimeSpan _defaultExpiration;
+
+        public MemoryCacheResponseBodyCache(TimeSpan defaultExpiration)
+        {
+            _defaultExpiration = defaultExpiration;
+        }
+
+        public long TotalRequests { get; private set; }
+        public long Hits { get; private set; }
+
+        public decimal HitRatio
+        {
+            get
+            {
+                return Math.Round(Hits / Math.Max(1, (decimal)TotalRequests), 2);
+            }
+        }
+
+        public void Add(IOwinRequest request, byte[] content)
+        {
+            if (ShouldCache(request))
+            {
+                Cache.Add(GetCacheKey(request), content, DateTimeOffset.UtcNow.Add(_defaultExpiration));
+            }
+        }
+
+        public bool TryGet(IOwinRequest request, out byte[] contentBytes)
+        {
+            TotalRequests++;
+
+            if (Contains(request))
+            {
+                try
+                {
+                    contentBytes = Get(request);
+                    if (contentBytes != null)
+                    {
+                        Hits++;
+                        return true;
+                    }
+                }
+                catch
+                {
+                    // Ignore - we will assume no cache if this happens
+                }
+            }
+
+            contentBytes = null;
+            return false;
+        }
+
+        public void Clear()
+        {
+            Cache.Trim(100);
+
+            TotalRequests = 0;
+            Hits = 0;
+        }
+
+        private bool ShouldCache(IOwinRequest request)
+        {
+            if (request.User.Identity.IsAuthenticated)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private string GetCacheKey(IOwinRequest request)
+        {
+            return string.Format("{0}|{1}|{2}", 
+                request.Uri, 
+                request.User.Identity.IsAuthenticated ? request.User.Identity.Name : "anon", 
+                request.Accept);
+        }
+
+        private bool Contains(IOwinRequest request)
+        {
+            return ShouldCache(request)
+                   && Cache.Contains(GetCacheKey(request));
+        }
+
+        private byte[] Get(IOwinRequest request)
+        {
+            var value = Cache.Get(GetCacheKey(request));
+            if (value != null)
+            {
+                return (byte[])value;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/NuGet.Services.BasicSearch/Caching/NullResponseBodyCache.cs
+++ b/src/NuGet.Services.BasicSearch/Caching/NullResponseBodyCache.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Owin;
+
+namespace NuGet.Services.BasicSearch.Caching
+{
+    public class NullResponseBodyCache
+        : IResponseBodyCache
+    {
+        public long TotalRequests
+        {
+            get { return 0; }
+        }
+
+        public long Hits
+        {
+            get { return 0; }
+        }
+
+        public decimal HitRatio
+        {
+            get { return 0; }
+        }
+
+        public void Add(IOwinRequest request, byte[] content)
+        {
+            // noop
+        }
+        
+        public bool TryGet(IOwinRequest request, out byte[] contentBytes)
+        {
+            contentBytes = null;
+            return false;
+        }
+
+        public void Clear()
+        {
+            // noop
+        }
+    }
+}

--- a/src/NuGet.Services.BasicSearch/LogMessages.Designer.cs
+++ b/src/NuGet.Services.BasicSearch/LogMessages.Designer.cs
@@ -70,6 +70,15 @@ namespace NuGet.Services.BasicSearch {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Response cache cleared. Previous hit ratio: {HitRatio} over {TotalRequests} requests.
+        /// </summary>
+        internal static string ResponseCacheCleared {
+            get {
+                return ResourceManager.GetString("ResponseCacheCleared", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to SearcherManager is not initialized.
         /// </summary>
         internal static string SearcherManagerNotInitialized {

--- a/src/NuGet.Services.BasicSearch/LogMessages.resx
+++ b/src/NuGet.Services.BasicSearch/LogMessages.resx
@@ -138,4 +138,7 @@
   <data name="SearchIndexReopenStarted" xml:space="preserve">
     <value>Beginning to reopen the search index on thread ID {ThreadId}</value>
   </data>
+  <data name="ResponseCacheCleared" xml:space="preserve">
+    <value>Response cache cleared. Previous hit ratio: {HitRatio} over {TotalRequests} requests</value>
+  </data>
 </root>

--- a/src/NuGet.Services.BasicSearch/NuGet.Services.BasicSearch.csproj
+++ b/src/NuGet.Services.BasicSearch/NuGet.Services.BasicSearch.csproj
@@ -183,6 +183,7 @@
     <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net" />
+    <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
       <Private>True</Private>
@@ -201,6 +202,7 @@
     <EmbeddedResource Include="LogMessages.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>LogMessages.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <None Include="Properties\PublishProfiles\nuget-int-0-v3search - FTP.pubxml" />
     <None Include="Properties\PublishProfiles\nuget-int-0-v3search - Web Deploy.pubxml" />
@@ -224,12 +226,15 @@
   <ItemGroup>
     <Compile Include="ConfigurationService.cs" />
     <Compile Include="CorrelationIdMiddleware.cs" />
+    <Compile Include="Caching\IResponseBodyCache.cs" />
     <Compile Include="Logging.cs" />
     <Compile Include="LogMessages.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>LogMessages.resx</DependentUpon>
     </Compile>
+    <Compile Include="Caching\MemoryCacheResponseBodyCache.cs" />
+    <Compile Include="Caching\NullResponseBodyCache.cs" />
     <Compile Include="ResponseHelpers.cs" />
     <Compile Include="ServiceEndpoints.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/NuGet.Services.BasicSearch/ResponseHelpers.cs
+++ b/src/NuGet.Services.BasicSearch/ResponseHelpers.cs
@@ -61,7 +61,10 @@ namespace NuGet.Services.BasicSearch
                 WriteToStream(content, writeContent);
                 content.Position = 0;
 
-                ResponseBodyCache.Add(context.Request, content.ToArray());
+                if (allowResponseCache)
+                {
+                    ResponseBodyCache.Add(context.Request, content.ToArray());
+                }
 
                 content.Position = 0;
             }

--- a/src/NuGet.Services.BasicSearch/ResponseHelpers.cs
+++ b/src/NuGet.Services.BasicSearch/ResponseHelpers.cs
@@ -16,14 +16,9 @@ using FrameworkLogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace NuGet.Services.BasicSearch
 {
-    public static class ResponseHelpers
+    public class ResponseWriter
     {
-        static ResponseHelpers()
-        {
-            ResponseBodyCache = new NullResponseBodyCache();
-        }
-
-        public static void SetResponseBodyCache(IResponseBodyCache responseBodyCache)
+        public ResponseWriter(IResponseBodyCache responseBodyCache)
         {
             if (responseBodyCache == null)
             {
@@ -32,15 +27,15 @@ namespace NuGet.Services.BasicSearch
 
             ResponseBodyCache = responseBodyCache;
         }
+        
+        public IResponseBodyCache ResponseBodyCache { get; private set; }
 
-        public static IResponseBodyCache ResponseBodyCache { get; private set; }
-
-        public static async Task WriteResponseAsync(IOwinContext context, HttpStatusCode statusCode, JToken content)
+        public async Task WriteResponseAsync(IOwinContext context, HttpStatusCode statusCode, JToken content)
         {
             await WriteResponseAsync(context, statusCode, w => context.Response.Write(content.ToString()));
         }
 
-        public static async Task WriteResponseAsync(IOwinContext context, HttpStatusCode statusCode, Action<JsonWriter> writeContent, bool allowResponseCache = true)
+        public async Task WriteResponseAsync(IOwinContext context, HttpStatusCode statusCode, Action<JsonWriter> writeContent, bool allowResponseCache = true)
         {
             bool fromCache = false;
             MemoryStream content;
@@ -99,12 +94,12 @@ namespace NuGet.Services.BasicSearch
             }
         }
 
-        public static async Task WriteResponseAsync(IOwinContext context, ClientException e)
+        public async Task WriteResponseAsync(IOwinContext context, ClientException e)
         {
             await WriteResponseAsync(context, e.StatusCode, e.Content);
         }
 
-        public static async Task WriteResponseAsync(IOwinContext context, Exception e, FrameworkLogger logger)
+        public async Task WriteResponseAsync(IOwinContext context, Exception e, FrameworkLogger logger)
         {
             logger.LogError("Internal server error", e);
 
@@ -115,7 +110,7 @@ namespace NuGet.Services.BasicSearch
             }));
         }
 
-        private static void WriteToStream(Stream destination, Action<JsonWriter> writeContent)
+        private void WriteToStream(Stream destination, Action<JsonWriter> writeContent)
         {
             using (var streamWriter = new StreamWriter(destination, new UTF8Encoding(false), 4096, true))
             using (var jsonWriter = new JsonTextWriter(streamWriter))

--- a/src/NuGet.Services.BasicSearch/ServiceEndpoints.cs
+++ b/src/NuGet.Services.BasicSearch/ServiceEndpoints.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Owin;
@@ -81,7 +82,8 @@ namespace NuGet.Services.BasicSearch
             await ResponseHelpers.WriteResponseAsync(
                 context,
                 HttpStatusCode.OK,
-                jsonWriter => ServiceInfoImpl.Rankings(jsonWriter, searcherManager));
+                jsonWriter => ServiceInfoImpl.Rankings(jsonWriter, searcherManager),
+                allowResponseCache: false);
         }
 
         public static async Task Stats(IOwinContext context, NuGetSearcherManager searcherManager)
@@ -89,7 +91,35 @@ namespace NuGet.Services.BasicSearch
             await ResponseHelpers.WriteResponseAsync(
                 context,
                 HttpStatusCode.OK,
-                jsonWriter => ServiceInfoImpl.Stats(jsonWriter, searcherManager));
+                jsonWriter => ServiceInfoImpl.Stats(jsonWriter, searcherManager),
+                allowResponseCache: false);
+        }
+
+        public static async Task CacheStats(IOwinContext context)
+        {
+            var totalRequests = ResponseHelpers.ResponseBodyCache.TotalRequests;
+            var totalCacheHits = ResponseHelpers.ResponseBodyCache.Hits;
+            var cacheHitRatio = ResponseHelpers.ResponseBodyCache.HitRatio;
+
+            await ResponseHelpers.WriteResponseAsync(
+                context,
+                HttpStatusCode.OK,
+                jsonWriter =>
+                {
+                    jsonWriter.WriteStartObject();
+
+                    jsonWriter.WritePropertyName("totalRequests");
+                    jsonWriter.WriteValue(totalRequests);
+
+                    jsonWriter.WritePropertyName("totalCacheHits");
+                    jsonWriter.WriteValue(totalCacheHits);
+
+                    jsonWriter.WritePropertyName("cacheHitRatio");
+                    jsonWriter.WriteValue(cacheHitRatio);
+
+                    jsonWriter.WriteEndObject();
+                },
+                allowResponseCache: false);
         }
 
         private static bool GetIncludeExplanation(IOwinContext context)

--- a/src/NuGet.Services.BasicSearch/ServiceEndpoints.cs
+++ b/src/NuGet.Services.BasicSearch/ServiceEndpoints.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Owin;
@@ -11,7 +10,7 @@ namespace NuGet.Services.BasicSearch
 {
     public class ServiceEndpoints
     {
-        public static async Task V3SearchAsync(IOwinContext context, NuGetSearcherManager searcherManager)
+        public static async Task V3SearchAsync(IOwinContext context, NuGetSearcherManager searcherManager, ResponseWriter responseWriter)
         {
             var skip = GetSkip(context);
             var take = GetTake(context);
@@ -22,13 +21,13 @@ namespace NuGet.Services.BasicSearch
             var feed = context.Request.Query["feed"];
             var scheme = context.Request.Uri.Scheme;
 
-            await ResponseHelpers.WriteResponseAsync(
+            await responseWriter.WriteResponseAsync(
                 context,
                 HttpStatusCode.OK,
                 jsonWriter => ServiceImpl.Search(jsonWriter, searcherManager, scheme, q, includePrerelease, skip, take, feed, includeExplanation));
         }
 
-        public static async Task AutoCompleteAsync(IOwinContext context, NuGetSearcherManager searcherManager)
+        public static async Task AutoCompleteAsync(IOwinContext context, NuGetSearcherManager searcherManager, ResponseWriter responseWriter)
         {
             var skip = GetSkip(context);
             var take = GetTake(context);
@@ -42,24 +41,24 @@ namespace NuGet.Services.BasicSearch
                 q = string.Empty;
             }
 
-            await ResponseHelpers.WriteResponseAsync(
+            await responseWriter.WriteResponseAsync(
                 context,
                 HttpStatusCode.OK,
                 jsonWriter => ServiceImpl.AutoComplete(jsonWriter, searcherManager, q, id, includePrerelease, skip, take, includeExplanation));
         }
 
-        public static async Task FindAsync(IOwinContext context, NuGetSearcherManager searcherManager)
+        public static async Task FindAsync(IOwinContext context, NuGetSearcherManager searcherManager, ResponseWriter responseWriter)
         {
             var id = context.Request.Query["id"] ?? string.Empty;
             var scheme = context.Request.Uri.Scheme;
 
-            await ResponseHelpers.WriteResponseAsync(
+            await responseWriter.WriteResponseAsync(
                 context,
                 HttpStatusCode.OK,
                 jsonWriter => ServiceImpl.Find(jsonWriter, searcherManager, id, scheme));
         }
 
-        public static async Task V2SearchAsync(IOwinContext context, NuGetSearcherManager searcherManager)
+        public static async Task V2SearchAsync(IOwinContext context, NuGetSearcherManager searcherManager, ResponseWriter responseWriter)
         {
             var skip = GetSkip(context);
             var take = GetTake(context);
@@ -71,37 +70,37 @@ namespace NuGet.Services.BasicSearch
             var sortBy = context.Request.Query["sortBy"] ?? string.Empty;
             var feed = context.Request.Query["feed"];
 
-            await ResponseHelpers.WriteResponseAsync(
+            await responseWriter.WriteResponseAsync(
                 context,
                 HttpStatusCode.OK,
                 jsonWriter => GalleryServiceImpl.Search(jsonWriter, searcherManager, q, countOnly, includePrerelease, sortBy, skip, take, feed, ignoreFilter));
         }
 
-        public static async Task RankingsAsync(IOwinContext context, NuGetSearcherManager searcherManager)
+        public static async Task RankingsAsync(IOwinContext context, NuGetSearcherManager searcherManager, ResponseWriter responseWriter)
         {
-            await ResponseHelpers.WriteResponseAsync(
+            await responseWriter.WriteResponseAsync(
                 context,
                 HttpStatusCode.OK,
                 jsonWriter => ServiceInfoImpl.Rankings(jsonWriter, searcherManager),
                 allowResponseCache: false);
         }
 
-        public static async Task Stats(IOwinContext context, NuGetSearcherManager searcherManager)
+        public static async Task Stats(IOwinContext context, NuGetSearcherManager searcherManager, ResponseWriter responseWriter)
         {
-            await ResponseHelpers.WriteResponseAsync(
+            await responseWriter.WriteResponseAsync(
                 context,
                 HttpStatusCode.OK,
                 jsonWriter => ServiceInfoImpl.Stats(jsonWriter, searcherManager),
                 allowResponseCache: false);
         }
 
-        public static async Task CacheStats(IOwinContext context)
+        public static async Task CacheStats(IOwinContext context, ResponseWriter responseWriter)
         {
-            var totalRequests = ResponseHelpers.ResponseBodyCache.TotalRequests;
-            var totalCacheHits = ResponseHelpers.ResponseBodyCache.Hits;
-            var cacheHitRatio = ResponseHelpers.ResponseBodyCache.HitRatio;
+            var totalRequests = responseWriter.ResponseBodyCache.TotalRequests;
+            var totalCacheHits = responseWriter.ResponseBodyCache.Hits;
+            var cacheHitRatio = responseWriter.ResponseBodyCache.HitRatio;
 
-            await ResponseHelpers.WriteResponseAsync(
+            await responseWriter.WriteResponseAsync(
                 context,
                 HttpStatusCode.OK,
                 jsonWriter =>

--- a/src/NuGet.Services.BasicSearch/Startup.cs
+++ b/src/NuGet.Services.BasicSearch/Startup.cs
@@ -131,11 +131,12 @@ namespace NuGet.Services.BasicSearch
 
                     if (!(ResponseHelpers.ResponseBodyCache is NullResponseBodyCache))
                     {
+                        var hitRatio = ResponseHelpers.ResponseBodyCache.HitRatio;
+                        var totalRequests = ResponseHelpers.ResponseBodyCache.TotalRequests;
+
                         ResponseHelpers.ResponseBodyCache.Clear();
 
-                        _logger.LogInformation(LogMessages.ResponseCacheCleared, 
-                            ResponseHelpers.ResponseBodyCache.HitRatio,
-                            ResponseHelpers.ResponseBodyCache.TotalRequests);
+                        _logger.LogInformation(LogMessages.ResponseCacheCleared, hitRatio, totalRequests);
                     }
                 }
                 finally

--- a/src/NuGet.Services.BasicSearch/Web.Release.config
+++ b/src/NuGet.Services.BasicSearch/Web.Release.config
@@ -11,11 +11,6 @@
       </triggers>
       <actions value="Recycle" />
     </monitoring>
-    <httpProtocol xdt:Transform="Insert">
-      <customHeaders>
-        <add name="Arr-Disable-Session-Affinity" value="true" />
-      </customHeaders>
-    </httpProtocol>
     <httpCompression xdt:Transform="Insert">
       <dynamicTypes>
         <add enabled="true" mimeType="application/json"/>

--- a/src/NuGet.Services.BasicSearch/Web.config
+++ b/src/NuGet.Services.BasicSearch/Web.config
@@ -13,18 +13,21 @@
     <customErrors mode="Off" />
   </system.web>
   <appSettings>
+     <add key="Search.EnableResponseCaching" value="true" />
+    
     <!--
     <add key="Local.Lucene.Directory" value="{path to local Lucene directory}" />
     <add key="Local.Data.Directory" value="{path to local data directory}" />
     -->
+    
     <add key="Storage.Primary" value="" />
     <add key="Search.IndexContainer" value="" />
     <add key="Search.DataContainer" value="" />
-    <add key="Search.IndexRefresh" value="30" />
+    <add key="Search.IndexRefresh" value="300" />
     <add key="Search.RegistrationBaseAddress" value="http://api.nuget.org/v3/registration0/" />
     <add key="owin:AppStartup" value="NuGet.Services.BasicSearch.Startup" />
     <!-- BEGIN Serilog logging configuration -->
-    <add key="serilog:Elasticsearch.nodeUris" value="http://esearchdev.cloudapp.net:9200" />
+    <add key="serilog:Elasticsearch.nodeUris" value="" />
     <add key="serilog:Elasticsearch.username" value="" />
     <add key="serilog:Elasticsearch.password" value="" />
     <!-- END Serilog logging configuration -->
@@ -39,6 +42,16 @@
       <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Extensibility.Web.RequestTracking.WebRequestTrackingModule, Microsoft.ApplicationInsights.Extensibility.Web" preCondition="managedHandler" />
     </modules>
   </system.webServer>
+  <system.runtime.caching>
+    <memoryCache>
+      <namedCaches>
+        <add name="SearchResponse"
+             cacheMemoryLimitMegabytes="100" 
+             physicalMemoryLimitPercentage="10"
+             pollingInterval="00:05:00" />
+      </namedCaches>
+    </memoryCache>
+  </system.runtime.caching>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>


### PR DESCRIPTION
* Memory limit is currently set to 100 MB (with a maximum of 10% of system memory in case there is memory pressure)
* Cache can easily be disabled: set Search.EnableResponseCaching setting to “false” in the portal
* I added the X-Cache: HIT header when a cache was hit – this is the same header the CDN provides us.
* Cache hit ratio can be viewed from /cache/diag. Note that this is intentionally not correct (hits may be missed as I did not add any locking mechanism to the hit counting to never block the request path)

It is quite opinionated for our scenario. Also, not sure if my "ShouldCache()" check is correct (e.g. we may want to exclude caches with cookies or certain header values)

@joyhui @johnataylor @xavierdecoster @skofman1 Please have a look