### PR TITLE
Filter semver2 results from Version list

### DIFF
--- a/src/NuGet.Indexing/Handlers/VersionsHandler.cs
+++ b/src/NuGet.Indexing/Handlers/VersionsHandler.cs
@@ -96,12 +96,13 @@ namespace NuGet.Indexing
                     downloads = downloadsByVersion[versionStr];
                 }
 
-                result.VersionDetails.Add(new VersionDetail
+                result.AllVersionDetails.Add(new VersionDetail
                 {
                     Version = versionStr,
                     Downloads = downloads,
                     IsStable = !registrationEntry.Version.IsPrerelease,
-                    IsListed = registrationEntry.IsListed
+                    IsListed = registrationEntry.IsListed,
+                    IsSemVer2 = registrationEntry.Version.IsSemVer2
                 });
             }
 

--- a/src/NuGet.Indexing/NuGetIndexSearcher.cs
+++ b/src/NuGet.Indexing/NuGetIndexSearcher.cs
@@ -95,7 +95,7 @@ namespace NuGet.Indexing
 
         public static int TotalDownloadCounts(VersionResult versions)
         {
-            int allVersions = versions.VersionDetails.Select(v => v.Downloads).Sum();
+            int allVersions = versions.AllVersionDetails.Select(v => v.Downloads).Sum();
 
             return allVersions;
         }
@@ -104,7 +104,7 @@ namespace NuGet.Indexing
         {
             int allVersions = TotalDownloadCounts(versions);
 
-            int thisVersion = versions.VersionDetails
+            int thisVersion = versions.AllVersionDetails
                 .Where(v => v.Version.Equals(version, StringComparison.OrdinalIgnoreCase))
                 .Select(v => v.Downloads)
                 .FirstOrDefault();

--- a/src/NuGet.Indexing/NuGetSearcherManager.cs
+++ b/src/NuGet.Indexing/NuGetSearcherManager.cs
@@ -365,16 +365,16 @@ namespace NuGet.Indexing
             using (var writer = new JsonTextWriter(new StreamWriter(new MemoryStream())))
             {
                 ResponseFormatter.WriteV2Result(writer, searcher, topDocs1, 0, 250, SemVerHelpers.SemVer2Level);
-                ResponseFormatter.WriteSearchResult(writer, searcher, "http", topDocs1, 0, 250, false, false, boostedQuery);
+                ResponseFormatter.WriteSearchResult(writer, searcher, "http", topDocs1, 0, 250, false, false, SemVerHelpers.SemVer2Level, boostedQuery);
 
                 ResponseFormatter.WriteV2Result(writer, searcher, topDocs2, 0, 250, SemVerHelpers.SemVer2Level);
-                ResponseFormatter.WriteSearchResult(writer, searcher, "http", topDocs2, 0, 250, false, false, boostedQuery);
+                ResponseFormatter.WriteSearchResult(writer, searcher, "http", topDocs2, 0, 250, false, false, SemVerHelpers.SemVer2Level, boostedQuery);
 
                 ResponseFormatter.WriteV2Result(writer, searcher, topDocs3, 0, 250, SemVerHelpers.SemVer2Level);
-                ResponseFormatter.WriteSearchResult(writer, searcher, "http", topDocs3, 0, 250, false, false, boostedQuery);
+                ResponseFormatter.WriteSearchResult(writer, searcher, "http", topDocs3, 0, 250, false, false, SemVerHelpers.SemVer2Level, boostedQuery);
 
                 ResponseFormatter.WriteV2Result(writer, searcher, topDocs4, 0, 250, SemVerHelpers.SemVer2Level);
-                ResponseFormatter.WriteSearchResult(writer, searcher, "http", topDocs4, 0, 250, false, false, boostedQuery);
+                ResponseFormatter.WriteSearchResult(writer, searcher, "http", topDocs4, 0, 250, false, false, SemVerHelpers.SemVer2Level, boostedQuery);
             }
 
             // Done, we're warm.

--- a/src/NuGet.Indexing/ResponseFormatter.cs
+++ b/src/NuGet.Indexing/ResponseFormatter.cs
@@ -14,13 +14,23 @@ namespace NuGet.Indexing
     public static class ResponseFormatter
     {
         // V3 implementation - called directly from the integrated Visual Studio client
-        public static void WriteSearchResult(JsonWriter jsonWriter, NuGetIndexSearcher searcher, string scheme, TopDocs topDocs, int skip, int take, bool includePrerelease, bool includeExplanation, Query query)
+        public static void WriteSearchResult(
+            JsonWriter jsonWriter,
+            NuGetIndexSearcher searcher,
+            string scheme,
+            TopDocs topDocs,
+            int skip,
+            int take,
+            bool includePrerelease,
+            bool includeExplanation,
+            NuGetVersion semVerLevel,
+            Query query)
         {
             Uri baseAddress = searcher.Manager.RegistrationBaseAddress[scheme];
 
             jsonWriter.WriteStartObject();
             WriteInfo(jsonWriter, baseAddress, searcher, topDocs);
-            WriteData(jsonWriter, searcher, topDocs, skip, take, baseAddress, includePrerelease, includeExplanation, query);
+            WriteData(jsonWriter, searcher, topDocs, skip, take, baseAddress, includePrerelease, includeExplanation, semVerLevel, query);
             jsonWriter.WriteEndObject();
         }
 
@@ -47,7 +57,17 @@ namespace NuGet.Indexing
             jsonWriter.WriteEndObject();
         }
 
-        private static void WriteData(JsonWriter jsonWriter, NuGetIndexSearcher searcher, TopDocs topDocs, int skip, int take, Uri baseAddress, bool includePrerelease, bool includeExplanation, Query query)
+        private static void WriteData(
+            JsonWriter jsonWriter, 
+            NuGetIndexSearcher searcher, 
+            TopDocs topDocs,
+            int skip,
+            int take,
+            Uri baseAddress,
+            bool includePrerelease,
+            bool includeExplanation,
+            NuGetVersion semVerLevel,
+            Query query)
         {
             jsonWriter.WritePropertyName("data");
 
@@ -81,8 +101,8 @@ namespace NuGet.Indexing
                 WriteDocumentValue(jsonWriter, "projectUrl", document, "ProjectUrl");
                 WriteDocumentValueAsArray(jsonWriter, "tags", document, "Tags");
                 WriteDocumentValueAsArray(jsonWriter, "authors", document, "Authors", true);
-                WriteProperty(jsonWriter, "totalDownloads", searcher.Versions[scoreDoc.Doc].VersionDetails.Select(item => item.Downloads).Sum());
-                WriteVersions(jsonWriter, baseAddress, id, includePrerelease, searcher.Versions[scoreDoc.Doc]);
+                WriteProperty(jsonWriter, "totalDownloads", searcher.Versions[scoreDoc.Doc].AllVersionDetails.Select(item => item.Downloads).Sum());
+                WriteVersions(jsonWriter, baseAddress, id, includePrerelease, semVerLevel, searcher.Versions[scoreDoc.Doc]);
 
                 if (includeExplanation)
                 {
@@ -101,15 +121,18 @@ namespace NuGet.Indexing
             Uri baseAddress,
             string id,
             bool includePrerelease,
+            NuGetVersion semVerLevel,
             VersionResult versionResult)
         {
+            var includeSemVer2 = SemVerHelpers.ShouldIncludeSemVer2Results(semVerLevel);
+
             jsonWriter.WritePropertyName("versions");
 
             jsonWriter.WriteStartArray();
 
             var results = includePrerelease
-                ? versionResult.VersionDetails
-                : versionResult.StableVersionDetails;
+                ? (includeSemVer2 ? versionResult.SemVer2VersionDetails : versionResult.LegacyVersionDetails)
+                : (includeSemVer2 ? versionResult.StableSemVer2VersionDetails : versionResult.StableLegacyVersionDetails);
 
             foreach (var item in results.Where(r => r.IsListed))
             {
@@ -142,11 +165,11 @@ namespace NuGet.Indexing
             jsonWriter.WriteEndObject();
         }
 
-        public static void WriteAutoCompleteVersionResult(JsonWriter jsonWriter, NuGetIndexSearcher searcher, bool includePrerelease, TopDocs topDocs)
+        public static void WriteAutoCompleteVersionResult(JsonWriter jsonWriter, NuGetIndexSearcher searcher, bool includePrerelease, NuGetVersion semVerLevel, TopDocs topDocs)
         {
             jsonWriter.WriteStartObject();
             WriteInfo(jsonWriter, null, searcher, topDocs);
-            WriteVersions(jsonWriter, searcher, includePrerelease, topDocs);
+            WriteVersions(jsonWriter, searcher, includePrerelease, semVerLevel, topDocs);
             jsonWriter.WriteEndObject();
         }
 
@@ -177,8 +200,10 @@ namespace NuGet.Indexing
             jsonWriter.WriteEndArray();
         }
 
-        private static void WriteVersions(JsonWriter jsonWriter, NuGetIndexSearcher searcher, bool includePrerelease, TopDocs topDocs)
+        private static void WriteVersions(JsonWriter jsonWriter, NuGetIndexSearcher searcher, bool includePrerelease, NuGetVersion semVerLevel, TopDocs topDocs)
         {
+            var includeSemVer2 = SemVerHelpers.ShouldIncludeSemVer2Results(semVerLevel);
+
             jsonWriter.WritePropertyName("data");
             jsonWriter.WriteStartArray();
 
@@ -187,8 +212,8 @@ namespace NuGet.Indexing
                 ScoreDoc scoreDoc = topDocs.ScoreDocs[0];
 
                 var versions = includePrerelease
-                    ? searcher.Versions[scoreDoc.Doc].GetVersions(onlyListed: true)
-                    : searcher.Versions[scoreDoc.Doc].GetStableVersions(onlyListed: true);
+                    ? searcher.Versions[scoreDoc.Doc].GetVersions(onlyListed: true, includeSemVer2: includeSemVer2)
+                    : searcher.Versions[scoreDoc.Doc].GetStableVersions(onlyListed: true, includeSemVer2: includeSemVer2);
 
                 foreach (var version in versions)
                 {

--- a/src/NuGet.Indexing/ServiceImpl.cs
+++ b/src/NuGet.Indexing/ServiceImpl.cs
@@ -40,7 +40,7 @@ namespace NuGet.Indexing
 
                 TopDocs topDocs = searcher.Search(query, skip + take);
 
-                ResponseFormatter.WriteSearchResult(jsonWriter, searcher, scheme, topDocs, skip, take, includePrerelease, includeExplanation, query);
+                ResponseFormatter.WriteSearchResult(jsonWriter, searcher, scheme, topDocs, skip, take, includePrerelease, includeExplanation, semVerLevel, query);
             }
             finally
             {
@@ -92,7 +92,7 @@ namespace NuGet.Indexing
                     }
 
                     TopDocs topDocs = searcher.Search(query, 1);
-                    ResponseFormatter.WriteAutoCompleteVersionResult(jsonWriter, searcher, includePrerelease, topDocs);
+                    ResponseFormatter.WriteAutoCompleteVersionResult(jsonWriter, searcher, includePrerelease, semVerLevel, topDocs);
                 }
             }
             finally

--- a/src/NuGet.Indexing/VersionDetail.cs
+++ b/src/NuGet.Indexing/VersionDetail.cs
@@ -12,5 +12,6 @@ namespace NuGet.Indexing
         public int Downloads { get; set; }
         public bool IsStable { get; set; }
         public bool IsListed { get; set; }
+        public bool IsSemVer2 { get; set; }
     }
 }

--- a/src/NuGet.Indexing/VersionResult.cs
+++ b/src/NuGet.Indexing/VersionResult.cs
@@ -10,21 +10,37 @@ namespace NuGet.Indexing
     {
         public VersionResult()
         {
-            VersionDetails = new List<VersionDetail>();
+            AllVersionDetails = new List<VersionDetail>();
         }
 
-        public List<VersionDetail> VersionDetails { get; private set; }
+        public List<VersionDetail> AllVersionDetails { get; private set; }
 
-        public IEnumerable<string> GetVersions(bool onlyListed)
+        public IEnumerable<VersionDetail> SemVer2VersionDetails { get { return AllVersionDetails; } }
+
+        public IEnumerable<VersionDetail> LegacyVersionDetails { get { return AllVersionDetails.Where(v => !v.IsSemVer2); } }
+
+        public IEnumerable<string> GetVersions(bool onlyListed, bool includeSemVer2)
         {
-            return VersionDetails.Where(v => !onlyListed || v.IsListed).Select(v => v.Version);
+            if (includeSemVer2)
+            {
+                return SemVer2VersionDetails.Where(v => !onlyListed || v.IsListed).Select(v => v.Version);
+            }
+
+            return LegacyVersionDetails.Where(v => !onlyListed || v.IsListed).Select(v => v.Version);
         }
 
-        public IEnumerable<string> GetStableVersions(bool onlyListed)
+        public IEnumerable<string> GetStableVersions(bool onlyListed, bool includeSemVer2)
         {
-            return StableVersionDetails.Where(v => !onlyListed || v.IsListed).Select(v => v.Version);
+            if (includeSemVer2)
+            {
+                return StableSemVer2VersionDetails.Where(v => !onlyListed || v.IsListed).Select(v => v.Version);
+            }
+
+            return StableLegacyVersionDetails.Where(v => !onlyListed || v.IsListed).Select(v => v.Version);
         }
 
-        public IEnumerable<VersionDetail> StableVersionDetails { get { return VersionDetails.Where(v => v.IsStable); } }
+        public IEnumerable<VersionDetail> StableLegacyVersionDetails { get { return AllVersionDetails.Where(v => v.IsStable && !v.IsSemVer2); } }
+
+        public IEnumerable<VersionDetail> StableSemVer2VersionDetails { get { return AllVersionDetails.Where(v => v.IsStable); } }
     }
 }

--- a/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
+++ b/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
@@ -202,6 +202,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestSupport\TokenAttributes.cs" />
     <Compile Include="TestSupport\TokenStreamExtensions.cs" />
+    <Compile Include="VersionResultTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/tests/NuGet.IndexingTests/ResponseFormatterTests.cs
+++ b/tests/NuGet.IndexingTests/ResponseFormatterTests.cs
@@ -138,7 +138,7 @@ namespace NuGet.IndexingTests
 
             using (var writer = new JsonTextWriter(sw))
             {
-                ResponseFormatter.WriteAutoCompleteVersionResult(writer, searcher, includePrerelease, topDocs);
+                ResponseFormatter.WriteAutoCompleteVersionResult(writer, searcher, includePrerelease, SemVerHelpers.SemVer2Level, topDocs);
 
                 Assert.Equal(string.Format(expected, searcher.LastReopen), sb.ToString());
             }
@@ -166,7 +166,7 @@ namespace NuGet.IndexingTests
 
             using (var writer = new JsonTextWriter(sw))
             {
-                ResponseFormatter.WriteSearchResult(writer, searcher, Constants.SchemeName, topDocs, skip, take, includePrerelease, includeExplanation, NuGetQuery.MakeQuery("test"));
+                ResponseFormatter.WriteSearchResult(writer, searcher, Constants.SchemeName, topDocs, skip, take, includePrerelease, includeExplanation, SemVerHelpers.SemVer2Level, NuGetQuery.MakeQuery("test"));
 
                 Assert.Equal(string.Format(expected,
                     Constants.BaseUri,

--- a/tests/NuGet.IndexingTests/VersionResultTests.cs
+++ b/tests/NuGet.IndexingTests/VersionResultTests.cs
@@ -1,0 +1,253 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Lucene.Net.Support;
+using NuGet.Indexing;
+using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace NuGet.IndexingTests
+{
+    public class VersionResultTests
+    {
+        private readonly Random randomizer = new Random(1000000);
+
+        [Theory]
+        [MemberData(nameof(VersionStringSets))]
+        public void LegacyResultHasNoSemVer2(string[] versionSet, int expectedNumSemVer1)
+        {
+            var result = MakeVersionResult(versionSet, randomizeListing: true);
+
+            var legacyResult = result.LegacyVersionDetails;
+            Assert.Equal(expectedNumSemVer1, legacyResult.Count());
+            foreach (var details in legacyResult)
+            {
+                Assert.True(!details.IsSemVer2);
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(VersionStringSets))]
+        public void SemVer2ResultContainsAllVersion(string[] versionSet, int expectedNumSemVer1)
+        {
+            var result = MakeVersionResult(versionSet, randomizeListing: true);
+
+            var semVer2Result = result.SemVer2VersionDetails;
+            Assert.True(semVer2Result.Count() >= expectedNumSemVer1);
+            Assert.True(semVer2Result.Count() == versionSet.Length);
+        }
+
+        [Theory]
+        [MemberData(nameof(VersionStringSets))]
+        public void StableResultContainsNoPrerelVersion(string[] versionSet, int expectedNumSemVer1)
+        {
+            var result = MakeVersionResult(versionSet, randomizeListing: true);
+
+            var semVer2StableResult = result.GetStableVersions(onlyListed: false, includeSemVer2: true);
+            var semVer2StableListedResult = result.GetStableVersions(onlyListed: true, includeSemVer2: true);
+            var semVer1StableResult = result.GetStableVersions(onlyListed: false, includeSemVer2: false);
+            var semVer1StableListedResult = result.GetStableVersions(onlyListed: true, includeSemVer2: false);
+
+            var semVer2StableCount = 0;
+            var semVer2StableListedCount = 0;
+            var semVer1StableCount = 0;
+            var semVer1StableListedCount = 0;
+
+            foreach (var details in semVer2StableResult)
+            {
+                var version = NuGetVersion.Parse(details);
+                Assert.True(!version.IsPrerelease);
+                semVer2StableCount++;
+            }
+
+            foreach (var details in semVer2StableListedResult)
+            {
+                var version = NuGetVersion.Parse(details);
+                Assert.True(!version.IsPrerelease);
+                semVer2StableListedCount++;
+            }
+
+            foreach (var details in semVer1StableResult)
+            {
+                var version = NuGetVersion.Parse(details);
+                Assert.True(!version.IsPrerelease);
+                semVer1StableCount++;
+            }
+
+            foreach (var details in semVer1StableListedResult)
+            {
+                var version = NuGetVersion.Parse(details);
+                Assert.True(!version.IsPrerelease);
+                semVer1StableListedCount++;
+            }
+
+            Assert.True(semVer2StableCount >= semVer1StableCount);
+            Assert.True(semVer2StableCount >= semVer2StableListedCount);
+            Assert.True(semVer1StableCount >= semVer1StableListedCount);
+            Assert.True(semVer2StableListedCount >= semVer1StableListedCount);
+        }
+
+        [Theory]
+        [MemberData(nameof(VersionStringSets))]
+        public void ListedOnlyReturnsListed(string[] versionSet, int expectedNumSemVer1)
+        {
+            var result = MakeVersionResult(versionSet, randomizeListing: true);
+
+            var listedMap = new HashMap<string, VersionDetail>();
+            var listedPackages = result.AllVersionDetails.Where(x => x.IsListed);
+            foreach(var detail in listedPackages)
+            {
+                listedMap.Add(detail.Version, detail);
+            }
+
+            var semVer2ListedResult = result.GetVersions(onlyListed: true, includeSemVer2: true);
+            var semVer1ListedResult = result.GetVersions(onlyListed: true, includeSemVer2: false);
+
+            Assert.True(semVer2ListedResult.Count() <= listedMap.Count);
+            foreach(var version in semVer2ListedResult)
+            {
+                Assert.True(listedMap.ContainsKey(version));
+            }
+
+            Assert.True(semVer1ListedResult.Count() <= listedMap.Count);
+            Assert.True(semVer1ListedResult.Count() <= semVer2ListedResult.Count());
+            foreach (var version in semVer1ListedResult)
+            {
+                Assert.True(listedMap.ContainsKey(version));
+                var versionResult = listedMap[version];
+                Assert.True(versionResult.IsListed);
+                Assert.True(!versionResult.IsSemVer2);
+            }
+
+        }
+
+        private VersionResult MakeVersionResult(string[] versions, bool randomizeListing = false, bool listAll = true)
+        {
+            var versionResult1 = new VersionResult();
+            foreach (var versionString in versions)
+            {
+                versionResult1.AllVersionDetails.Add(MakeVersionDetail(versionString, randomizeListing ? (randomizer.Next(100) >= 50 ? true : false ) : listAll));
+            }
+
+            return versionResult1;
+        }
+
+        private VersionDetail MakeVersionDetail(string version, bool listed)
+        {
+            NuGetVersion parsedVersion;
+            if (NuGetVersion.TryParse(version, out parsedVersion))
+            {
+                return new VersionDetail
+                {
+                    Downloads = 0,
+                    Version = parsedVersion.ToNormalizedString(),
+                    IsListed = listed,
+                    IsStable = !parsedVersion.IsPrerelease,
+                    IsSemVer2 = parsedVersion.IsSemVer2
+                };
+            }
+
+            return new VersionDetail
+            {
+                Downloads = 0,
+                Version = parsedVersion.ToNormalizedString(),
+                IsListed = listed,
+                IsStable = !parsedVersion.IsPrerelease,
+                IsSemVer2 = parsedVersion.IsSemVer2
+            };
+        }
+
+        public static IEnumerable<object[]> VersionStringSets
+        {
+            get
+            {
+                yield return new object[]
+                {
+                    // latest semVer1 stable, no semVer2
+                    new string[]
+                    {
+                        "1.0.0"
+                    },
+                    1
+                };
+
+                yield return new object[]
+                {
+                    // latest semVer1 prerel, no semVer2
+                    new string[]
+                    {
+                        "1.0.0",
+                        "2.0.0-prerel"
+                    },
+                    2
+                };
+
+                yield return new object[]
+                {
+                    // latest SemVer1 stable, including SemVer2
+                    new string[]
+                    {
+                        "1.0.0-pre.3+semVer2",
+                        "3.0.0+semVer2",
+                        "4.0.0"
+                    },
+                    1
+                };
+
+                yield return new object[]
+                {
+                    // latest SemVer1 prerel, including SemVer2
+                    new string[]
+                    {
+                        "1.0.0-pre.3+semVer2",
+                        "3.0.0+semVer2",
+                        "4.0.0",
+                        "4.0.6-prerel"
+                    },
+                    2
+                };
+
+                yield return new object[]
+                {
+                    // latest SemVer2 stable, including SemVer1
+                    new string[]
+                    {
+                        "1.0.0-pre.3+semVer2",
+                        "4.0.0",
+                        "4.0.6-prerel",
+                        "6.0.0+semVer2"
+                    },
+                    2
+                };
+
+                yield return new object[]
+                {
+                    // latest SemVer2 prerel, including SemVer1
+                    new string[]
+                    {
+                        "1.0.0-pre.3+semVer2",
+                        "4.0.0",
+                        "4.0.6-prerel",
+                        "6.0.0+semVer2",
+                        "6.0.5-pre.2+semVer2"
+                    },
+                    2
+                };
+
+                yield return new object[]
+                {
+                    // latest SemVer2
+                    new string[]
+                    {
+                        "1.0.0-pre.3+semVer2",
+                        "6.0.0+semVer2"
+                    },
+                    0
+                };
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the filtering of semver2 versions from the list of versions on a search result.
Addresses issue https://github.com/NuGet/NuGetGallery/issues/3754

@joelverhagen @xavierdecoster 