### PR TITLE
Add SemVer2 support to Lucene Jobs

### DIFF
--- a/src/NuGet.Indexing/Extraction/CatalogPackageMetadataExtraction.cs
+++ b/src/NuGet.Indexing/Extraction/CatalogPackageMetadataExtraction.cs
@@ -33,32 +33,32 @@ namespace NuGet.Indexing
                 _reader = new CatalogPackageReader(_catalog);
                 _metadata = new Dictionary<string, string>();
 
-                AddString("id");
-                AddString("version");
-                AddString("verbatimVersion", "originalVersion");
-                AddString("title");
-                AddString("description");
-                AddString("summary");
-                AddString("authors");
-                AddStringArray("tags");
+                AddString(MetadataConstants.IdPropertyName);
+                AddString(MetadataConstants.NormalizedVersionPropertyName);
+                AddString(MetadataConstants.VersionPropertyName);
+                AddString(MetadataConstants.TitlePropertyName);
+                AddString(MetadataConstants.DescriptionPropertyName);
+                AddString(MetadataConstants.SummaryPropertyName);
+                AddString(MetadataConstants.AuthorsPropertyName);
+                AddStringArray(MetadataConstants.TagsPropertyName);
 
                 AddListed();
                 AddSemVerLevelKey();
-                AddString("created");
-                AddString("published");
-                AddString("lastEdited");
+                AddString(MetadataConstants.CreatedPropertyName);
+                AddString(MetadataConstants.PublishedPropertyName);
+                AddString(MetadataConstants.LastEditedPropertyName);
 
-                AddString("iconUrl");
-                AddString("projectUrl");
-                AddString("minClientVersion");
-                AddString("releaseNotes");
-                AddString("copyright");
-                AddString("language");
-                AddString("licenseUrl");
-                AddString("packageHash");
-                AddString("packageHashAlgorithm");
-                AddString("packageSize");
-                AddString("requireLicenseAcceptance");
+                AddString(MetadataConstants.IconUrlPropertyName);
+                AddString(MetadataConstants.ProjectUrlPropertyName);
+                AddString(MetadataConstants.MinClientVersionPropertyName);
+                AddString(MetadataConstants.ReleaseNotesPropertyName);
+                AddString(MetadataConstants.CopyrightPropertyName);
+                AddString(MetadataConstants.LanguagePropertyName);
+                AddString(MetadataConstants.LicenseUrlPropertyName);
+                AddString(MetadataConstants.PackageHashPropertyName);
+                AddString(MetadataConstants.PackageHashAlgorithmPropertyName);
+                AddString(MetadataConstants.PackageSizePropertyName);
+                AddString(MetadataConstants.CatalogMetadata.RequiresLicenseAcceptancePropertyName, MetadataConstants.RequiresLicenseAcceptancePropertyName);
 
                 AddFlattenedDependencies();
                 AddSupportedFrameworks();
@@ -108,8 +108,8 @@ namespace NuGet.Indexing
 
             private void AddListed()
             {
-                var listed = (string)_catalog["listed"];
-                var published = _catalog["published"];
+                var listed = (string)_catalog[MetadataConstants.ListedPropertyName];
+                var published = _catalog[MetadataConstants.PublishedPropertyName];
                 if (listed == null)
                 {
                     if (published != null && ((DateTime)published).ToString("yyyyMMdd") == "19000101")
@@ -122,12 +122,12 @@ namespace NuGet.Indexing
                     }
                 }
 
-                _metadata["listed"] = listed;
+                _metadata[MetadataConstants.ListedPropertyName] = listed;
             }
 
             private void AddSemVerLevelKey()
             {
-                var version = (string)_catalog["verbatimVersion"];
+                var version = (string)_catalog[MetadataConstants.VersionPropertyName];
                 if (version != null)
                 {
                     NuGetVersion packageOriginalVersion;
@@ -135,7 +135,7 @@ namespace NuGet.Indexing
                     {
                         if (packageOriginalVersion.IsSemVer2)
                         {
-                            _metadata["semVerLevelKey"] = "2";
+                            _metadata[MetadataConstants.SemVerLevelKeyPropertyName] = MetadataConstants.SemVerLevel2Value;
                             return;
                         }
                     }
@@ -146,14 +146,13 @@ namespace NuGet.Indexing
                 {
                     if (dependencyGroup.Packages.Any())
                     {
-                        // Add packages list
                         foreach (var packageDependency in dependencyGroup.Packages)
                         {
                             var versionRange = packageDependency.VersionRange;
                             if ((versionRange.MaxVersion != null && versionRange.MaxVersion.IsSemVer2)
                                 || (versionRange.MinVersion != null && versionRange.MinVersion.IsSemVer2))
                             {
-                                _metadata["semVerLevelKey"] = "2";
+                                _metadata[MetadataConstants.SemVerLevelKeyPropertyName] = MetadataConstants.SemVerLevel2Value;
                                 return;
                             }
                         }
@@ -191,7 +190,7 @@ namespace NuGet.Indexing
                 
                 if (builder.Length > 0)
                 {
-                    _metadata["flattenedDependencies"] = builder.ToString();
+                    _metadata[MetadataConstants.FlattenedDependenciesPropertyName] = builder.ToString();
                 }
             }
 
@@ -278,7 +277,7 @@ namespace NuGet.Indexing
                 
                 if (supportedFrameworks.Any())
                 {
-                    _metadata["supportedFrameworks"] = string.Join("|", supportedFrameworks);
+                    _metadata[MetadataConstants.SupportedFrameworksPropertyName] = string.Join("|", supportedFrameworks);
                 }
             }
 

--- a/src/NuGet.Indexing/Extraction/CatalogPackageMetadataExtraction.cs
+++ b/src/NuGet.Indexing/Extraction/CatalogPackageMetadataExtraction.cs
@@ -144,17 +144,14 @@ namespace NuGet.Indexing
                 var dependencyGroups = _reader.GetPackageDependencies().ToList();
                 foreach (var dependencyGroup in dependencyGroups)
                 {
-                    if (dependencyGroup.Packages.Any())
+                    foreach (var packageDependency in dependencyGroup.Packages)
                     {
-                        foreach (var packageDependency in dependencyGroup.Packages)
+                        var versionRange = packageDependency.VersionRange;
+                        if ((versionRange.MaxVersion != null && versionRange.MaxVersion.IsSemVer2)
+                            || (versionRange.MinVersion != null && versionRange.MinVersion.IsSemVer2))
                         {
-                            var versionRange = packageDependency.VersionRange;
-                            if ((versionRange.MaxVersion != null && versionRange.MaxVersion.IsSemVer2)
-                                || (versionRange.MinVersion != null && versionRange.MinVersion.IsSemVer2))
-                            {
-                                _metadata[MetadataConstants.SemVerLevelKeyPropertyName] = MetadataConstants.SemVerLevel2Value;
-                                return;
-                            }
+                            _metadata[MetadataConstants.SemVerLevelKeyPropertyName] = MetadataConstants.SemVerLevel2Value;
+                            return;
                         }
                     }
                 }
@@ -187,7 +184,7 @@ namespace NuGet.Indexing
                         AddFlattenedFrameworkDependency(dependencyGroup, builder);
                     }
                 }
-                
+
                 if (builder.Length > 0)
                 {
                     _metadata[MetadataConstants.FlattenedDependenciesPropertyName] = builder.ToString();
@@ -195,7 +192,7 @@ namespace NuGet.Indexing
             }
 
             private void AddFlattennedPackageDependency(
-                PackageDependencyGroup dependencyGroup, 
+                PackageDependencyGroup dependencyGroup,
                 Packaging.Core.PackageDependency packageDependency,
                 StringBuilder builder)
             {
@@ -255,7 +252,7 @@ namespace NuGet.Indexing
                     Trace.TraceError("CatalogPackageMetadataExtraction.AddSupportedFrameworks exception: " + ex.Message);
                     return;
                 }
-                
+
                 // Filter out special frameworks + get short framework names
                 var supportedFrameworks = supportedFrameworksFromReader
                     .Except(SpecialFrameworks)
@@ -274,7 +271,7 @@ namespace NuGet.Indexing
                     })
                     .Where(f => !String.IsNullOrEmpty(f))
                     .ToArray();
-                
+
                 if (supportedFrameworks.Any())
                 {
                     _metadata[MetadataConstants.SupportedFrameworksPropertyName] = string.Join("|", supportedFrameworks);

--- a/src/NuGet.Indexing/Extraction/DocumentCreator.cs
+++ b/src/NuGet.Indexing/Extraction/DocumentCreator.cs
@@ -47,7 +47,7 @@ namespace NuGet.Indexing
             AddField(document, "Authors", package, "authors", Field.Index.ANALYZED);
 
             // add fields used by filtering and sorting
-            AddSemVerLevel(document, package, errors);
+            AddField(document, "SemVerLevel", package, "semVerLevelKey", Field.Index.ANALYZED);
             AddListed(document, package, errors);
             AddDates(document, package, errors);
             AddSortableTitle(document, package);
@@ -142,63 +142,6 @@ namespace NuGet.Indexing
             }
 
             AddField(document, "Title", value ?? string.Empty, Field.Index.ANALYZED);
-        }
-
-        private static void AddSemVerLevel(Document document, IDictionary<string, string> package, List<string> errors)
-        {
-            string semVerLevel = "1";
-            string semVerLevelKeyValue;
-            if (package.TryGetValue("SemVerLevelKey", out semVerLevelKeyValue))
-            {
-                int semVerLevelKey;
-                if (int.TryParse(semVerLevelKeyValue, out semVerLevelKey))
-                {
-                    semVerLevel = semVerLevelKey >= 2 ? "2" : "1";
-                }
-            }
-
-            AddField(document, "SemVerLevel", semVerLevel, Field.Index.ANALYZED);
-
-            //string semVerLevel = "1.0.0";
-            //string packageVersionString;
-            //if(package.TryGetValue("version", out packageVersionString))
-            //{
-            //    NuGetVersion packageVersion;
-            //    if (NuGetVersion.TryParse(packageVersionString, out packageVersion))
-            //    {
-            //        if(packageVersion.IsSemVer2)
-            //        {
-            //            semVerLevel = "2.0.0";
-            //        }
-            //        else
-            //        {
-            //            string flattenedDependencies;
-            //            if (package.TryGetValue("flattenedDependencies", out flattenedDependencies))
-            //            {
-            //                foreach (var dependency in flattenedDependencies.Split('|'))
-            //                {
-            //                    string[] fields = dependency.Split(':');
-            //                    if (fields.Length > 1)
-            //                    {
-            //                        VersionRange dependencyRange;
-            //                        if(VersionRange.TryParse(fields[1], out dependencyRange))
-            //                        {
-            //                            if((dependencyRange.MaxVersion != null && dependencyRange.MaxVersion.IsSemVer2)
-            //                                || (dependencyRange.MinVersion != null && dependencyRange.MinVersion.IsSemVer2))
-            //                            {
-            //                                semVerLevel = "2.0.0";
-            //                            }
-            //                        }
-            //                    }
-            //                }
-            //            }
-            //        }
-            //    }
-            //}
-            //else
-            //{
-            //    errors.Add("Required property 'version' not found while trying to determine SemVerLevel. Falling back to 1.0.0.");
-            //}
         }
 
         private static void AddListed(Document document, IDictionary<string, string> package, List<string> errors)

--- a/src/NuGet.Indexing/Extraction/DocumentCreator.cs
+++ b/src/NuGet.Indexing/Extraction/DocumentCreator.cs
@@ -9,6 +9,7 @@ using Lucene.Net.Documents;
 using Lucene.Net.Index;
 using Newtonsoft.Json;
 using NuGet.Versioning;
+using LuceneConstants = NuGet.Indexing.MetadataConstants.LuceneMetadata;
 
 namespace NuGet.Indexing
 {
@@ -41,27 +42,27 @@ namespace NuGet.Indexing
             AddId(document, package, errors);
             AddVersion(document, package, errors);
             AddTitle(document, package);
-            AddField(document, "Description", package, "description", Field.Index.ANALYZED);
-            AddField(document, "Summary", package, "summary", Field.Index.ANALYZED);
-            AddField(document, "Tags", package, "tags", Field.Index.ANALYZED, 2.0f);
-            AddField(document, "Authors", package, "authors", Field.Index.ANALYZED);
+            AddField(document, LuceneConstants.DescriptionPropertyName, package, MetadataConstants.DescriptionPropertyName, Field.Index.ANALYZED);
+            AddField(document, LuceneConstants.SummaryPropertyName, package, MetadataConstants.SummaryPropertyName, Field.Index.ANALYZED);
+            AddField(document, LuceneConstants.TagsPropertyName, package, MetadataConstants.TagsPropertyName, Field.Index.ANALYZED, 2.0f);
+            AddField(document, LuceneConstants.AuthorsPropertyName, package, MetadataConstants.AuthorsPropertyName, Field.Index.ANALYZED);
 
             // add fields used by filtering and sorting
-            AddField(document, "SemVerLevel", package, "semVerLevelKey", Field.Index.ANALYZED);
+            AddField(document, LuceneConstants.SemVerLevelPropertyName, package, MetadataConstants.SemVerLevelKeyPropertyName, Field.Index.ANALYZED);
             AddListed(document, package, errors);
             AddDates(document, package, errors);
             AddSortableTitle(document, package);
 
             // add fields used when materializing the result
-            AddField(document, "IconUrl", package, "iconUrl", Field.Index.NOT_ANALYZED);
-            AddField(document, "ProjectUrl", package, "projectUrl", Field.Index.NOT_ANALYZED);
-            AddField(document, "MinClientVersion", package, "minClientVersion", Field.Index.NOT_ANALYZED);
-            AddField(document, "ReleaseNotes", package, "releaseNotes", Field.Index.NOT_ANALYZED);
-            AddField(document, "Copyright", package, "copyright", Field.Index.NOT_ANALYZED);
-            AddField(document, "Language", package, "language", Field.Index.NOT_ANALYZED);
-            AddField(document, "LicenseUrl", package, "licenseUrl", Field.Index.NOT_ANALYZED);
-            AddField(document, "PackageHash", package, "packageHash", Field.Index.NOT_ANALYZED);
-            AddField(document, "PackageHashAlgorithm", package, "packageHashAlgorithm", Field.Index.NOT_ANALYZED);
+            AddField(document, LuceneConstants.IconUrlPropertyName, package, MetadataConstants.IconUrlPropertyName, Field.Index.NOT_ANALYZED);
+            AddField(document, LuceneConstants.ProjectUrlPropertyName, package, MetadataConstants.ProjectUrlPropertyName, Field.Index.NOT_ANALYZED);
+            AddField(document, LuceneConstants.MinClientVersionPropertyName, package, MetadataConstants.MinClientVersionPropertyName, Field.Index.NOT_ANALYZED);
+            AddField(document, LuceneConstants.ReleaseNotesPropertyName, package, MetadataConstants.ReleaseNotesPropertyName, Field.Index.NOT_ANALYZED);
+            AddField(document, LuceneConstants.CopyrightPropertyName, package, MetadataConstants.CopyrightPropertyName, Field.Index.NOT_ANALYZED);
+            AddField(document, LuceneConstants.LanguagePropertyName, package, MetadataConstants.LanguagePropertyName, Field.Index.NOT_ANALYZED);
+            AddField(document, LuceneConstants.LicenseUrlPropertyName, package, MetadataConstants.LicenseUrlPropertyName, Field.Index.NOT_ANALYZED);
+            AddField(document, LuceneConstants.PackageHashPropertyName, package, MetadataConstants.PackageHashPropertyName, Field.Index.NOT_ANALYZED);
+            AddField(document, LuceneConstants.PackageHashAlgorithmPropertyName, package, MetadataConstants.PackageHashAlgorithmPropertyName, Field.Index.NOT_ANALYZED);
             AddPackageSize(document, package, errors);
             AddRequiresLicenseAcceptance(document, package, errors);
             AddDependencies(document, package);
@@ -76,57 +77,57 @@ namespace NuGet.Indexing
         private static void AddId(Document document, IDictionary<string, string> package, List<string> errors)
         {
             string value;
-            if (package.TryGetValue("id", out value))
+            if (package.TryGetValue(MetadataConstants.IdPropertyName, out value))
             {
                 float boost = 2.0f;
-                if (!package.ContainsKey("tags"))
+                if (!package.ContainsKey(MetadataConstants.TagsPropertyName))
                 {
                     boost += 0.5f;
                 }
 
-                AddField(document, "Id", value, Field.Index.ANALYZED, boost);
-                AddField(document, "IdAutocomplete", value, Field.Index.ANALYZED, boost);
-                AddField(document, "TokenizedId", value, Field.Index.ANALYZED, boost);
-                AddField(document, "ShingledId", value, Field.Index.ANALYZED, boost);
+                AddField(document, LuceneConstants.IdPropertyName, value, Field.Index.ANALYZED, boost);
+                AddField(document, LuceneConstants.IdAutocompletePropertyName, value, Field.Index.ANALYZED, boost);
+                AddField(document, LuceneConstants.TokenizedIdPropertyName, value, Field.Index.ANALYZED, boost);
+                AddField(document, LuceneConstants.ShingledIdPropertyName, value, Field.Index.ANALYZED, boost);
             }
             else
             {
-                errors.Add("Required property 'id' not found.");
+                errors.Add($"Required property '{MetadataConstants.IdPropertyName}' not found.");
             }
         }
 
         private static void AddVersion(Document document, IDictionary<string, string> package, List<string> errors)
         {
-            string originalVersion;
-            if (package.TryGetValue("originalVersion", out originalVersion))
+            string verbatimVersion;
+            if (package.TryGetValue(MetadataConstants.VersionPropertyName, out verbatimVersion))
             {
-                AddField(document, "OriginalVersion", originalVersion, Field.Index.NOT_ANALYZED);
+                AddField(document, LuceneConstants.VersionPropertyName, verbatimVersion, Field.Index.NOT_ANALYZED);
             }
 
             string version;
-            if (!package.TryGetValue("version", out version))
+            if (!package.TryGetValue(MetadataConstants.NormalizedVersionPropertyName, out version))
             {
-                if (originalVersion != null)
+                if (verbatimVersion != null)
                 {
                     NuGetVersion nuGetVersion;
-                    if (NuGetVersion.TryParse(originalVersion, out nuGetVersion))
+                    if (NuGetVersion.TryParse(verbatimVersion, out nuGetVersion))
                     {
                         version = nuGetVersion.ToNormalizedString();
                     }
                     else
                     {
-                        errors.Add("Unable to parse 'originalVersion' as NuGetVersion.");
+                        errors.Add($"Unable to parse '{MetadataConstants.VersionPropertyName}' as NuGetVersion.");
                     }
                 }
             }
 
             if (version != null)
             {
-                AddField(document, "Version", version, Field.Index.ANALYZED);
+                AddField(document, LuceneConstants.NormalizedVersionPropertyName, version, Field.Index.ANALYZED);
             }
             else
             {
-                errors.Add("Required property 'version' or 'originalVersion' not found.");
+                errors.Add($"Required property '{MetadataConstants.NormalizedVersionPropertyName}' or '{MetadataConstants.VersionPropertyName}' not found.");
             }
         }
 
@@ -134,34 +135,34 @@ namespace NuGet.Indexing
         {
             string value;
 
-            package.TryGetValue("title", out value);
+            package.TryGetValue(MetadataConstants.TitlePropertyName, out value);
 
             if (string.IsNullOrEmpty(value))
             {
-                package.TryGetValue("id", out value);
+                package.TryGetValue(MetadataConstants.IdPropertyName, out value);
             }
 
-            AddField(document, "Title", value ?? string.Empty, Field.Index.ANALYZED);
+            AddField(document, LuceneConstants.TitlePropertyName, value ?? string.Empty, Field.Index.ANALYZED);
         }
 
         private static void AddListed(Document document, IDictionary<string, string> package, List<string> errors)
         {
             string value;
-            if (package.TryGetValue("listed", out value))
+            if (package.TryGetValue(MetadataConstants.ListedPropertyName, out value))
             {
                 bool listed;
                 if (bool.TryParse(value, out listed))
                 {
-                    AddField(document, "Listed", value, Field.Index.ANALYZED);
+                    AddField(document, LuceneConstants.ListedPropertyName, value, Field.Index.ANALYZED);
                 }
                 else
                 {
-                    errors.Add("Unable to parse 'listed' as Boolean.");
+                    errors.Add($"Unable to parse '{MetadataConstants.ListedPropertyName}' as Boolean.");
                 }
             }
             else
             {
-                errors.Add("Required property 'listed' not found.");
+                errors.Add($"Required property '{MetadataConstants.ListedPropertyName}' not found.");
             }
         }
 
@@ -169,43 +170,43 @@ namespace NuGet.Indexing
         {
             string value;
 
-            package.TryGetValue("title", out value);
+            package.TryGetValue(MetadataConstants.TitlePropertyName, out value);
 
             if (string.IsNullOrEmpty(value))
             {
-                package.TryGetValue("id", out value);
+                package.TryGetValue(MetadataConstants.IdPropertyName, out value);
             }
 
-            AddField(document, "SortableTitle", (value ?? string.Empty).Trim().ToLower(), Field.Index.NOT_ANALYZED);
+            AddField(document, LuceneConstants.SortableTitlePropertyName, (value ?? string.Empty).Trim().ToLower(), Field.Index.NOT_ANALYZED);
         }
 
         private static void AddDates(Document document, IDictionary<string, string> package, List<string> errors)
         {
             string created;
-            if (package.TryGetValue("created", out created))
+            if (package.TryGetValue(MetadataConstants.CreatedPropertyName, out created))
             {
-                AddField(document, "OriginalCreated", created, Field.Index.NOT_ANALYZED);
+                AddField(document, LuceneConstants.OriginalCreatedPropertyName, created, Field.Index.NOT_ANALYZED);
             }
 
             string published;
-            if (package.TryGetValue("published", out published))
+            if (package.TryGetValue(MetadataConstants.PublishedPropertyName, out published))
             {
-                AddField(document, "OriginalPublished", published, Field.Index.NOT_ANALYZED);
+                AddField(document, LuceneConstants.OriginalPublishedPropertyName, published, Field.Index.NOT_ANALYZED);
 
                 DateTimeOffset publishedDateTime;
                 if (DateTimeOffset.TryParse(published, out publishedDateTime))
                 {
-                    AddDateField(document, "PublishedDate", publishedDateTime);
+                    AddDateField(document, LuceneConstants.PublishedDatePropertyName, publishedDateTime);
                 }
                 else
                 {
-                    errors.Add("Unable to parse 'published' as DateTime.");
+                    errors.Add($"Unable to parse '{MetadataConstants.PublishedPropertyName}' as DateTime.");
                 }
 
                 string lastEdited;
-                if (package.TryGetValue("lastEdited", out lastEdited) && lastEdited != "01/01/0001 00:00:00")
+                if (package.TryGetValue(MetadataConstants.LastEditedPropertyName, out lastEdited) && lastEdited != MetadataConstants.DateTimeZeroStringValue)
                 {
-                    AddField(document, "OriginalLastEdited", lastEdited, Field.Index.NOT_ANALYZED);
+                    AddField(document, LuceneConstants.OriginalLastEditedPropertyName, lastEdited, Field.Index.NOT_ANALYZED);
                 }
                 else
                 {
@@ -215,32 +216,32 @@ namespace NuGet.Indexing
                 DateTimeOffset lastEditedDateTime;
                 if (DateTimeOffset.TryParse(lastEdited, out lastEditedDateTime))
                 {
-                    AddDateField(document, "LastEditedDate", lastEditedDateTime);
+                    AddDateField(document, LuceneConstants.LastEditedDatePropertyName, lastEditedDateTime);
                 }
                 else
                 {
-                    errors.Add("Unable to parse 'lastEdited' as DateTime.");
+                    errors.Add($"Unable to parse '{MetadataConstants.LastEditedPropertyName}' as DateTime.");
                 }
             }
             else
             {
-                errors.Add("Required property 'published' not found.");
+                errors.Add($"Required property '{MetadataConstants.PublishedPropertyName}' not found.");
             }
         }
 
         private static void AddPackageSize(Document document, IDictionary<string, string> package, List<string> errors)
         {
             string value;
-            if (package.TryGetValue("packageSize", out value))
+            if (package.TryGetValue(MetadataConstants.PackageSizePropertyName, out value))
             {
                 int packageSize;
                 if (int.TryParse(value, out packageSize))
                 {
-                    AddField(document, "PackageSize", value, Field.Index.NOT_ANALYZED);
+                    AddField(document, LuceneConstants.PackageSizePropertyName, value, Field.Index.NOT_ANALYZED);
                 }
                 else
                 {
-                    errors.Add("Unable to parse 'packageSize' as Int32.");
+                    errors.Add($"Unable to parse '{MetadataConstants.PackageSizePropertyName}' as Int32.");
                 }
             }
         }
@@ -248,16 +249,16 @@ namespace NuGet.Indexing
         private static void AddRequiresLicenseAcceptance(Document document, IDictionary<string, string> package, List<string> errors)
         {
             string value;
-            if (package.TryGetValue("requireLicenseAcceptance", out value))
+            if (package.TryGetValue(MetadataConstants.RequiresLicenseAcceptancePropertyName, out value))
             {
                 bool requiresLicenseAcceptance;
                 if (bool.TryParse(value, out requiresLicenseAcceptance))
                 {
-                    AddField(document, "RequiresLicenseAcceptance", value, Field.Index.NOT_ANALYZED);
+                    AddField(document, LuceneConstants.RequiresLicenseAcceptancePropertyName, value, Field.Index.NOT_ANALYZED);
                 }
                 else
                 {
-                    errors.Add("Unable to parse 'requireLicenseAcceptance' as Boolean.");
+                    errors.Add($"Unable to parse '{MetadataConstants.RequiresLicenseAcceptancePropertyName}' as Boolean.");
                 }
             }
         }
@@ -265,9 +266,9 @@ namespace NuGet.Indexing
         private static void AddDependencies(Document document, IDictionary<string, string> package)
         {
             string value;
-            if (package.TryGetValue("flattenedDependencies", out value))
+            if (package.TryGetValue(MetadataConstants.FlattenedDependenciesPropertyName, out value))
             {
-                AddField(document, "FlattenedDependencies", value, Field.Index.NOT_ANALYZED);
+                AddField(document, LuceneConstants.FlattenedDependenciesPropertyName, value, Field.Index.NOT_ANALYZED);
 
                 if (!string.IsNullOrWhiteSpace(value))
                 {
@@ -303,7 +304,7 @@ namespace NuGet.Indexing
                             textWriter.Flush();
                             string dependencies = textWriter.ToString();
 
-                            AddField(document, "Dependencies", dependencies, Field.Index.NOT_ANALYZED);
+                            AddField(document, LuceneConstants.DependenciesPropertyName, dependencies, Field.Index.NOT_ANALYZED);
                         }
                     }
                 }
@@ -313,7 +314,7 @@ namespace NuGet.Indexing
         private static void AddSupportedFrameworks(Document document, IDictionary<string, string> package)
         {
             string value;
-            if (package.TryGetValue("supportedFrameworks", out value))
+            if (package.TryGetValue(MetadataConstants.SupportedFrameworksPropertyName, out value))
             {
                 using (var textWriter = new StringWriter())
                 {
@@ -329,7 +330,7 @@ namespace NuGet.Indexing
                         textWriter.Flush();
                         string supportedFrameworks = textWriter.ToString();
 
-                        document.Add(new Field("SupportedFrameworks", supportedFrameworks, Field.Store.YES, Field.Index.NOT_ANALYZED));
+                        document.Add(new Field(LuceneConstants.SupportedFrameworksPropertyName, supportedFrameworks, Field.Store.YES, Field.Index.NOT_ANALYZED));
                     }
                 }
             }
@@ -339,7 +340,7 @@ namespace NuGet.Indexing
         {
             string id;
             string language;
-            if (package.TryGetValue("id", out id) && package.TryGetValue("language", out language))
+            if (package.TryGetValue(MetadataConstants.IdPropertyName, out id) && package.TryGetValue(MetadataConstants.LanguagePropertyName, out language))
             {
                 if (!string.IsNullOrWhiteSpace(language))
                 {

--- a/src/NuGet.Indexing/Extraction/MetadataConstants.cs
+++ b/src/NuGet.Indexing/Extraction/MetadataConstants.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Indexing
+{
+    public static class MetadataConstants
+    {
+        public static class LuceneMetadata
+        {
+            // Id Properties
+            public const string IdPropertyName = "Id";
+            public const string IdAutocompletePropertyName = "IdAutocomplete";
+            public const string ShingledIdPropertyName = "ShingledId";
+            public const string TokenizedIdPropertyName = "TokenizedId";
+
+            // Version Properties
+            public const string NormalizedVersionPropertyName = "Version";
+            public const string VersionPropertyName = "OriginalVersion";
+
+            // Date Properties
+            public const string LastEditedDatePropertyName = "LastEditedDate";
+            public const string OriginalCreatedPropertyName = "OriginalCreated";
+            public const string OriginalPublishedPropertyName = "OriginalPublished";
+            public const string OriginalLastEditedPropertyName = "OriginalLastEdited";
+            public const string PublishedDatePropertyName = "PublishedDate";
+
+            // Other Properties
+            public const string AuthorsPropertyName = "Authors";
+            public const string CopyrightPropertyName = "Copyright";
+            public const string DependenciesPropertyName = "Dependencies";
+            public const string DescriptionPropertyName = "Description";
+            public const string FlattenedDependenciesPropertyName = "FlattenedDependencies";
+            public const string IconUrlPropertyName = "IconUrl";
+            public const string LanguagePropertyName = "Language";
+            public const string LicenseUrlPropertyName = "LicenseUrl";
+            public const string ListedPropertyName = "Listed";
+            public const string MinClientVersionPropertyName = "MinClientVersion";
+            public const string PackageHashPropertyName = "PackageHash";
+            public const string PackageHashAlgorithmPropertyName = "PackageHashAlgorithm";
+            public const string PackageSizePropertyName = "PackageSize";
+            public const string ProjectUrlPropertyName = "ProjectUrl";
+            public const string ReleaseNotesPropertyName = "ReleaseNotes";
+            public const string RequiresLicenseAcceptancePropertyName = "RequiresLicenseAcceptance";
+            public const string SemVerLevelPropertyName = "SemVerLevel";
+            public const string SortableTitlePropertyName = "SortableTitle";
+            public const string SummaryPropertyName = "Summary";
+            public const string SupportedFrameworksPropertyName = "SupportedFrameworks";
+            public const string TagsPropertyName = "Tags";
+            public const string TitlePropertyName = "Title";
+        }
+
+        // These are here to account for the minor variations when extracting data from various sources.
+        public static class NuPkgMetadata
+        {
+            public const string VersionPropertyName = "version";
+        }
+
+        public static class CatalogMetadata
+        {
+            public const string RequiresLicenseAcceptancePropertyName = "requireLicenseAcceptance";
+        }
+
+        // Shared Property names
+        public const string AuthorsPropertyName = "authors";
+        public const string CopyrightPropertyName = "copyright";
+        public const string CreatedPropertyName = "created";
+        public const string DescriptionPropertyName = "description";
+        public const string FlattenedDependenciesPropertyName = "flattenedDependencies";
+        public const string IconUrlPropertyName = "iconUrl";
+        public const string IdPropertyName = "id";
+        public const string LanguagePropertyName = "language";
+        public const string LastEditedPropertyName = "lastEdited";
+        public const string LicenseUrlPropertyName = "licenseUrl";
+        public const string ListedPropertyName = "listed";
+        public const string MinClientVersionPropertyName = "minClientVersion";
+        public const string NormalizedVersionPropertyName = "version";
+        public const string PackageHashPropertyName = "packageHash";
+        public const string PackageHashAlgorithmPropertyName = "packageHashAlgorithm";
+        public const string PackageSizePropertyName = "packageSize";
+        public const string ProjectUrlPropertyName = "projectUrl";
+        public const string PublishedPropertyName = "published";
+        public const string ReleaseNotesPropertyName = "releaseNotes";
+        public const string RequiresLicenseAcceptancePropertyName = "requiresLicenseAcceptance";
+        public const string SemVerLevelKeyPropertyName = "semVerLevelKey";
+        public const string SummaryPropertyName = "summary";
+        public const string SupportedFrameworksPropertyName = "supportedFrameworks";
+        public const string TagsPropertyName = "tags";
+        public const string TitlePropertyName = "title";
+        public const string VersionPropertyName = "verbatimVersion";
+
+        // Constant Values
+        public const string DateTimeZeroStringValue = "01/01/0001 00:00:00";
+        public const string SemVerLevel2Value = "2";
+        public const string HashAlgorithmValue = "SHA512";
+    }
+}

--- a/src/NuGet.Indexing/Extraction/NupkgPackageMetadataExtraction.cs
+++ b/src/NuGet.Indexing/Extraction/NupkgPackageMetadataExtraction.cs
@@ -46,12 +46,12 @@ namespace NuGet.Indexing
             // TODO: extract supported frameworks from the folder structure
 
             nupkgStream.Seek(0, SeekOrigin.Begin);
-            package["packageSize"] = nupkgStream.Length.ToString();
-            using (HashAlgorithm hashAlgorithm = HashAlgorithm.Create("SHA512"))
+            package[MetadataConstants.PackageSizePropertyName] = nupkgStream.Length.ToString();
+            using (HashAlgorithm hashAlgorithm = HashAlgorithm.Create(MetadataConstants.HashAlgorithmValue))
             {
                 string hash = Convert.ToBase64String(hashAlgorithm.ComputeHash(nupkgStream));
-                package["packageHash"] = hash;
-                package["packageHashAlgorithm"] = "SHA512";
+                package[MetadataConstants.PackageHashPropertyName] = hash;
+                package[MetadataConstants.PackageHashAlgorithmPropertyName] = MetadataConstants.HashAlgorithmValue;
             }
 
             return package;
@@ -65,26 +65,26 @@ namespace NuGet.Indexing
                 return;
             }
 
-            ExtractProperty(package, document, "id");
-            ExtractProperty(package, document, "version", "originalVersion");
-            ExtractProperty(package, document, "title");
-            ExtractProperty(package, document, "summary");
-            ExtractProperty(package, document, "tags");
-            ExtractProperty(package, document, "authors");
-            ExtractProperty(package, document, "description");
-            ExtractProperty(package, document, "iconUrl");
-            ExtractProperty(package, document, "projectUrl");
-            ExtractProperty(package, document, "minClientVersion");
-            ExtractProperty(package, document, "releaseNotes");
-            ExtractProperty(package, document, "copyright");
-            ExtractProperty(package, document, "language");
-            ExtractProperty(package, document, "licenseUrl");
-            ExtractProperty(package, document, "requiresLicenseAcceptance");
+            ExtractProperty(package, document, MetadataConstants.IdPropertyName);
+            ExtractProperty(package, document, MetadataConstants.NuPkgMetadata.VersionPropertyName, MetadataConstants.VersionPropertyName);
+            ExtractProperty(package, document, MetadataConstants.TitlePropertyName);
+            ExtractProperty(package, document, MetadataConstants.SummaryPropertyName);
+            ExtractProperty(package, document, MetadataConstants.TagsPropertyName);
+            ExtractProperty(package, document, MetadataConstants.AuthorsPropertyName);
+            ExtractProperty(package, document, MetadataConstants.DescriptionPropertyName);
+            ExtractProperty(package, document, MetadataConstants.IconUrlPropertyName);
+            ExtractProperty(package, document, MetadataConstants.ProjectUrlPropertyName);
+            ExtractProperty(package, document, MetadataConstants.MinClientVersionPropertyName);
+            ExtractProperty(package, document, MetadataConstants.ReleaseNotesPropertyName);
+            ExtractProperty(package, document, MetadataConstants.CopyrightPropertyName);
+            ExtractProperty(package, document, MetadataConstants.LanguagePropertyName);
+            ExtractProperty(package, document, MetadataConstants.LicenseUrlPropertyName);
+            ExtractProperty(package, document, MetadataConstants.RequiresLicenseAcceptancePropertyName);
 
             // TODO: extract from the XML - refer to the XSLT for an accurate definition of the generic structure
 
-            package["published"] = DateTimeOffset.UtcNow.ToString("O");
-            package["listed"] = "true";
+            package[MetadataConstants.PublishedPropertyName] = DateTimeOffset.UtcNow.ToString("O");
+            package[MetadataConstants.ListedPropertyName] = "true";
         }
 
         static bool TryLoad(Stream stream, out XDocument document, List<string> errors)

--- a/src/NuGet.Indexing/Extraction/PackageEntityMetadataExtraction.cs
+++ b/src/NuGet.Indexing/Extraction/PackageEntityMetadataExtraction.cs
@@ -26,33 +26,33 @@ namespace NuGet.Indexing
                 _package = package;
                 _metadata = new Dictionary<string, string>();
 
-                AddString("id", package.PackageRegistration.Id);
-                AddString("version", package.NormalizedVersion);
-                AddString("originalVersion", package.Version);
-                AddString("title", package.Title);
-                AddString("description", package.Description);
-                AddString("summary", package.Summary);
-                AddString("tags", package.Tags);
-                AddString("authors", package.FlattenedAuthors);
+                AddString(MetadataConstants.IdPropertyName, package.PackageRegistration.Id);
+                AddString(MetadataConstants.NormalizedVersionPropertyName, package.NormalizedVersion);
+                AddString(MetadataConstants.VersionPropertyName, package.Version);
+                AddString(MetadataConstants.TitlePropertyName, package.Title);
+                AddString(MetadataConstants.DescriptionPropertyName, package.Description);
+                AddString(MetadataConstants.SummaryPropertyName, package.Summary);
+                AddString(MetadataConstants.TagsPropertyName, package.Tags);
+                AddString(MetadataConstants.AuthorsPropertyName, package.FlattenedAuthors);
 
-                AddString("listed", package.Listed.ToString());
-                AddString("created", package.Created.ToString("O"));
-                AddString("published", package.Published.ToString("O"));
-                AddString("lastEdited", package.LastEdited?.ToString("O"));
+                AddString(MetadataConstants.ListedPropertyName, package.Listed.ToString());
+                AddString(MetadataConstants.CreatedPropertyName, package.Created.ToString("O"));
+                AddString(MetadataConstants.PublishedPropertyName, package.Published.ToString("O"));
+                AddString(MetadataConstants.LastEditedPropertyName, package.LastEdited?.ToString("O"));
 
-                AddString("iconUrl", package.IconUrl);
-                AddString("projectUrl", package.ProjectUrl);
-                AddString("minClientVersion", package.MinClientVersion);
-                AddString("releaseNotes", package.ReleaseNotes);
-                AddString("copyright", package.Copyright);
-                AddString("language", package.Language);
-                AddString("licenseUrl", package.LicenseUrl);
-                AddString("packageHash", package.Hash);
-                AddString("packageHashAlgorithm", package.HashAlgorithm);
-                AddString("packageSize", package.PackageFileSize.ToString());
-                AddString("requiresLicenseAcceptance", package.RequiresLicenseAcceptance.ToString());
+                AddString(MetadataConstants.IconUrlPropertyName, package.IconUrl);
+                AddString(MetadataConstants.ProjectUrlPropertyName, package.ProjectUrl);
+                AddString(MetadataConstants.MinClientVersionPropertyName, package.MinClientVersion);
+                AddString(MetadataConstants.ReleaseNotesPropertyName, package.ReleaseNotes);
+                AddString(MetadataConstants.CopyrightPropertyName, package.Copyright);
+                AddString(MetadataConstants.LanguagePropertyName, package.Language);
+                AddString(MetadataConstants.LicenseUrlPropertyName, package.LicenseUrl);
+                AddString(MetadataConstants.PackageHashPropertyName, package.Hash);
+                AddString(MetadataConstants.PackageHashAlgorithmPropertyName, package.HashAlgorithm);
+                AddString(MetadataConstants.PackageSizePropertyName, package.PackageFileSize.ToString());
+                AddString(MetadataConstants.RequiresLicenseAcceptancePropertyName, package.RequiresLicenseAcceptance.ToString());
 
-                AddString("flattenedDependencies", package.FlattenedDependencies);
+                AddString(MetadataConstants.FlattenedDependenciesPropertyName, package.FlattenedDependencies);
                 AddSupportedFrameworks();
 
                 return _metadata;
@@ -77,7 +77,7 @@ namespace NuGet.Indexing
 
                 var supportedFrameworks = _package.SupportedFrameworks.Select(f => f.TargetFramework).ToArray();
                 var flattened = string.Join("|", supportedFrameworks);
-                AddString("supportedFrameworks", flattened);
+                AddString(MetadataConstants.SupportedFrameworksPropertyName, flattened);
             }
         }
     }

--- a/src/NuGet.Indexing/Handlers/LatestListedHandler.cs
+++ b/src/NuGet.Indexing/Handlers/LatestListedHandler.cs
@@ -111,14 +111,14 @@ namespace NuGet.Indexing
 
         internal static bool GetListed(Document document)
         {
-            string listed = document.Get("Listed");
+            string listed = document.Get(MetadataConstants.LuceneMetadata.ListedPropertyName);
             return (listed == null) ? false : listed.Equals("true", StringComparison.InvariantCultureIgnoreCase);
         }
 
         internal static bool IsSemVer2(Document document)
         {
-            string semVerLevel = document.Get("SemVerLevel");
-            return (semVerLevel == null) ? false : semVerLevel.Equals("2");
+            string semVerLevel = document.Get(MetadataConstants.LuceneMetadata.SemVerLevelPropertyName);
+            return (semVerLevel == null) ? false : semVerLevel.Equals(MetadataConstants.SemVerLevel2Value);
         }
     }
 }

--- a/src/NuGet.Indexing/NuGet.Indexing.csproj
+++ b/src/NuGet.Indexing/NuGet.Indexing.csproj
@@ -266,6 +266,7 @@
     <Compile Include="DownloadRankings.cs" />
     <Compile Include="DownloadsByVersion.cs" />
     <Compile Include="DynamicDocIdSet.cs" />
+    <Compile Include="Extraction\MetadataConstants.cs" />
     <Compile Include="IndexDirectoryProvider\LocalIndexDirectoryProvider.cs" />
     <Compile Include="ExpandAcronymsFilter.cs" />
     <Compile Include="Extraction\CatalogNuspecReader.cs" />

--- a/src/NuGet.Indexing/Sql2Lucene.cs
+++ b/src/NuGet.Indexing/Sql2Lucene.cs
@@ -82,7 +82,8 @@ namespace NuGet.Indexing
                         Packages.Created                        'created',
                         Packages.LastEdited                     'lastEdited',
                         Packages.Published                      'published',
-                        Packages.Listed                         'listed'
+                        Packages.Listed                         'listed',
+                        Packages.SemVerLevelKey                 'semVerLevelKey'
                     FROM Packages
                     INNER JOIN PackageRegistrations ON Packages.PackageRegistrationKey = PackageRegistrations.[Key]
                       AND Packages.[Key] >= @BeginKey

--- a/tests/NuGet.IndexingTests/Extraction/CatalogPackageMetadataExtractorTests.cs
+++ b/tests/NuGet.IndexingTests/Extraction/CatalogPackageMetadataExtractorTests.cs
@@ -19,8 +19,8 @@ namespace NuGet.IndexingTests.Extraction
             var metadata = CatalogPackageMetadataExtraction.MakePackageMetadata(catalogEntryJObject);
 
             // Assert
-            Assert.Contains("listed", metadata.Keys);
-            Assert.Equal(expected, metadata["listed"]);
+            Assert.Contains(MetadataConstants.ListedPropertyName, metadata.Keys);
+            Assert.Equal(expected, metadata[MetadataConstants.ListedPropertyName]);
         }
 
         [Theory, MemberData(nameof(AddsSemVerLevelKeyData))]
@@ -34,10 +34,10 @@ namespace NuGet.IndexingTests.Extraction
 
 
             // Assert
-            Assert.Equal(expectedToContainKey, metadata.Keys.Contains("semVerLevelKey"));
+            Assert.Equal(expectedToContainKey, metadata.Keys.Contains(MetadataConstants.SemVerLevelKeyPropertyName));
             if (expectedToContainKey)
             {
-                Assert.Equal(expected, metadata["semVerLevelKey"]);
+                Assert.Equal(expected, metadata[MetadataConstants.SemVerLevelKeyPropertyName]);
             }
         }
 
@@ -51,8 +51,8 @@ namespace NuGet.IndexingTests.Extraction
             var metadata = CatalogPackageMetadataExtraction.MakePackageMetadata(catalogEntryJObject);
 
             // Assert
-            Assert.Contains("supportedFrameworks", metadata.Keys);
-            Assert.Equal(expected.Split('|').OrderBy(f => f), metadata["supportedFrameworks"].Split('|').OrderBy(f => f));
+            Assert.Contains(MetadataConstants.SupportedFrameworksPropertyName, metadata.Keys);
+            Assert.Equal(expected.Split('|').OrderBy(f => f), metadata[MetadataConstants.SupportedFrameworksPropertyName].Split('|').OrderBy(f => f));
         }
 
         [Theory, MemberData(nameof(AddsFlattenedDependenciesData))]
@@ -65,8 +65,8 @@ namespace NuGet.IndexingTests.Extraction
             var metadata = CatalogPackageMetadataExtraction.MakePackageMetadata(catalogEntryJObject);
 
             // Assert
-            Assert.Contains("flattenedDependencies", metadata.Keys);
-            Assert.Equal(expected, metadata["flattenedDependencies"]);
+            Assert.Contains(MetadataConstants.FlattenedDependenciesPropertyName, metadata.Keys);
+            Assert.Equal(expected, metadata[MetadataConstants.FlattenedDependenciesPropertyName]);
         }
 
         public static IEnumerable<object[]> AddsListedData

--- a/tests/NuGet.IndexingTests/Extraction/DocumentCreatorTests.cs
+++ b/tests/NuGet.IndexingTests/Extraction/DocumentCreatorTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Lucene.Net.Documents;
 using NuGet.Indexing;
 using Xunit;
+using LuceneConstants = NuGet.Indexing.MetadataConstants.LuceneMetadata;
 
 namespace NuGet.IndexingTests
 {
@@ -41,12 +42,12 @@ namespace NuGet.IndexingTests
         {
             // Arrange
             var package = GetPackage();
-            package.Remove("version");
-            package.Remove("originalVersion");
+            package.Remove(MetadataConstants.NormalizedVersionPropertyName);
+            package.Remove(MetadataConstants.VersionPropertyName);
 
             // Act, Assert
             var exception = Assert.Throws<Exception>(() => DocumentCreator.CreateDocument(package));
-            Assert.Equal("Required property 'version' or 'originalVersion' not found.\r\n", exception.Message);
+            Assert.Equal($"Required property '{MetadataConstants.NormalizedVersionPropertyName}' or '{MetadataConstants.VersionPropertyName}' not found.\r\n", exception.Message);
         }
 
         [Fact]
@@ -54,12 +55,12 @@ namespace NuGet.IndexingTests
         {
             // Arrange
             var package = GetPackage();
-            package.Remove("version");
-            package["originalVersion"] = "bad";
+            package.Remove(MetadataConstants.NormalizedVersionPropertyName);
+            package[MetadataConstants.VersionPropertyName] = "bad";
 
             // Act, Assert
             var exception = Assert.Throws<Exception>(() => DocumentCreator.CreateDocument(package));
-            Assert.Equal("Unable to parse 'originalVersion' as NuGetVersion.\r\nRequired property 'version' or 'originalVersion' not found.\r\n", exception.Message);
+            Assert.Equal($"Unable to parse '{MetadataConstants.VersionPropertyName}' as NuGetVersion.\r\nRequired property '{MetadataConstants.NormalizedVersionPropertyName}' or '{MetadataConstants.VersionPropertyName}' not found.\r\n", exception.Message);
         }
 
         [Fact]
@@ -102,14 +103,14 @@ namespace NuGet.IndexingTests
         {
             // Arrange
             var package = GetPackage();
-            package.Remove("title");
+            package.Remove(MetadataConstants.TitlePropertyName);
 
             // Act
             var document = DocumentCreator.CreateDocument(package);
 
             // Assert
-            Assert.Equal("DotNetZip", document.GetFieldable("Title").StringValue);
-            Assert.Equal("dotnetzip", document.GetFieldable("SortableTitle").StringValue);
+            Assert.Equal("DotNetZip", document.GetFieldable(LuceneConstants.TitlePropertyName).StringValue);
+            Assert.Equal("dotnetzip", document.GetFieldable(LuceneConstants.SortableTitlePropertyName).StringValue);
         }
 
         [Fact]
@@ -117,14 +118,14 @@ namespace NuGet.IndexingTests
         {
             // Arrange
             var package = GetPackage();
-            package["title"] = string.Empty;
+            package[MetadataConstants.TitlePropertyName] = string.Empty;
 
             // Act
             var document = DocumentCreator.CreateDocument(package);
 
             // Assert
-            Assert.Equal("DotNetZip", document.GetFieldable("Title").StringValue);
-            Assert.Equal("dotnetzip", document.GetFieldable("SortableTitle").StringValue);
+            Assert.Equal("DotNetZip", document.GetFieldable(LuceneConstants.TitlePropertyName).StringValue);
+            Assert.Equal("dotnetzip", document.GetFieldable(LuceneConstants.SortableTitlePropertyName).StringValue);
         }
 
         [Fact]
@@ -132,16 +133,16 @@ namespace NuGet.IndexingTests
         {
             // Arrange
             var package = GetPackage();
-            package.Remove("lastEdited");
+            package.Remove(MetadataConstants.LastEditedPropertyName);
 
             // Act
             var document = DocumentCreator.CreateDocument(package);
 
             // Assert
-            Assert.Equal("2002-02-02T00:00:00.0000000Z", document.GetField("OriginalPublished").StringValue);
-            Assert.Null(document.GetField("OriginalLastEdited"));
-            Assert.Equal("20020202", document.GetFieldable("PublishedDate").StringValue);
-            Assert.Equal("20020202", document.GetFieldable("LastEditedDate").StringValue);
+            Assert.Equal("2002-02-02T00:00:00.0000000Z", document.GetField(LuceneConstants.OriginalPublishedPropertyName).StringValue);
+            Assert.Null(document.GetField(LuceneConstants.OriginalLastEditedPropertyName));
+            Assert.Equal("20020202", document.GetFieldable(LuceneConstants.PublishedDatePropertyName).StringValue);
+            Assert.Equal("20020202", document.GetFieldable(LuceneConstants.LastEditedDatePropertyName).StringValue);
         }
 
         [Fact]
@@ -149,15 +150,15 @@ namespace NuGet.IndexingTests
         {
             // Arrange
             var package = GetPackage();
-            package.Remove("version");
-            package["originalVersion"] = "1.02.003";
+            package.Remove(MetadataConstants.NormalizedVersionPropertyName);
+            package[MetadataConstants.VersionPropertyName] = "1.02.003";
 
             // Act
             var document = DocumentCreator.CreateDocument(package);
 
             // Assert
-            Assert.Equal("1.02.003", document.GetFieldable("OriginalVersion").StringValue);
-            Assert.Equal("1.2.3", document.GetFieldable("Version").StringValue);
+            Assert.Equal("1.02.003", document.GetFieldable(LuceneConstants.VersionPropertyName).StringValue);
+            Assert.Equal("1.2.3", document.GetFieldable(LuceneConstants.NormalizedVersionPropertyName).StringValue);
         }
 
         [Fact]
@@ -167,38 +168,39 @@ namespace NuGet.IndexingTests
             var package = GetPackage();
             var expected = new[]
             {
-                new KeyValuePair<string, string>("Id", "DotNetZip"),
-                new KeyValuePair<string, string>("IdAutocomplete", "DotNetZip"),
-                new KeyValuePair<string, string>("TokenizedId", "DotNetZip"),
-                new KeyValuePair<string, string>("ShingledId", "DotNetZip"),
-                new KeyValuePair<string, string>("OriginalVersion", "1.00.000"),
-                new KeyValuePair<string, string>("Version", "1.0.0"),
-                new KeyValuePair<string, string>("Title", "The Famous DotNetZip"),
-                new KeyValuePair<string, string>("Description", "The description."),
-                new KeyValuePair<string, string>("Summary", "The summary."),
-                new KeyValuePair<string, string>("Tags", "dot net zip"),
-                new KeyValuePair<string, string>("Authors", "Justin Bieber, Nick Jonas"),
-                new KeyValuePair<string, string>("Listed", "true"),
-                new KeyValuePair<string, string>("OriginalCreated", "2001-01-01T00:00:00.0000000Z"),
-                new KeyValuePair<string, string>("OriginalPublished", "2002-02-02T00:00:00.0000000Z"),
-                new KeyValuePair<string, string>("PublishedDate", "20020202"),
-                new KeyValuePair<string, string>("OriginalLastEdited", "2003-03-03T00:00:00.0000000Z"),
-                new KeyValuePair<string, string>("LastEditedDate", "20030303"),
-                new KeyValuePair<string, string>("SortableTitle", "the famous dotnetzip"),
-                new KeyValuePair<string, string>("IconUrl", "http://example/icon.png"),
-                new KeyValuePair<string, string>("ProjectUrl", "http://example/"),
-                new KeyValuePair<string, string>("MinClientVersion", "2.0.0"),
-                new KeyValuePair<string, string>("ReleaseNotes", "The release notes."),
-                new KeyValuePair<string, string>("Copyright", "The copyright."),
-                new KeyValuePair<string, string>("Language", "English"),
-                new KeyValuePair<string, string>("LicenseUrl", "http://example/license.txt"),
-                new KeyValuePair<string, string>("PackageHash", "0123456789ABCDEF"),
-                new KeyValuePair<string, string>("PackageHashAlgorithm", "SHA1"),
-                new KeyValuePair<string, string>("PackageSize", "1200"),
-                new KeyValuePair<string, string>("RequiresLicenseAcceptance", "true"),
-                new KeyValuePair<string, string>("FlattenedDependencies", "Lucene.Net:2.9.4.1|WindowsAzure.Storage:1.6"),
-                new KeyValuePair<string, string>("Dependencies", "[{\"Id\":\"Lucene.Net\",\"VersionSpec\":\"2.9.4.1\"},{\"Id\":\"WindowsAzure.Storage\",\"VersionSpec\":\"1.6\"}]"),
-                new KeyValuePair<string, string>("SupportedFrameworks", "[\"net40\",\"aspnet99\"]")
+                new KeyValuePair<string, string>(LuceneConstants.IdPropertyName, "DotNetZip"),
+                new KeyValuePair<string, string>(LuceneConstants.IdAutocompletePropertyName, "DotNetZip"),
+                new KeyValuePair<string, string>(LuceneConstants.TokenizedIdPropertyName, "DotNetZip"),
+                new KeyValuePair<string, string>(LuceneConstants.ShingledIdPropertyName, "DotNetZip"),
+                new KeyValuePair<string, string>(LuceneConstants.VersionPropertyName, "1.00.000"),
+                new KeyValuePair<string, string>(LuceneConstants.NormalizedVersionPropertyName, "1.0.0"),
+                new KeyValuePair<string, string>(LuceneConstants.TitlePropertyName, "The Famous DotNetZip"),
+                new KeyValuePair<string, string>(LuceneConstants.DescriptionPropertyName, "The description."),
+                new KeyValuePair<string, string>(LuceneConstants.SummaryPropertyName, "The summary."),
+                new KeyValuePair<string, string>(LuceneConstants.TagsPropertyName, "dot net zip"),
+                new KeyValuePair<string, string>(LuceneConstants.AuthorsPropertyName, "Justin Bieber, Nick Jonas"),
+                new KeyValuePair<string, string>(LuceneConstants.SemVerLevelPropertyName, ""),
+                new KeyValuePair<string, string>(LuceneConstants.ListedPropertyName, "true"),
+                new KeyValuePair<string, string>(LuceneConstants.OriginalCreatedPropertyName, "2001-01-01T00:00:00.0000000Z"),
+                new KeyValuePair<string, string>(LuceneConstants.OriginalPublishedPropertyName, "2002-02-02T00:00:00.0000000Z"),
+                new KeyValuePair<string, string>(LuceneConstants.PublishedDatePropertyName, "20020202"),
+                new KeyValuePair<string, string>(LuceneConstants.OriginalLastEditedPropertyName, "2003-03-03T00:00:00.0000000Z"),
+                new KeyValuePair<string, string>(LuceneConstants.LastEditedDatePropertyName, "20030303"),
+                new KeyValuePair<string, string>(LuceneConstants.SortableTitlePropertyName, "the famous dotnetzip"),
+                new KeyValuePair<string, string>(LuceneConstants.IconUrlPropertyName, "http://example/icon.png"),
+                new KeyValuePair<string, string>(LuceneConstants.ProjectUrlPropertyName, "http://example/"),
+                new KeyValuePair<string, string>(LuceneConstants.MinClientVersionPropertyName, "2.0.0"),
+                new KeyValuePair<string, string>(LuceneConstants.ReleaseNotesPropertyName, "The release notes."),
+                new KeyValuePair<string, string>(LuceneConstants.CopyrightPropertyName, "The copyright."),
+                new KeyValuePair<string, string>(LuceneConstants.LanguagePropertyName, "English"),
+                new KeyValuePair<string, string>(LuceneConstants.LicenseUrlPropertyName, "http://example/license.txt"),
+                new KeyValuePair<string, string>(LuceneConstants.PackageHashPropertyName, "0123456789ABCDEF"),
+                new KeyValuePair<string, string>(LuceneConstants.PackageHashAlgorithmPropertyName, "SHA1"),
+                new KeyValuePair<string, string>(LuceneConstants.PackageSizePropertyName, "1200"),
+                new KeyValuePair<string, string>(LuceneConstants.RequiresLicenseAcceptancePropertyName, "true"),
+                new KeyValuePair<string, string>(LuceneConstants.FlattenedDependenciesPropertyName, "Lucene.Net:2.9.4.1|WindowsAzure.Storage:1.6"),
+                new KeyValuePair<string, string>(LuceneConstants.DependenciesPropertyName, "[{\"Id\":\"Lucene.Net\",\"VersionSpec\":\"2.9.4.1\"},{\"Id\":\"WindowsAzure.Storage\",\"VersionSpec\":\"1.6\"}]"),
+                new KeyValuePair<string, string>(LuceneConstants.SupportedFrameworksPropertyName, "[\"net40\",\"aspnet99\"]")
             };
 
             // Act
@@ -217,9 +219,9 @@ namespace NuGet.IndexingTests
         {
             get
             {
-                yield return new[] { "id", "Required property 'id' not found.\r\n" };
-                yield return new[] { "listed", "Required property 'listed' not found.\r\n" };
-                yield return new[] { "published", "Required property 'published' not found.\r\n" };
+                yield return new[] { MetadataConstants.IdPropertyName, "Required property 'id' not found.\r\n" };
+                yield return new[] { MetadataConstants.ListedPropertyName, "Required property 'listed' not found.\r\n" };
+                yield return new[] { MetadataConstants.PublishedPropertyName, "Required property 'published' not found.\r\n" };
             }
         }
 
@@ -227,11 +229,11 @@ namespace NuGet.IndexingTests
         {
             get
             {
-                yield return new[] { "listed", "Unable to parse 'listed' as Boolean.\r\n" };
-                yield return new[] { "published", "Unable to parse 'published' as DateTime.\r\n" };
-                yield return new[] { "lastEdited", "Unable to parse 'lastEdited' as DateTime.\r\n" };
-                yield return new[] { "requireLicenseAcceptance", "Unable to parse 'requireLicenseAcceptance' as Boolean.\r\n" };
-                yield return new[] { "packageSize", "Unable to parse 'packageSize' as Int32.\r\n" };
+                yield return new[] { MetadataConstants.ListedPropertyName, "Unable to parse 'listed' as Boolean.\r\n" };
+                yield return new[] { MetadataConstants.PublishedPropertyName, "Unable to parse 'published' as DateTime.\r\n" };
+                yield return new[] { MetadataConstants.LastEditedPropertyName, "Unable to parse 'lastEdited' as DateTime.\r\n" };
+                yield return new[] { MetadataConstants.RequiresLicenseAcceptancePropertyName, "Unable to parse 'requiresLicenseAcceptance' as Boolean.\r\n" };
+                yield return new[] { MetadataConstants.PackageSizePropertyName, "Unable to parse 'packageSize' as Int32.\r\n" };
             }
         }
 
@@ -240,35 +242,36 @@ namespace NuGet.IndexingTests
             return new Dictionary<string, string>
             {
                 // required
-                { "id", "DotNetZip" },
-                { "version", "1.0.0" },
-                { "listed", "true" },
-                { "published", new DateTime(2002, 2, 2, 0, 0, 0, DateTimeKind.Utc).ToString("O") },
+                { MetadataConstants.IdPropertyName, "DotNetZip" },
+                { MetadataConstants.NormalizedVersionPropertyName, "1.0.0" },
+                { MetadataConstants.ListedPropertyName, "true" },
+                { MetadataConstants.PublishedPropertyName, new DateTime(2002, 2, 2, 0, 0, 0, DateTimeKind.Utc).ToString("O") },
 
                 // not required but validated
-                { "lastEdited", new DateTime(2003, 3, 3, 0, 0, 0, DateTimeKind.Utc).ToString("O") },
-                { "packageSize", "1200" },
-                { "requireLicenseAcceptance", "true" },
+                { MetadataConstants.LastEditedPropertyName, new DateTime(2003, 3, 3, 0, 0, 0, DateTimeKind.Utc).ToString("O") },
+                { MetadataConstants.PackageSizePropertyName, "1200" },
+                { MetadataConstants.RequiresLicenseAcceptancePropertyName, "true" },
 
                 // not required
-                { "originalVersion", "1.00.000" },
-                { "title", "The Famous DotNetZip" },
-                { "description", "The description." },
-                { "summary", "The summary." },
-                { "tags", "dot net zip" },
-                { "authors", "Justin Bieber, Nick Jonas" },
-                { "created", new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc).ToString("O") },
-                { "iconUrl", "http://example/icon.png" },
-                { "projectUrl", "http://example/" },
-                { "minClientVersion", "2.0.0" },
-                { "releaseNotes", "The release notes." },
-                { "copyright", "The copyright." },
-                { "language", "English" },
-                { "licenseUrl", "http://example/license.txt" },
-                { "packageHash", "0123456789ABCDEF" },
-                { "packageHashAlgorithm", "SHA1" },
-                { "flattenedDependencies", "Lucene.Net:2.9.4.1|WindowsAzure.Storage:1.6" },
-                { "supportedFrameworks", "net40|aspnet99" }
+                { MetadataConstants.SemVerLevelKeyPropertyName, "" },
+                { MetadataConstants.VersionPropertyName, "1.00.000" },
+                { MetadataConstants.TitlePropertyName, "The Famous DotNetZip" },
+                { MetadataConstants.DescriptionPropertyName, "The description." },
+                { MetadataConstants.SummaryPropertyName, "The summary." },
+                { MetadataConstants.TagsPropertyName, "dot net zip" },
+                { MetadataConstants.AuthorsPropertyName, "Justin Bieber, Nick Jonas" },
+                { MetadataConstants.CreatedPropertyName, new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc).ToString("O") },
+                { MetadataConstants.IconUrlPropertyName, "http://example/icon.png" },
+                { MetadataConstants.ProjectUrlPropertyName, "http://example/" },
+                { MetadataConstants.MinClientVersionPropertyName, "2.0.0" },
+                { MetadataConstants.ReleaseNotesPropertyName, "The release notes." },
+                { MetadataConstants.CopyrightPropertyName, "The copyright." },
+                { MetadataConstants.LanguagePropertyName, "English" },
+                { MetadataConstants.LicenseUrlPropertyName, "http://example/license.txt" },
+                { MetadataConstants.PackageHashPropertyName, "0123456789ABCDEF" },
+                { MetadataConstants.PackageHashAlgorithmPropertyName, "SHA1" },
+                { MetadataConstants.FlattenedDependenciesPropertyName, "Lucene.Net:2.9.4.1|WindowsAzure.Storage:1.6" },
+                { MetadataConstants.SupportedFrameworksPropertyName, "net40|aspnet99" }
             };
         }
     }


### PR DESCRIPTION
This PR adds support for writing a new Field into the Lucene Index, SemVerLevel.
Currently, this field will match the value in the SemVerLevelKey column in the database added with https://github.com/NuGet/NuGetGallery/pull/3678

https://github.com/NuGet/NuGet.Services.Metadata/pull/142 contains parallel changes for search service to consume these updates.

@joelverhagen @skofman1 @xavierdecoster 