### PR TITLE
Fix Intermittent 500's on Autocomplete

### DIFF
--- a/src/NuGet.Indexing/DownloadsByVersion.cs
+++ b/src/NuGet.Indexing/DownloadsByVersion.cs
@@ -9,10 +9,10 @@ namespace NuGet.Indexing
 {
     public class DownloadsByVersion
     {
-        private IDictionary<string, int> _downloadsByVersion =
+        private readonly IDictionary<string, int> _downloadsByVersion =
             new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
-        private int? total;
+        private int _total = 0;
 
         /// <summary>
         /// The total count of downloads across all versionss
@@ -24,14 +24,7 @@ namespace NuGet.Indexing
         {
             get
             {
-                if (total.HasValue)
-                {
-                    return total.Value;
-                }
-
-                total = _downloadsByVersion.Values.Sum();
-
-                return total.Value;
+                return _total;
             }
         }
 
@@ -48,8 +41,13 @@ namespace NuGet.Indexing
 
             set
             {
+                if (_downloadsByVersion.ContainsKey(version))
+                {
+                    _total = _total - _downloadsByVersion[version];
+                }
+
                 _downloadsByVersion[version] = value;
-                total = null;
+                _total = _total + value;
             }
         }
     }

--- a/src/NuGet.Indexing/DownloadsByVersion.cs
+++ b/src/NuGet.Indexing/DownloadsByVersion.cs
@@ -15,7 +15,7 @@ namespace NuGet.Indexing
         private int _total;
 
         /// <summary>
-        /// The total count of downloads across all versionss
+        /// The total count of downloads across all versions
         /// </summary>
         /// <remarks>
         /// This is thread safe as long as set is not being called from multiple threads
@@ -39,6 +39,7 @@ namespace NuGet.Indexing
                 return count;
             }
 
+            // Set is only ever called when the auxiliary data is reloaded, which is only ever done on one thread per instance.
             set
             {
                 int oldValue;

--- a/src/NuGet.Indexing/DownloadsByVersion.cs
+++ b/src/NuGet.Indexing/DownloadsByVersion.cs
@@ -12,7 +12,7 @@ namespace NuGet.Indexing
         private readonly IDictionary<string, int> _downloadsByVersion =
             new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
-        private int _total = 0;
+        private int _total;
 
         /// <summary>
         /// The total count of downloads across all versionss
@@ -41,13 +41,11 @@ namespace NuGet.Indexing
 
             set
             {
-                if (_downloadsByVersion.ContainsKey(version))
-                {
-                    _total = _total - _downloadsByVersion[version];
-                }
-
+                int oldValue;
+                _downloadsByVersion.TryGetValue(version, out oldValue);
                 _downloadsByVersion[version] = value;
-                _total = _total + value;
+
+                _total = _total + value - oldValue;
             }
         }
     }

--- a/src/NuGet.Services.BasicSearch/ResponseHelpers.cs
+++ b/src/NuGet.Services.BasicSearch/ResponseHelpers.cs
@@ -58,7 +58,7 @@ namespace NuGet.Services.BasicSearch
 
         public async Task WriteResponseAsync(IOwinContext context, Exception e, FrameworkLogger logger)
         {
-            logger.LogError("Internal server error", e);
+            logger.LogError("Internal server error: {0}", e);
 
             await WriteResponseAsync(context, HttpStatusCode.InternalServerError, JObject.FromObject(new
             {

--- a/tests/NuGet.IndexingTests/DownloadsByVersionTests.cs
+++ b/tests/NuGet.IndexingTests/DownloadsByVersionTests.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Indexing;
+using Xunit;
+
+namespace NuGet.IndexingTests
+{
+    public class DownloadsByVersionTests
+    {
+        [Theory]
+        [MemberData(nameof(RollingTotalTestData))]
+        public void RollingTotalCountTest(Dictionary<string, int> versionDownloads, int expectedTotal)
+        {
+            var newDownloadsByVersion = new DownloadsByVersion();
+            var rollingTotal = 0;
+            foreach (var version in versionDownloads)
+            {
+                newDownloadsByVersion[version.Key] = version.Value;
+                rollingTotal += version.Value;
+                Assert.Equal(rollingTotal, newDownloadsByVersion.Total);
+                Assert.Equal(newDownloadsByVersion[version.Key], version.Value);
+            }
+
+            Assert.Equal(expectedTotal, newDownloadsByVersion.Total);
+        }
+
+        [Theory]
+        [MemberData(nameof(UpdateTotalTestData))]
+        public void UpdateTotalTest(Dictionary<string, int> originalData, Dictionary<string, int> updatedVersionDownloads, int expectedTotal)
+        {
+            var newDownloadsByVersion = new DownloadsByVersion();
+            foreach (var entry in originalData)
+            {
+                newDownloadsByVersion[entry.Key] = entry.Value;
+            }
+
+            foreach (var version in updatedVersionDownloads)
+            {
+                newDownloadsByVersion[version.Key] = version.Value;
+            }
+
+            Assert.Equal(expectedTotal, newDownloadsByVersion.Total);
+        }
+
+        [Fact]
+        public void ReturnZeroForUnknownTest()
+        {
+            var newDownloadsByVersion = new DownloadsByVersion();
+            Assert.Equal(0, newDownloadsByVersion["not.real.version"]);
+        }
+
+        public static IEnumerable<object[]> RollingTotalTestData
+        {
+            get
+            {
+                // simple
+                yield return new object[]
+                {
+                    new Dictionary<string, int> {
+                        { "1.0.0", 10 },
+                        { "1.0.1", 10 },
+                        { "2.0.0", 20 }
+                    },
+                    40
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> UpdateTotalTestData
+        {
+            get
+            {
+                // simple overwrite
+                yield return new object[]
+                {
+                    new Dictionary<string, int> {
+                        { "1.0.0", 10 },
+                        { "1.0.1", 10 },
+                        { "2.0.0", 20 }
+                    },
+                    new Dictionary<string, int> {
+                        { "2.0.0", 30 }
+                    },
+                    50
+                };
+
+                // overwrite + new
+                yield return new object[]
+                {
+                    new Dictionary<string, int> {
+                        { "1.0.0", 10 },
+                        { "1.0.1", 10 },
+                        { "2.0.0", 20 }
+                    },
+                    new Dictionary<string, int> {
+                        { "2.0.0", 30 },
+                        { "3.0.0", 100 }
+                    },
+                    150
+                };
+
+                // overwrite all
+                yield return new object[]
+                {
+                    new Dictionary<string, int> {
+                        { "1.0.0", 10 },
+                        { "1.0.1", 10 },
+                        { "2.0.0", 20 }
+                    },
+                    new Dictionary<string, int> {
+                        { "1.0.0", 100 },
+                        { "1.0.1", 100 },
+                        { "2.0.0", 100 }
+                    },
+                    300
+                };
+            }
+        }
+    }
+}

--- a/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
+++ b/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
@@ -177,6 +177,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CamelCaseFilterTests.cs" />
+    <Compile Include="DownloadsByVersionTests.cs" />
     <Compile Include="DownloadsScoreProviderTests.cs" />
     <Compile Include="ExpandAcronymsFilterTests.cs" />
     <Compile Include="Extraction\CatalogPackageMetadataExtractorTests.cs" />


### PR DESCRIPTION
We believe this issue was caused by a race condition in DownloadsByVersion.

Request thread would come in and attempt to refer to Total, which would start the computation of the sum. While this was happening, the auxiliary data would reload on another thread and start writing the dictionary.
Request thread would then fail because the underlying enumerable was mutated. "Collection was modified; enumeration operation may not execute."

Change DownloadsByVersion to keep a rolling total and not compute on reference to Total.

Also includes a minor fix to message logged to AI to actually include the exception.

@joelverhagen @skofman1 @shishirx34 