### PR TITLE
Improve catalog2registration processing performance

### DIFF
--- a/NgTests/RegistrationCollectorTests.cs
+++ b/NgTests/RegistrationCollectorTests.cs
@@ -35,8 +35,7 @@ namespace NgTests
             // Setup collector
             var target = new RegistrationCollector(new Uri("http://tempuri.org/index.json"), catalogToRegistrationStorageFactory, () => mockServer)
             {
-                ContentBaseAddress = new Uri("http://tempuri.org/packages"),
-                UnlistShouldDelete = false
+                ContentBaseAddress = new Uri("http://tempuri.org/packages")
             };
             ReadWriteCursor front = new DurableCursor(catalogToRegistrationStorage.ResolveUri("cursor.json"), catalogToRegistrationStorage, MemoryCursor.MinValue);
             ReadCursor back = MemoryCursor.CreateMax();

--- a/src/Catalog/CatalogWriterBase.cs
+++ b/src/Catalog/CatalogWriterBase.cs
@@ -102,7 +102,7 @@ namespace NuGet.Services.Metadata.Catalog
             var saveTasks = new List<Task>();
             foreach (CatalogItem item in _batch)
             {
-                Uri resourceUri = null;
+                ResourceSaveOperation saveOperationForItem = null;
 
                 try
                 {
@@ -110,32 +110,27 @@ namespace NuGet.Services.Metadata.Catalog
                     item.CommitId = commitId;
                     item.BaseAddress = Storage.BaseAddress;
 
-                    StorageContent content = item.CreateContent(Context);
-
-                    resourceUri = item.GetItemAddress();
-
-                    if (content != null)
+                    saveOperationForItem = CreateSaveOperationForItem(Storage, Context, item, cancellationToken);
+                    if (saveOperationForItem.SaveTask != null)
                     {
-                        saveTasks.Add(
-                            Storage.Save(resourceUri, content, cancellationToken));
-                    }
-                    else
-                    {
-                        Trace.WriteLine(string.Format("Item did not return content or already exists. Skipping resource {0}.", resourceUri), "Debug");
+                        saveTasks.Add(saveOperationForItem.SaveTask);
                     }
 
                     IGraph pageContent = item.CreatePageContent(Context);
 
-                    if (!pageItems.TryAdd(resourceUri.AbsoluteUri, new CatalogItemSummary(item.GetItemType(), commitId, commitTimeStamp, null, pageContent)))
+                    if (!pageItems.TryAdd(saveOperationForItem.ResourceUri.AbsoluteUri, new CatalogItemSummary(item.GetItemType(), commitId, commitTimeStamp, null, pageContent)))
                     {
-                        throw new Exception("Duplicate page: " + resourceUri.AbsoluteUri);
+                        throw new Exception("Duplicate page: " + saveOperationForItem.ResourceUri.AbsoluteUri);
                     }
 
                     batchIndex++;
                 }
                 catch (Exception e)
                 {
-                    string msg = (resourceUri == null) ? string.Format("batch index: {0}", batchIndex) : string.Format("batch index: {0} resourceUri: {1}", batchIndex, resourceUri);
+                    string msg = (saveOperationForItem.ResourceUri == null) 
+                        ? string.Format("batch index: {0}", batchIndex)
+                        : string.Format("batch index: {0} resourceUri: {1}", batchIndex, saveOperationForItem.ResourceUri);
+
                     throw new Exception(msg, e);
                 }
             }
@@ -143,6 +138,25 @@ namespace NuGet.Services.Metadata.Catalog
             await Task.WhenAll(saveTasks);
 
             return pageItems;
+        }
+
+        protected virtual ResourceSaveOperation CreateSaveOperationForItem(IStorage storage, CatalogContext context, CatalogItem item, CancellationToken cancellationToken)
+        {
+            // This method decides what to do with the item.
+            // Standard method of operation: if content == null, don't do a thing. Else, write content.
+
+            var content = item.CreateContent(Context); // note: always do this first
+            var resourceUri = item.GetItemAddress();
+
+            var operation = new ResourceSaveOperation();
+            operation.ResourceUri = resourceUri;
+
+            if (content != null)
+            {
+                operation.SaveTask = storage.Save(resourceUri, content, cancellationToken);
+            }
+
+            return operation;
         }
 
         async Task SaveRoot(Guid commitId, DateTime commitTimeStamp, IDictionary<string, CatalogItemSummary> pageEntries, IGraph commitMetadata, CancellationToken cancellationToken)

--- a/src/Catalog/CatalogWriterBase.cs
+++ b/src/Catalog/CatalogWriterBase.cs
@@ -5,6 +5,7 @@ using NuGet.Services.Metadata.Catalog.Persistence;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -98,8 +99,7 @@ namespace NuGet.Services.Metadata.Catalog
 
             int batchIndex = 0;
 
-            Task[] saveTasks = new Task[_batch.Count];
-
+            var saveTasks = new List<Task>();
             foreach (CatalogItem item in _batch)
             {
                 Uri resourceUri = null;
@@ -116,7 +116,12 @@ namespace NuGet.Services.Metadata.Catalog
 
                     if (content != null)
                     {
-                        saveTasks[batchIndex] = Storage.Save(resourceUri, content, cancellationToken);
+                        saveTasks.Add(
+                            Storage.Save(resourceUri, content, cancellationToken));
+                    }
+                    else
+                    {
+                        Trace.WriteLine(string.Format("Item did not return content or already exists. Skipping resource {0}.", resourceUri), "Debug");
                     }
 
                     IGraph pageContent = item.CreatePageContent(Context);

--- a/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
+++ b/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
@@ -159,6 +159,7 @@
     <Compile Include="RegistrationCatalogItem.cs" />
     <Compile Include="RegistrationCatalogWriter.cs" />
     <Compile Include="ReindexCatalogItem.cs" />
+    <Compile Include="ResourceSaveOperation.cs" />
     <Compile Include="SortingCollector.cs" />
     <Compile Include="SortingGraphCollector.cs" />
     <Compile Include="StorageWriteLock.cs" />

--- a/src/Catalog/Registration/RegistrationCatalogEntry.cs
+++ b/src/Catalog/Registration/RegistrationCatalogEntry.cs
@@ -9,24 +9,27 @@ namespace NuGet.Services.Metadata.Catalog.Registration
 {
     public class RegistrationCatalogEntry
     {
-        public RegistrationCatalogEntry(string resourceUri, IGraph graph)
+        public RegistrationCatalogEntry(string resourceUri, IGraph graph, bool isExistingItem)
         {
             ResourceUri = resourceUri;
             Graph = graph;
+            IsExistingItem = isExistingItem;
         }
+
         public string ResourceUri { get; set; }
         public IGraph Graph { get; set; }
+        public bool IsExistingItem { get; set; }
 
-        public static KeyValuePair<RegistrationEntryKey, RegistrationCatalogEntry> Promote(string resourceUri, IGraph graph, bool unlistShouldDelete = false)
+        public static KeyValuePair<RegistrationEntryKey, RegistrationCatalogEntry> Promote(string resourceUri, IGraph graph, bool isExistingItem)
         {
             INode subject = graph.CreateUriNode(new Uri(resourceUri));
             string version = graph.GetTriplesWithSubjectPredicate(subject, graph.CreateUriNode(Schema.Predicates.Version)).First().Object.ToString();
 
             RegistrationEntryKey registrationEntryKey = new RegistrationEntryKey(RegistrationKey.Promote(resourceUri, graph), version);
 
-            bool deleteByUnlisting = unlistShouldDelete & !IsListed(subject, graph);
-
-            RegistrationCatalogEntry registrationCatalogEntry = deleteByUnlisting | IsDelete(subject, graph) ? null : new RegistrationCatalogEntry(resourceUri, graph);
+            RegistrationCatalogEntry registrationCatalogEntry = IsDelete(subject, graph) 
+                ? null 
+                : new RegistrationCatalogEntry(resourceUri, graph, isExistingItem);
 
             return new KeyValuePair<RegistrationEntryKey, RegistrationCatalogEntry>(registrationEntryKey, registrationCatalogEntry);
         }

--- a/src/Catalog/Registration/RegistrationCollector.cs
+++ b/src/Catalog/Registration/RegistrationCollector.cs
@@ -28,7 +28,6 @@ namespace NuGet.Services.Metadata.Catalog.Registration
         public Uri ContentBaseAddress { get; set; }
         public int PartitionSize { get; set; }
         public int PackageCountThreshold { get; set; }
-        public bool UnlistShouldDelete { get; set; }
 
         protected override Task ProcessGraphs(KeyValuePair<string, IDictionary<string, IGraph>> sortedGraphs, CancellationToken cancellationToken)
         {
@@ -39,7 +38,7 @@ namespace NuGet.Services.Metadata.Catalog.Registration
                 ContentBaseAddress,
                 PartitionSize,
                 PackageCountThreshold,
-                UnlistShouldDelete, cancellationToken);
+                cancellationToken);
         }
     }
 }

--- a/src/Catalog/Registration/RegistrationMaker.cs
+++ b/src/Catalog/Registration/RegistrationMaker.cs
@@ -12,7 +12,7 @@ namespace NuGet.Services.Metadata.Catalog.Registration
 {
     public static class RegistrationMaker
     {
-        public static async Task Process(RegistrationKey registrationKey, IDictionary<string, IGraph> newItems, StorageFactory storageFactory, Uri contentBaseAddress, int partitionSize, int packageCountThreshold, bool unlistShouldDelete, CancellationToken cancellationToken)
+        public static async Task Process(RegistrationKey registrationKey, IDictionary<string, IGraph> newItems, StorageFactory storageFactory, Uri contentBaseAddress, int partitionSize, int packageCountThreshold, CancellationToken cancellationToken)
         {
             Trace.TraceInformation("RegistrationMaker.Process: registrationKey = {0} newItems: {1}", registrationKey, newItems.Count);
 
@@ -22,7 +22,7 @@ namespace NuGet.Services.Metadata.Catalog.Registration
 
             Trace.TraceInformation("RegistrationMaker.Process: existing = {0}", existing.Count);
 
-            IDictionary<RegistrationEntryKey, RegistrationCatalogEntry> delta = PromoteRegistrationKey(newItems, unlistShouldDelete);
+            IDictionary<RegistrationEntryKey, RegistrationCatalogEntry> delta = PromoteRegistrationKey(newItems);
 
             Trace.TraceInformation("RegistrationMaker.Process: delta = {0}", delta.Count);
             
@@ -33,12 +33,12 @@ namespace NuGet.Services.Metadata.Catalog.Registration
             await registration.Save(resulting, cancellationToken);
         }
 
-        static IDictionary<RegistrationEntryKey, RegistrationCatalogEntry> PromoteRegistrationKey(IDictionary<string, IGraph> newItems, bool unlistShouldDelete)
+        static IDictionary<RegistrationEntryKey, RegistrationCatalogEntry> PromoteRegistrationKey(IDictionary<string, IGraph> newItems)
         {
             IDictionary<RegistrationEntryKey, RegistrationCatalogEntry> promoted = new Dictionary<RegistrationEntryKey, RegistrationCatalogEntry>();
             foreach (var newItem in newItems)
             {
-                promoted.Add(RegistrationCatalogEntry.Promote(newItem.Key, newItem.Value, unlistShouldDelete));
+                promoted.Add(RegistrationCatalogEntry.Promote(newItem.Key, newItem.Value, isExistingItem: false));
             }
             return promoted;
         }

--- a/src/Catalog/Registration/RegistrationMakerCatalogItem.cs
+++ b/src/Catalog/Registration/RegistrationMakerCatalogItem.cs
@@ -22,7 +22,6 @@ namespace NuGet.Services.Metadata.Catalog.Registration
         private Uri _registrationAddress;
         private DateTime _publishedDate;
         private bool _listed;
-        private readonly bool _isExistingItem;
 
         public RegistrationMakerCatalogItem(Uri catalogUri, IGraph catalogItem, Uri registrationBaseAddress, bool isExistingItem, Uri packageContentBaseAddress = null)
         {
@@ -30,16 +29,12 @@ namespace NuGet.Services.Metadata.Catalog.Registration
             _catalogItem = catalogItem;
             _packageContentBaseAddress = packageContentBaseAddress;
             _registrationBaseAddress = registrationBaseAddress;
-            _isExistingItem = isExistingItem;
+
+            IsExistingItem = isExistingItem;
         }
 
         public override StorageContent CreateContent(CatalogContext context)
         {
-            if (_isExistingItem)
-            {
-                return null;
-            }
-
             IGraph graph = new Graph();
             INode subject = graph.CreateUriNode(GetItemAddress());
 
@@ -57,6 +52,8 @@ namespace NuGet.Services.Metadata.Catalog.Registration
             JObject frame = context.GetJsonLdContext("context.Package.json", Schema.DataTypes.Package);
             return new JTokenStorageContent(Utils.CreateJson(graph, frame), "application/json", "no-store");
         }
+
+        public bool IsExistingItem { get; private set; }
 
         public override Uri GetItemType()
         {
@@ -109,7 +106,6 @@ namespace NuGet.Services.Metadata.Catalog.Registration
             _listed = (_publishedDate.Year == 1900) ? false : true;
 
             return _publishedDate;
-
         }
 
         Uri GetPackageContentAddress()

--- a/src/Catalog/Registration/RegistrationMakerCatalogItem.cs
+++ b/src/Catalog/Registration/RegistrationMakerCatalogItem.cs
@@ -6,7 +6,6 @@ using NuGet.Services.Metadata.Catalog.Persistence;
 using System;
 using System.Linq;
 using VDS.RDF;
-using VDS.RDF.Writing;
 using VDS.RDF.Query;
 using System.Globalization;
 
@@ -14,30 +13,37 @@ namespace NuGet.Services.Metadata.Catalog.Registration
 {
     public class RegistrationMakerCatalogItem : CatalogItem
     {
-        Uri _catalogUri;
-        IGraph _catalogItem;
-        Uri _itemAddress;
-        Uri _packageContentBaseAddress;
-        Uri _packageContentAddress;
-        Uri _registrationBaseAddress;
-        Uri _registrationAddress;
-        DateTime _publishedDate;
-        Boolean _listed;
+        private readonly Uri _catalogUri;
+        private readonly IGraph _catalogItem;
+        private Uri _itemAddress;
+        private readonly Uri _packageContentBaseAddress;
+        private Uri _packageContentAddress;
+        private readonly Uri _registrationBaseAddress;
+        private Uri _registrationAddress;
+        private DateTime _publishedDate;
+        private bool _listed;
+        private readonly bool _isExistingItem;
 
-        public RegistrationMakerCatalogItem(Uri catalogUri, IGraph catalogItem, Uri registrationBaseAddress, Uri packageContentBaseAddress = null)
+        public RegistrationMakerCatalogItem(Uri catalogUri, IGraph catalogItem, Uri registrationBaseAddress, bool isExistingItem, Uri packageContentBaseAddress = null)
         {
             _catalogUri = catalogUri;
             _catalogItem = catalogItem;
             _packageContentBaseAddress = packageContentBaseAddress;
             _registrationBaseAddress = registrationBaseAddress;
+            _isExistingItem = isExistingItem;
         }
 
         public override StorageContent CreateContent(CatalogContext context)
         {
+            if (_isExistingItem)
+            {
+                return null;
+            }
+
             IGraph graph = new Graph();
             INode subject = graph.CreateUriNode(GetItemAddress());
 
-            INode catalogEntry = graph.CreateUriNode(_catalogUri);
+            graph.CreateUriNode(_catalogUri);
 
             graph.Assert(subject, graph.CreateUriNode(Schema.Predicates.Type), graph.CreateUriNode(Schema.DataTypes.Package));
             graph.Assert(subject, graph.CreateUriNode(Schema.Predicates.Type), graph.CreateUriNode(Schema.DataTypes.Permalink));
@@ -101,6 +107,7 @@ namespace NuGet.Services.Metadata.Catalog.Registration
             }
 
             _listed = (_publishedDate.Year == 1900) ? false : true;
+
             return _publishedDate;
 
         }

--- a/src/Catalog/Registration/RegistrationMakerCatalogWriter.cs
+++ b/src/Catalog/Registration/RegistrationMakerCatalogWriter.cs
@@ -5,6 +5,7 @@ using NuGet.Services.Metadata.Catalog.Persistence;
 using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -75,6 +76,34 @@ namespace NuGet.Services.Metadata.Catalog.Registration
             }
 
             return newPageEntries;
+        }
+
+        protected override ResourceSaveOperation CreateSaveOperationForItem(IStorage storage, CatalogContext context, CatalogItem item, CancellationToken cancellationToken)
+        {
+            // This method decides what to do with the item.
+            // If it's a RegistrationMakerCatalogItem and it already exists, then don't write content.
+            var registrationMakerCatalogItem = item as RegistrationMakerCatalogItem;
+            if (registrationMakerCatalogItem != null)
+            {
+                var content = item.CreateContent(Context); // note: always do this first
+                var resourceUri = item.GetItemAddress();
+
+                var saveOperation = new ResourceSaveOperation();
+                saveOperation.ResourceUri = resourceUri;
+
+                if (!registrationMakerCatalogItem.IsExistingItem && content != null)
+                {
+                    saveOperation.SaveTask = storage.Save(resourceUri, content, cancellationToken);
+                }
+                else
+                {
+                    Trace.WriteLine(string.Format("Resource {0} already exists. Skipping.", resourceUri), "Debug");
+                }
+
+                return saveOperation;
+            }
+
+            return base.CreateSaveOperationForItem(storage, context, item, cancellationToken);
         }
 
         async Task<IDictionary<string, CatalogItemSummary>> PartitionAndSavePages(Guid commitId, DateTime commitTimeStamp, SortedDictionary<NuGetVersion, KeyValuePair<string, CatalogItemSummary>> versions, CancellationToken cancellationToken)

--- a/src/Catalog/ResourceSaveOperation.cs
+++ b/src/Catalog/ResourceSaveOperation.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.Metadata.Catalog
+{
+    public class ResourceSaveOperation
+    {
+        public Uri ResourceUri { get; set; }
+        public Task SaveTask { get; set; }
+    }
+}

--- a/src/Ng/Catalog2Registration.cs
+++ b/src/Ng/Catalog2Registration.cs
@@ -26,8 +26,9 @@ namespace Ng
         {
             CommitCollector collector = new RegistrationCollector(new Uri(source), storageFactory, CommandHelpers.GetHttpMessageHandlerFactory(verbose))
             {
-                ContentBaseAddress = contentBaseAddress == null ? null : new Uri(contentBaseAddress),
-                UnlistShouldDelete = unlistShouldDelete
+                ContentBaseAddress = contentBaseAddress == null 
+                    ? null 
+                    : new Uri(contentBaseAddress)
             };
 
             Storage storage = storageFactory.Create();

--- a/src/Ng/Lightning.cs
+++ b/src/Ng/Lightning.cs
@@ -413,7 +413,7 @@ namespace Ng
 
         private static Task ProcessGraphsAsync(string packageId, IDictionary<string, IGraph> sortedGraphs, StorageFactory storageFactory, string contentBaseAddress)
         {
-            return RegistrationMaker.Process(new RegistrationKey(packageId), sortedGraphs, storageFactory, new Uri(contentBaseAddress), 64, 128, false, CancellationToken.None);
+            return RegistrationMaker.Process(new RegistrationKey(packageId), sortedGraphs, storageFactory, new Uri(contentBaseAddress), 64, 128, CancellationToken.None);
         }
     }
 }

--- a/tests/CatalogTests/RegistrationMakerTests.cs
+++ b/tests/CatalogTests/RegistrationMakerTests.cs
@@ -71,7 +71,7 @@ namespace CatalogTests
             catalog.Add(CreateTestCatalogEntry("mypackage", "4.0.0"));
             catalog.Add(CreateTestCatalogEntry("mypackage", "5.0.0"));
             FileStorageFactory factory = new FileStorageFactory(new Uri("http://tempuri.org"), path);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), catalog, factory, new Uri("http://content/"), 2, 3, false, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), catalog, factory, new Uri("http://content/"), 2, 3, CancellationToken.None);
         }
 
         public static async Task Test1Async()
@@ -87,12 +87,12 @@ namespace CatalogTests
 
             FileStorageFactory factory = new FileStorageFactory(new Uri("http://tempuri.org"), path);
 
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "1.0.0"), factory, new Uri("http://content/"), 2, 3, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "2.0.0"), factory, new Uri("http://content/"), 2, 3, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "3.0.0"), factory, new Uri("http://content/"), 2, 3, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "4.0.0"), factory, new Uri("http://content/"), 2, 3, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "5.0.0"), factory, new Uri("http://content/"), 2, 3, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "6.0.0"), factory, new Uri("http://content/"), 2, 3, false, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "1.0.0"), factory, new Uri("http://content/"), 2, 3, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "2.0.0"), factory, new Uri("http://content/"), 2, 3, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "3.0.0"), factory, new Uri("http://content/"), 2, 3, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "4.0.0"), factory, new Uri("http://content/"), 2, 3, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "5.0.0"), factory, new Uri("http://content/"), 2, 3, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "6.0.0"), factory, new Uri("http://content/"), 2, 3, CancellationToken.None);
         }
 
         public static async Task Test2Async()
@@ -108,12 +108,12 @@ namespace CatalogTests
 
             FileStorageFactory factory = new FileStorageFactory(new Uri("http://tempuri.org"), path);
 
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "1.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "2.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "3.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "4.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "5.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "6.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "1.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "2.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "3.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "4.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "5.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "6.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
         }
 
         public static async Task Test3Async()
@@ -133,14 +133,15 @@ namespace CatalogTests
             catalog.Add(CreateTestCatalogEntry("mypackage", "1.0.0"));
             catalog.Add(CreateTestCatalogEntry("mypackage", "2.0.0"));
             catalog.Add(CreateTestCatalogEntry("mypackage", "3.0.0"));
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), catalog, factory, new Uri("http://content/"), 2, 3, false, CancellationToken.None);
 
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "3.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "4.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "5.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "6.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), catalog, factory, new Uri("http://content/"), 2, 3, CancellationToken.None);
 
-            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryDeleteBatch("mypackage", "4.0.0"), factory, new Uri("http://content/"), 10, 10, false, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "3.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "4.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "5.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryBatch("mypackage", "6.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
+
+            await RegistrationMaker.Process(new RegistrationKey("mypackage"), CreateTestSingleEntryDeleteBatch("mypackage", "4.0.0"), factory, new Uri("http://content/"), 10, 10, CancellationToken.None);
         }
 
         public static async Task Test4Async()
@@ -162,7 +163,6 @@ namespace CatalogTests
 
             CollectorBase collector = new RegistrationCollector(catalogUri, factory)
             {
-                UnlistShouldDelete = true,
                 Concurrent = false
             };
 


### PR DESCRIPTION
Given a package that has 1000 version leafs + an index.json, the current catalog2registration process will read all 1000 version leafs + index.json, and writes them all again as well. Adding a package thus means 2x 1000 + 2x index.json + 1x new package I/O operations.

This PR reduces the I/O to 2x index.json + 1x new package I/O operations:

1. For each registration, only read index.json (and pages on large
registration). Leaf nodes are not read.
2. Only write new registration leaf blobs (don't re-write leafs that
already exist as it's a waste of effort).

Based on https://github.com/NuGet/NuGet.Services.Metadata/pull/47