### PR TITLE
Update "originalVersion" to "verbatimVersion" for SQL query

### DIFF
--- a/src/NuGet.Indexing/Sql2Lucene.cs
+++ b/src/NuGet.Indexing/Sql2Lucene.cs
@@ -60,7 +60,7 @@ namespace NuGet.Indexing
                     SELECT
                         Packages.[Key]                          'key',
                         PackageRegistrations.Id                 'id',
-                        Packages.[Version]                      'originalVersion',
+                        Packages.[Version]                      'verbatimVersion',
                         Packages.NormalizedVersion              'version',
                         Packages.Title                          'title',
                         Packages.Tags                           'tags',


### PR DESCRIPTION
Fix for https://github.com/NuGet/NuGetGallery/issues/3827

The issue here was that when the sql query to retrieve data was made, one of the columns was being retrieved with the wrong name. When we later tried to map this property, it was missing, Fix was to update the name to the new name.

@joelverhagen @skofman1 @xavierdecoster @loic-sharma