### PR TITLE
Parse autocomplete queries like regaular searches

### DIFF
--- a/src/NuGet.Indexing/NuGetQuery.cs
+++ b/src/NuGet.Indexing/NuGetQuery.cs
@@ -31,6 +31,16 @@ namespace NuGet.Indexing
             return ConstructQuery(grouping, owners);
         }
 
+        public static Query MakeAutoCompleteQuery(string q)
+        {
+            if (string.IsNullOrEmpty(q))
+            {
+                return new MatchAllDocsQuery();
+            }
+
+            return ExecuteAnalyzer(new PackageAnalyzer(), "IdAutocomplete", q);
+        }
+
         // Lucene Query creation logic
 
         private static Query ConstructQuery(Dictionary<QueryField, HashSet<string>> clauses, OwnersResult owners)
@@ -218,7 +228,7 @@ namespace NuGet.Indexing
             AuthorClause(query, analyzer, values, Occur.SHOULD);
         }
 
-        static Query ExecuteAnalyzer(Analyzer analyzer, string field, string text)
+        private static Query ExecuteAnalyzer(Analyzer analyzer, string field, string text)
         {
             TokenStream tokenStream = analyzer.TokenStream(field, new StringReader(text));
 

--- a/src/NuGet.Indexing/ServiceImpl.cs
+++ b/src/NuGet.Indexing/ServiceImpl.cs
@@ -130,17 +130,9 @@ namespace NuGet.Indexing
             RankingResult rankings,
             QueryBoostingContext context)
         {
-            if (string.IsNullOrEmpty(q))
-            {
-                return new MatchAllDocsQuery();
-            }
+            var query = NuGetQuery.MakeAutoCompleteQuery(q);
 
-            var queryParser = new QueryParser(Lucene.Net.Util.Version.LUCENE_30,
-                "IdAutocomplete",
-                new PackageAnalyzer());
-
-            Query query = queryParser.Parse(q);
-            Query boostedQuery = new DownloadsBoostedQuery(query,
+            var boostedQuery = new DownloadsBoostedQuery(query,
                 docIdMapping,
                 downloads,
                 rankings,


### PR DESCRIPTION
Changed the way autocomplete queries are parsed, to avoid throwing 500 on illegal Lucene syntax.
Queries that contain special lucene characters would fail: https://lucene.apache.org/core/3_0_3/queryparsersyntax.html

Examples of such queries here: https://github.com/NuGet/NuGetGallery/issues/3330

@xavierdecoster @joelverhagen 