### PR TITLE
Update to NuGet.Services.Logging 2.1.1

### DIFF
--- a/src/Ng/Ng.csproj
+++ b/src/Ng/Ng.csproj
@@ -242,8 +242,8 @@
     <Reference Include="NuGet.Services.KeyVault, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Services.KeyVault.2.1.0\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Logging, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Logging.2.1.0\lib\net452\NuGet.Services.Logging.dll</HintPath>
+    <Reference Include="NuGet.Services.Logging, Version=2.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Logging.2.1.1\lib\net452\NuGet.Services.Logging.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Versioning, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Versioning.3.5.0-rc1-final\lib\net45\NuGet.Versioning.dll</HintPath>

--- a/src/Ng/packages.config
+++ b/src/Ng/packages.config
@@ -37,7 +37,7 @@
   <package id="NuGet.Core" version="2.8.5" targetFramework="net452" />
   <package id="NuGet.Services.Configuration" version="2.1.0" targetFramework="net452" />
   <package id="NuGet.Services.KeyVault" version="2.1.0" targetFramework="net452" />
-  <package id="NuGet.Services.Logging" version="2.1.0" targetFramework="net452" />
+  <package id="NuGet.Services.Logging" version="2.1.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.5.0-rc1-final" targetFramework="net452" />
   <package id="Serilog" version="2.0.0" targetFramework="net452" />
   <package id="Serilog.Enrichers.Environment" version="2.1.0" targetFramework="net452" />

--- a/src/NuGet.Services.BasicSearch/NuGet.Services.BasicSearch.csproj
+++ b/src/NuGet.Services.BasicSearch/NuGet.Services.BasicSearch.csproj
@@ -231,8 +231,8 @@
     <Reference Include="NuGet.Services.KeyVault, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Services.KeyVault.2.1.0\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Logging, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Logging.2.1.0\lib\net452\NuGet.Services.Logging.dll</HintPath>
+    <Reference Include="NuGet.Services.Logging, Version=2.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Logging.2.1.1\lib\net452\NuGet.Services.Logging.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Versioning, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Versioning.3.5.0-rc1-final\lib\net45\NuGet.Versioning.dll</HintPath>

--- a/src/NuGet.Services.BasicSearch/packages.config
+++ b/src/NuGet.Services.BasicSearch/packages.config
@@ -48,7 +48,7 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Services.Configuration" version="2.1.0" targetFramework="net452" />
   <package id="NuGet.Services.KeyVault" version="2.1.0" targetFramework="net452" />
-  <package id="NuGet.Services.Logging" version="2.1.0" targetFramework="net452" />
+  <package id="NuGet.Services.Logging" version="2.1.1" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.5.0-rc1-final" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="Serilog" version="2.0.0" targetFramework="net452" />

--- a/tests/NuGet.Services.BasicSearchTests/NuGet.Services.BasicSearchTests.csproj
+++ b/tests/NuGet.Services.BasicSearchTests/NuGet.Services.BasicSearchTests.csproj
@@ -150,8 +150,8 @@
     <Reference Include="NuGet.Services.KeyVault, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Services.KeyVault.2.1.0\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Logging, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Logging.2.1.0\lib\net452\NuGet.Services.Logging.dll</HintPath>
+    <Reference Include="NuGet.Services.Logging, Version=2.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Logging.2.1.1\lib\net452\NuGet.Services.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/tests/NuGet.Services.BasicSearchTests/packages.config
+++ b/tests/NuGet.Services.BasicSearchTests/packages.config
@@ -30,7 +30,7 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Services.Configuration" version="2.1.0" targetFramework="net452" />
   <package id="NuGet.Services.KeyVault" version="2.1.0" targetFramework="net452" />
-  <package id="NuGet.Services.Logging" version="2.1.0" targetFramework="net452" />
+  <package id="NuGet.Services.Logging" version="2.1.1" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="Serilog" version="2.0.0" targetFramework="net452" />
   <package id="Serilog.Enrichers.Environment" version="2.1.0" targetFramework="net452" />


### PR DESCRIPTION
* Verified change by deploying a job and checking that Application Insights logging still works.
* Pinned NuGet.Services.Logging 2.1.1 in myget.org.