### PR TITLE
Pass normalized version when creating flat container

### DIFF
--- a/src/Catalog/Dnx/DnxCatalogCollector.cs
+++ b/src/Catalog/Dnx/DnxCatalogCollector.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Services.Metadata.Catalog.Persistence;
+using NuGet.Services.Metadata.Catalog.Helpers;
 
 namespace NuGet.Services.Metadata.Catalog.Dnx
 {
@@ -31,7 +32,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
             foreach (JToken item in items)
             {
                 string id = item["nuget:id"].ToString().ToLowerInvariant();
-                string version = item["nuget:version"].ToString().ToLowerInvariant();
+                string version = NuGetVersionUtility.NormalizeVersion(item["nuget:version"].ToString().ToLowerInvariant());
                 string type = item["@type"].ToString().Replace("nuget:", Schema.Prefixes.NuGet);
 
                 if (type == Schema.DataTypes.PackageDetails.ToString())

--- a/tests/NgTests/DnxCatalogCollectorTests.cs
+++ b/tests/NgTests/DnxCatalogCollectorTests.cs
@@ -15,6 +15,7 @@ using NuGet.Services.Metadata.Catalog;
 using NuGet.Services.Metadata.Catalog.Dnx;
 using NuGet.Versioning;
 using Xunit;
+using Newtonsoft.Json.Linq;
 
 namespace NgTests
 {
@@ -175,19 +176,18 @@ namespace NgTests
 
         [Theory]
         [InlineData("1.2.0")]
-        [InlineData("1.2")]
         [InlineData("0.1.2")]
-        [InlineData("1.2.3.0")]
         [InlineData("1.2.3.4")]
         [InlineData("1.2.3-beta1")]
+        [InlineData("1.2.3-beta.1")]
         [Description("Test the dnxmarker save and delete scenarios.")]
-        public async Task DnxMarkerTestVersion(string version)
+        public async Task DnxMakerTestVersion(string version)
         {
             string id = "testid";
             // Arrange
             var catalogToDnxStorage = new MemoryStorage();
             var catalogToDnxStorageFactory = new TestStorageFactory(name => catalogToDnxStorage.WithName(name));
-            DnxMaker marker = new DnxMaker(catalogToDnxStorageFactory);
+            DnxMaker maker = new DnxMaker(catalogToDnxStorageFactory);
 
             var nupkg = new MemoryStream();
             StreamWriter writer = new StreamWriter(nupkg);
@@ -196,19 +196,72 @@ namespace NgTests
             nupkg.Position = 0;
 
             //Act
-            var dnxEntry = await marker.AddPackage(nupkg, "nuspec data", id, version, CancellationToken.None);
-            string normalizedVer = NuGetVersion.Parse(version).ToNormalizedString();
-            string expectedNuspec = $"{catalogToDnxStorage.BaseAddress}{id}/{normalizedVer}/{id}.nuspec";
-            string expectedNupkg = $"{catalogToDnxStorage.BaseAddress}{id}/{normalizedVer}/{id}.{normalizedVer}.nupkg";
+            var dnxEntry = await maker.AddPackage(nupkg, "nuspec data", id, version, CancellationToken.None);
+            string expectedNuspec = $"{catalogToDnxStorage.BaseAddress}{id}/{version}/{id}.nuspec";
+            string expectedNupkg = $"{catalogToDnxStorage.BaseAddress}{id}/{version}/{id}.{version}.nupkg";
+
+            var storageForPackage = catalogToDnxStorageFactory.Create(id);
+            var indexJson = await storageForPackage.Load(new Uri(storageForPackage.BaseAddress, "index.json"), new CancellationToken());
+
+            var indexObject = JObject.Parse(indexJson.GetContentString());
+
+            var versions = indexObject["versions"].ToObject<string[]>();
 
             //Assert
+            Assert.True(versions.Length > 0);
+            Assert.Equal(version, versions[0]);
             Assert.Equal(expectedNuspec, dnxEntry.Nuspec.ToString());
             Assert.Equal(expectedNupkg, dnxEntry.Nupkg.ToString());
             //three items : nuspec, nupkg, and index.json
             Assert.Equal(catalogToDnxStorage.Content.Count, 3);
 
             //Act
-            await marker.DeletePackage(id, version, CancellationToken.None);
+            await maker.DeletePackage(id, version, CancellationToken.None);
+            //Assert
+            Assert.Equal(catalogToDnxStorage.Content.Count, 0);
+        }
+
+        [Theory]
+        [InlineData("1.2")]
+        [InlineData("1.2.3.0")]
+        [InlineData("1.02.3")]
+        [Description("Test the dnxmarker save and delete scenarios.")]
+        public async Task DnxMakerFailsTestVersion(string version)
+        {
+            string id = "testid";
+            // Arrange
+            var catalogToDnxStorage = new MemoryStorage();
+            var catalogToDnxStorageFactory = new TestStorageFactory(name => catalogToDnxStorage.WithName(name));
+            DnxMaker maker = new DnxMaker(catalogToDnxStorageFactory);
+
+            var nupkg = new MemoryStream();
+            StreamWriter writer = new StreamWriter(nupkg);
+            writer.Write("nupkg data");
+            writer.Flush();
+            nupkg.Position = 0;
+
+            //Act
+            var dnxEntry = await maker.AddPackage(nupkg, "nuspec data", id, version, CancellationToken.None);
+            string expectedNuspec = $"{catalogToDnxStorage.BaseAddress}{id}/{version}/{id}.nuspec";
+            string expectedNupkg = $"{catalogToDnxStorage.BaseAddress}{id}/{version}/{id}.{version}.nupkg";
+
+            var storageForPackage = catalogToDnxStorageFactory.Create(id);
+            var indexJson = await storageForPackage.Load(new Uri(storageForPackage.BaseAddress, "index.json"), new CancellationToken());
+
+            var indexObject = JObject.Parse(indexJson.GetContentString());
+
+            var versions = indexObject["versions"].ToObject<string[]>();
+
+            //Assert
+            Assert.True(versions.Length > 0);
+            Assert.Equal(version, versions[0]);
+            Assert.NotEqual(expectedNuspec, dnxEntry.Nuspec.ToString());
+            Assert.NotEqual(expectedNupkg, dnxEntry.Nupkg.ToString());
+            //three items : nuspec, nupkg, and index.json
+            Assert.Equal(catalogToDnxStorage.Content.Count, 3);
+
+            //Act
+            await maker.DeletePackage(id, version, CancellationToken.None);
             //Assert
             Assert.Equal(catalogToDnxStorage.Content.Count, 0);
         }

--- a/tests/NgTests/DnxCatalogCollectorTests.cs
+++ b/tests/NgTests/DnxCatalogCollectorTests.cs
@@ -9,13 +9,12 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 using NgTests.Data;
 using NgTests.Infrastructure;
 using NuGet.Services.Metadata.Catalog;
 using NuGet.Services.Metadata.Catalog.Dnx;
-using NuGet.Versioning;
 using Xunit;
-using Newtonsoft.Json.Linq;
 
 namespace NgTests
 {
@@ -180,7 +179,7 @@ namespace NgTests
         [InlineData("1.2.3.4")]
         [InlineData("1.2.3-beta1")]
         [InlineData("1.2.3-beta.1")]
-        [Description("Test the dnxmarker save and delete scenarios.")]
+        [Description("Test the dnxmaker save and delete scenarios.")]
         public async Task DnxMakerTestVersion(string version)
         {
             string id = "testid";
@@ -225,7 +224,7 @@ namespace NgTests
         [InlineData("1.2")]
         [InlineData("1.2.3.0")]
         [InlineData("1.02.3")]
-        [Description("Test the dnxmarker save and delete scenarios.")]
+        [Description("Test the dnxmaker save and delete scenarios.")]
         public async Task DnxMakerFailsTestVersion(string version)
         {
             string id = "testid";


### PR DESCRIPTION
This is to strip metadata from versions before we write to the index.json.
Versions were already being normalized before we were writing the nuspec/nupkg, so no changes are necessary here.

@joelverhagen @skofman1 @xavierdecoster 