### PR TITLE
Middleware for additional headers

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights.JavaScript" version="0.11.0-build09387" />
-  <package id="Microsoft.CodeAnalysis.BinSkim" version="1.3.4-beta" />
+  <package id="Microsoft.CodeAnalysis.BinSkim" version="1.3.6" />
   <package id="xunit.runner.console" version="2.1.0" />
 </packages>

--- a/src/Catalog/xslt/nuspec.xslt
+++ b/src/Catalog/xslt/nuspec.xslt
@@ -11,6 +11,12 @@
   <xsl:param name="base" />
   <xsl:param name="extension" />
 
+  <xsl:template match="*">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
   <xsl:template match="/nuget:package/nuget:metadata">
     
     <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">

--- a/src/NuGet.Services.BasicSearch/Startup.cs
+++ b/src/NuGet.Services.BasicSearch/Startup.cs
@@ -71,6 +71,13 @@ namespace NuGet.Services.BasicSearch
             // Add Application Insights
             app.Use(typeof(RequestTrackingMiddleware));
 
+            // Enable HSTS
+            app.Use(async (context, next) =>
+            {
+                context.Response.Headers.Add("Strict-Transport-Security", new string[] { "max-age=31536000; includeSubDomains" });
+                await next.Invoke();
+            });
+
             // Enable CORS
             var corsPolicy = new CorsPolicy
             {


### PR DESCRIPTION
Adding a middleware to add a place to attach headers to responses.

This is to enable HSTS (https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security).

@skofman1 @shishirx34 @xavierdecoster 