### PR TITLE
Middleware for additional Headers

### DIFF
--- a/src/NuGet.Services.BasicSearch/Startup.cs
+++ b/src/NuGet.Services.BasicSearch/Startup.cs
@@ -71,6 +71,13 @@ namespace NuGet.Services.BasicSearch
             // Add Application Insights
             app.Use(typeof(RequestTrackingMiddleware));
 
+            // Enable HSTS
+            app.Use(async (context, next) =>
+            {
+                context.Response.Headers.Add("Strict-Transport-Security", new string[] { "max-age=31536000; includeSubDomains" });
+                await next.Invoke();
+            });
+
             // Enable CORS
             var corsPolicy = new CorsPolicy
             {


### PR DESCRIPTION
Adding a middleware to add a place to attach headers to responses.

This is to enable HSTS (https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security).

@skofman1 @shishirx34 @xavierdecoster