### PR TITLE
Adding SemVer2 awareness to search result registration values.

### DIFF
--- a/src/NuGet.Indexing/IndexingConfiguration.cs
+++ b/src/NuGet.Indexing/IndexingConfiguration.cs
@@ -40,8 +40,12 @@ namespace NuGet.Indexing
         public string LocalLuceneDirectory { get; set; }
 
         [ConfigurationKeyPrefix(SearchPrefix)]
-        [DefaultValue("http://api.nuget.org/v3/registration0/")]
+        [DefaultValue("http://api.nuget.org/v3/registration1/")]
         public string RegistrationBaseAddress { get; set; }
+
+        [ConfigurationKeyPrefix(SearchPrefix)]
+        [DefaultValue("http://api.nuget.org/v3/registration2-gz-semver2/")]
+        public string SemVer2RegistrationBaseAddress { get; set; }
 
         [ConfigurationKeyPrefix(StoragePrefix)]
         [ConfigurationKey("Primary")]

--- a/src/NuGet.Indexing/NuGet.Indexing.csproj
+++ b/src/NuGet.Indexing/NuGet.Indexing.csproj
@@ -311,6 +311,7 @@
     <Compile Include="RankingBySegment.cs" />
     <Compile Include="RankingResult.cs" />
     <Compile Include="Handlers\RankingsHandler.cs" />
+    <Compile Include="RegistrationAddresses.cs" />
     <Compile Include="ResponseFormatter.cs" />
     <Compile Include="Retry.cs" />
     <Compile Include="IndexingConfiguration.cs" />

--- a/src/NuGet.Indexing/NuGetSearcherManager.cs
+++ b/src/NuGet.Indexing/NuGetSearcherManager.cs
@@ -26,7 +26,7 @@ namespace NuGet.Indexing
         public virtual DateTime? LastIndexReloadTime { get; private set; } = null;
         public virtual DateTime? LastAuxiliaryDataLoadTime { get; private set; } = null;
         public virtual string MachineName => Environment.MachineName;
-        public RegistrationAddresses RegistrationBaseAddresses { get; }
+        public RegistrationBaseAddresses RegistrationBaseAddresses { get; }
 
         private readonly FrameworkLogger _logger;
         private readonly IIndexDirectoryProvider _indexProvider;
@@ -53,7 +53,7 @@ namespace NuGet.Indexing
 
             _logger = logger;
 
-            RegistrationBaseAddresses = new RegistrationAddresses();
+            RegistrationBaseAddresses = new RegistrationBaseAddresses();
 
             _indexProvider = indexProvider;
             _loader = loader;
@@ -124,10 +124,10 @@ namespace NuGet.Indexing
             var registrationBaseAddress = config.RegistrationBaseAddress;
             var semVer2RegistrationBaseAddress = config.SemVer2RegistrationBaseAddress;
 
-            searcherManager.RegistrationBaseAddresses.HttpRegistrationAddress = MakeRegistrationBaseAddress("http", registrationBaseAddress);
-            searcherManager.RegistrationBaseAddresses.HttpsRegistrationAddress = MakeRegistrationBaseAddress("https", registrationBaseAddress);
-            searcherManager.RegistrationBaseAddresses.SemVer2HttpRegistrationAddress = MakeRegistrationBaseAddress("http", semVer2RegistrationBaseAddress);
-            searcherManager.RegistrationBaseAddresses.SemVer2HttpsRegistrationAddress = MakeRegistrationBaseAddress("https", semVer2RegistrationBaseAddress);
+            searcherManager.RegistrationBaseAddresses.LegacyHttp = MakeRegistrationBaseAddress("http", registrationBaseAddress);
+            searcherManager.RegistrationBaseAddresses.LegacyHttps = MakeRegistrationBaseAddress("https", registrationBaseAddress);
+            searcherManager.RegistrationBaseAddresses.SemVer2Http = MakeRegistrationBaseAddress("http", semVer2RegistrationBaseAddress);
+            searcherManager.RegistrationBaseAddresses.SemVer2Https = MakeRegistrationBaseAddress("https", semVer2RegistrationBaseAddress);
 
             return searcherManager;
         }

--- a/src/NuGet.Indexing/NuGetSearcherManager.cs
+++ b/src/NuGet.Indexing/NuGetSearcherManager.cs
@@ -26,7 +26,7 @@ namespace NuGet.Indexing
         public virtual DateTime? LastIndexReloadTime { get; private set; } = null;
         public virtual DateTime? LastAuxiliaryDataLoadTime { get; private set; } = null;
         public virtual string MachineName => Environment.MachineName;
-        public IDictionary<string, Uri> RegistrationBaseAddress { get; }
+        public RegistrationAddresses RegistrationBaseAddresses { get; }
 
         private readonly FrameworkLogger _logger;
         private readonly IIndexDirectoryProvider _indexProvider;
@@ -53,7 +53,7 @@ namespace NuGet.Indexing
 
             _logger = logger;
 
-            RegistrationBaseAddress = new Dictionary<string, Uri>();
+            RegistrationBaseAddresses = new RegistrationAddresses();
 
             _indexProvider = indexProvider;
             _loader = loader;
@@ -122,8 +122,12 @@ namespace NuGet.Indexing
             var searcherManager = new NuGetSearcherManager(logger, indexProvider, loader, config.AuxiliaryDataRefreshRateSec, config.IndexReloadRateSec);
 
             var registrationBaseAddress = config.RegistrationBaseAddress;
-            searcherManager.RegistrationBaseAddress["http"] = MakeRegistrationBaseAddress("http", registrationBaseAddress);
-            searcherManager.RegistrationBaseAddress["https"] = MakeRegistrationBaseAddress("https", registrationBaseAddress);
+            var semVer2RegistrationBaseAddress = config.SemVer2RegistrationBaseAddress;
+
+            searcherManager.RegistrationBaseAddresses.HttpRegistrationAddress = MakeRegistrationBaseAddress("http", registrationBaseAddress);
+            searcherManager.RegistrationBaseAddresses.HttpsRegistrationAddress = MakeRegistrationBaseAddress("https", registrationBaseAddress);
+            searcherManager.RegistrationBaseAddresses.SemVer2HttpRegistrationAddress = MakeRegistrationBaseAddress("http", semVer2RegistrationBaseAddress);
+            searcherManager.RegistrationBaseAddresses.SemVer2HttpsRegistrationAddress = MakeRegistrationBaseAddress("https", semVer2RegistrationBaseAddress);
 
             return searcherManager;
         }

--- a/src/NuGet.Indexing/RegistrationAddresses.cs
+++ b/src/NuGet.Indexing/RegistrationAddresses.cs
@@ -5,11 +5,11 @@ using System;
 
 namespace NuGet.Indexing
 {
-    public class RegistrationAddresses
+    public class RegistrationBaseAddresses
     {
-        public Uri HttpRegistrationAddress { get; set; }
-        public Uri HttpsRegistrationAddress { get; set; }
-        public Uri SemVer2HttpRegistrationAddress { get; set; }
-        public Uri SemVer2HttpsRegistrationAddress { get; set; }
+        public Uri LegacyHttp { get; set; }
+        public Uri LegacyHttps { get; set; }
+        public Uri SemVer2Http { get; set; }
+        public Uri SemVer2Https { get; set; }
     }
 }

--- a/src/NuGet.Indexing/RegistrationAddresses.cs
+++ b/src/NuGet.Indexing/RegistrationAddresses.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Indexing
+{
+    public class RegistrationAddresses
+    {
+        public Uri HttpRegistrationAddress { get; set; }
+        public Uri HttpsRegistrationAddress { get; set; }
+        public Uri SemVer2HttpRegistrationAddress { get; set; }
+        public Uri SemVer2HttpsRegistrationAddress { get; set; }
+    }
+}

--- a/src/NuGet.Indexing/ResponseFormatter.cs
+++ b/src/NuGet.Indexing/ResponseFormatter.cs
@@ -28,21 +28,17 @@ namespace NuGet.Indexing
         {
             Uri baseAddress;
             var useSemVer2Registration = SemVerHelpers.ShouldIncludeSemVer2Results(semVerLevel);
-            RegistrationAddresses registrationAddresses = searcher.Manager.RegistrationBaseAddresses;
+            RegistrationBaseAddresses registrationAddresses = searcher.Manager.RegistrationBaseAddresses;
 
             switch (scheme)
             {
-                case "http":
-                    baseAddress = (useSemVer2Registration ? registrationAddresses.SemVer2HttpRegistrationAddress : registrationAddresses.HttpRegistrationAddress);
-                    break;
                 case "https":
-                    baseAddress = (useSemVer2Registration ? registrationAddresses.SemVer2HttpsRegistrationAddress : registrationAddresses.HttpsRegistrationAddress);
+                    baseAddress = (useSemVer2Registration ? registrationAddresses.SemVer2Https : registrationAddresses.LegacyHttps);
                     break;
-                case "test":
-                    // this case is explicitly for test purposes. When ResponseFormatterTests calls into this, it calls with "test" scheme, which we will then return the default value.
+                case "http":
                 default:
-                    // if scheme specified is invalid, fall back to the most widely compatible version
-                    baseAddress = registrationAddresses.HttpRegistrationAddress;
+                    // if scheme specified is invalid, fall back to using as much information as we can
+                    baseAddress = (useSemVer2Registration ? registrationAddresses.SemVer2Http : registrationAddresses.LegacyHttp);
                     break;
             }
 

--- a/src/NuGet.Services.BasicSearch/Web.config
+++ b/src/NuGet.Services.BasicSearch/Web.config
@@ -24,6 +24,7 @@
     <add key="Search.DataContainer" value="" />
     <add key="Search.IndexRefresh" value="" />
     <add key="Search.RegistrationBaseAddress" value="" />
+    <add key="Search.SemVer2RegistrationBaseAddress" value="" />
     <add key="Search.AuxiliaryDataRefreshRateSec" value="" />
     <add key="Search.IndexReloadRateSec" value="" />
     <add key="owin:AppStartup" value="NuGet.Services.BasicSearch.Startup" />

--- a/tests/NuGet.IndexingTests/ResponseFormatterTests.cs
+++ b/tests/NuGet.IndexingTests/ResponseFormatterTests.cs
@@ -9,6 +9,7 @@ using Lucene.Net.Search;
 using Newtonsoft.Json;
 using NuGet.Indexing;
 using NuGet.IndexingTests.TestSupport;
+using NuGet.Versioning;
 using Xunit;
 
 namespace NuGet.IndexingTests
@@ -156,6 +157,9 @@ namespace NuGet.IndexingTests
             int take,
             bool includePrerelease,
             bool includeExplanation,
+            NuGetVersion semVerlLevel,
+            string scheme,
+            string expectedBaseUrl,
             string expected)
         {
             var searcher = new MockSearcher(indexName, numDocs, commitUserData, versions: Constants.VersionResults);
@@ -166,10 +170,10 @@ namespace NuGet.IndexingTests
 
             using (var writer = new JsonTextWriter(sw))
             {
-                ResponseFormatter.WriteSearchResult(writer, searcher, Constants.SchemeName, topDocs, skip, take, includePrerelease, includeExplanation, SemVerHelpers.SemVer2Level, NuGetQuery.MakeQuery("test"));
+                ResponseFormatter.WriteSearchResult(writer, searcher, scheme, topDocs, skip, take, includePrerelease, includeExplanation, semVerlLevel, NuGetQuery.MakeQuery("test"));
 
                 Assert.Equal(string.Format(expected,
-                    Constants.BaseUri,
+                    expectedBaseUrl,
                     searcher.LastReopen,
                     Constants.MockBase.ToLower(),
                     Constants.LucenePropertyId.ToLower(),
@@ -445,6 +449,26 @@ namespace NuGet.IndexingTests
                     0,    // take
                     false,// Include Explanation
                     false,// Include Prerelease
+                    SemVerHelpers.SemVer2Level,
+                    Constants.SchemeNameHttp,
+                    Constants.BaseUriSemVer2Http,
+                    "{{\"@context\":{{\"@vocab\":\"http://schema.nuget.org/schema#\",\"@base\":\"{0}\"}},\"totalHits\":10,\"lastReopen\":\"{1:o}\",\"index\":\"mockNoResults\",\"data\":[]}}"
+                };
+
+                yield return new object[]
+                {
+                    "mockNoResults",
+                    100,  // Num docs in index
+                    new Dictionary<string, string> { },
+                    10,   // Top Docs Total Hits
+                    1.0,  // Top Docs Max Score
+                    0,    // skip
+                    0,    // take
+                    false,// Include Explanation
+                    false,// Include Prerelease
+                    SemVerHelpers.SemVer2Level,
+                    Constants.SchemeNameHttps,
+                    Constants.BaseUriSemVer2Https,
                     "{{\"@context\":{{\"@vocab\":\"http://schema.nuget.org/schema#\",\"@base\":\"{0}\"}},\"totalHits\":10,\"lastReopen\":\"{1:o}\",\"index\":\"mockNoResults\",\"data\":[]}}"
                 };
 
@@ -460,6 +484,9 @@ namespace NuGet.IndexingTests
                     2,    // take
                     true, // Include Explanation
                     false,// Include Prerelease
+                    SemVerHelpers.SemVer1Level,
+                    Constants.SchemeNameHttp,
+                    Constants.BaseUriHttp,
                     "{{\"@context\":{{\"@vocab\":\"http://schema.nuget.org/schema#\",\"@base\":\"{0}\"}},\"totalHits\":1,\"lastReopen\":\"{1:o}\",\"index\":\"{2}IncludeExplanations\",\"data\":[{{\"@id\":\"{0}{2}{3}0/index.json\",\"@type\":\"Package\",\"registration\":\"{0}{2}{3}0/index.json\",\"id\":\"{4}{5}0\",\"version\":\"{4}{6}0\",\"description\":\"{4}{7}0\",\"summary\":\"{4}{8}0\",\"title\":\"{4}{9}0\",\"iconUrl\":\"{4}{10}0\",\"licenseUrl\":\"{4}{11}0\",\"projectUrl\":\"{4}{12}0\",\"totalDownloads\":0,\"versions\":[]}},{{\"@id\":\"{0}{2}{3}1/index.json\",\"@type\":\"Package\",\"registration\":\"{0}{2}{3}1/index.json\",\"id\":\"{4}{5}1\",\"version\":\"{4}{6}1\",\"description\":\"{4}{7}1\",\"summary\":\"{4}{8}1\",\"title\":\"{4}{9}1\",\"iconUrl\":\"{4}{10}1\",\"licenseUrl\":\"{4}{11}1\",\"projectUrl\":\"{4}{12}1\",\"totalDownloads\":0,\"versions\":[]}}]}}"
                 };
 
@@ -475,6 +502,9 @@ namespace NuGet.IndexingTests
                     0,    // take
                     false,// Include Explanation
                     false,// Include Prerelease
+                    SemVerHelpers.SemVer1Level,
+                    Constants.SchemeNameHttps,
+                    Constants.BaseUriHttps,
                     "{{\"@context\":{{\"@vocab\":\"http://schema.nuget.org/schema#\",\"@base\":\"{0}\"}},\"totalHits\":10,\"lastReopen\":\"{1:o}\",\"index\":\"mockNoExplanation\",\"data\":[]}}"
                 };
             }

--- a/tests/NuGet.IndexingTests/TestSupport/Constants.cs
+++ b/tests/NuGet.IndexingTests/TestSupport/Constants.cs
@@ -12,7 +12,10 @@ namespace NuGet.IndexingTests.TestSupport
 {
     public class Constants
     {
-        public static readonly string BaseUri = "http://testuri/";
+        public static readonly string BaseUriHttp = "http://testuri/";
+        public static readonly string BaseUriHttps = "https://testuri/";
+        public static readonly string BaseUriSemVer2Http = "http://testurisemver2/";
+        public static readonly string BaseUriSemVer2Https = "https://testurisemver2/";
         public static readonly string LucenePropertyIconUrl = "IconUrl";
         public static readonly string LucenePropertyId = "Id";
         public static readonly string LucenePropertyDescription = "Description";
@@ -28,7 +31,8 @@ namespace NuGet.IndexingTests.TestSupport
         public static readonly string Query = "test";
         public static readonly string RankingsIdPrefix = "testId";
         public static readonly string RankingsSegmentName = "testReader";
-        public static readonly string SchemeName = "test";
+        public static readonly string SchemeNameHttp = "http";
+        public static readonly string SchemeNameHttps = "https";
         public static readonly string SegmentReaderPrefix = "SegmentReader";
         public static readonly string SemVerLevel2Value = "2";
 

--- a/tests/NuGet.IndexingTests/TestSupport/MockSearcher.cs
+++ b/tests/NuGet.IndexingTests/TestSupport/MockSearcher.cs
@@ -47,8 +47,10 @@ namespace NuGet.IndexingTests.TestSupport
             mockAuxiliaryFiles.Setup(y => y.LastModifiedTimeForFiles).Returns(lastModifiedTimeForAuxFiles);
 
             mockSearcherManager.Setup(x => x.IndexName).Returns(indexName);
-            // HttpRegistrationAddress is the default when we call into this with "test" scheme, which is technically invalid.
-            mockSearcherManager.Object.RegistrationBaseAddresses.HttpRegistrationAddress = new Uri(Constants.BaseUri);
+            mockSearcherManager.Object.RegistrationBaseAddresses.LegacyHttp = new Uri(Constants.BaseUriHttp);
+            mockSearcherManager.Object.RegistrationBaseAddresses.LegacyHttps = new Uri(Constants.BaseUriHttps);
+            mockSearcherManager.Object.RegistrationBaseAddresses.SemVer2Http = new Uri(Constants.BaseUriSemVer2Http);
+            mockSearcherManager.Object.RegistrationBaseAddresses.SemVer2Https = new Uri(Constants.BaseUriSemVer2Https);
             mockSearcherManager.Setup(x => x.LastIndexReloadTime).Returns(time);
             mockSearcherManager.Setup(x => x.LastAuxiliaryDataLoadTime).Returns(time);
             mockSearcherManager.Setup(x => x.MachineName).Returns(machineName);

--- a/tests/NuGet.IndexingTests/TestSupport/MockSearcher.cs
+++ b/tests/NuGet.IndexingTests/TestSupport/MockSearcher.cs
@@ -47,7 +47,8 @@ namespace NuGet.IndexingTests.TestSupport
             mockAuxiliaryFiles.Setup(y => y.LastModifiedTimeForFiles).Returns(lastModifiedTimeForAuxFiles);
 
             mockSearcherManager.Setup(x => x.IndexName).Returns(indexName);
-            mockSearcherManager.Object.RegistrationBaseAddress[Constants.SchemeName] = new Uri(Constants.BaseUri);
+            // HttpRegistrationAddress is the default when we call into this with "test" scheme, which is technically invalid.
+            mockSearcherManager.Object.RegistrationBaseAddresses.HttpRegistrationAddress = new Uri(Constants.BaseUri);
             mockSearcherManager.Setup(x => x.LastIndexReloadTime).Returns(time);
             mockSearcherManager.Setup(x => x.LastAuxiliaryDataLoadTime).Returns(time);
             mockSearcherManager.Setup(x => x.MachineName).Returns(machineName);


### PR DESCRIPTION
Updates search to be able to return different registration containers in the result based on if we are responding to a SemVer2 compatible search.
Updates default registration url to point to registration1

@joelverhagen @skofman1 @xavierdecoster 