### PR TITLE
Feed2Catalog - Normalize unicode strings to prevent errors in graph creation

### DIFF
--- a/src/Catalog/CatalogWriterBase.cs
+++ b/src/Catalog/CatalogWriterBase.cs
@@ -129,7 +129,7 @@ namespace NuGet.Services.Metadata.Catalog
                 }
                 catch (Exception e)
                 {
-                    string msg = (saveOperationForItem.ResourceUri == null) 
+                    string msg = (saveOperationForItem == null || saveOperationForItem.ResourceUri == null) 
                         ? string.Format("batch index: {0}", batchIndex)
                         : string.Format("batch index: {0} resourceUri: {1}", batchIndex, saveOperationForItem.ResourceUri);
 


### PR DESCRIPTION
We had a live site issue caused by uploading this package: https://dev.nugettest.org/packages/Z%CC%88%CC%8D%CC%90%CC%83%CC%8A%CD%8B%CC%81%CC%A1%CC%9C%CD%8DA%CC%BD%CD%A7%CD%97%CC%9C%CC%A3%CD%8D%CC%AC%CC%9E%CC%9D%CD%89L%CC%83%CC%8C%CD%A4%CC%B8%CC%96%CD%95%CC%A4%CC%A0%CC%B9%CC%98%CD%96G%CC%80%CD%AA%CD%93%CC%9D%CD%93%CC%B0O%CD%8C%CD%88/1.0.0

Feed2Catalog was failing with this error:
An Attribute with an incorrectly encoded URIRef was encountered, URIRef's must be encoded in Unicode Normal Form C
[Source XML]
rdf:about="https://api.nuget.org/v3/catalog0/data/2016.08.08.20.46.32/z̡̜͍̈̍̐̃̊͋́a̜̣͍̬̞̝͉̽ͧ͗l̸̖͕̤̠̹̘͖̃̌ͤg͓̝͓̰̀ͪo͈͌.1.0.0.json"

@maartenba @xavierdecoster @yishaigalatzer @qianjun22 