### PR TITLE
Make use of different names of versions consistent

### DIFF
--- a/src/NuGet.Indexing/Extraction/CatalogPackageMetadataExtraction.cs
+++ b/src/NuGet.Indexing/Extraction/CatalogPackageMetadataExtraction.cs
@@ -35,7 +35,7 @@ namespace NuGet.Indexing
 
                 AddString(MetadataConstants.IdPropertyName);
                 AddString(MetadataConstants.NormalizedVersionPropertyName);
-                AddString(MetadataConstants.VersionPropertyName);
+                AddString(MetadataConstants.VerbatimVersionPropertyName);
                 AddString(MetadataConstants.TitlePropertyName);
                 AddString(MetadataConstants.DescriptionPropertyName);
                 AddString(MetadataConstants.SummaryPropertyName);
@@ -127,7 +127,7 @@ namespace NuGet.Indexing
 
             private void AddSemVerLevelKey()
             {
-                var version = (string)_catalog[MetadataConstants.VersionPropertyName];
+                var version = (string)_catalog[MetadataConstants.VerbatimVersionPropertyName];
                 if (version != null)
                 {
                     NuGetVersion packageOriginalVersion;

--- a/src/NuGet.Indexing/Extraction/DocumentCreator.cs
+++ b/src/NuGet.Indexing/Extraction/DocumentCreator.cs
@@ -106,7 +106,7 @@ namespace NuGet.Indexing
                 NuGetVersion parsedVerbatimVersion;
                 if (NuGetVersion.TryParse(verbatimVersion, out parsedVerbatimVersion))
                 {
-                    AddField(document, LuceneConstants.NormalizedVersionPropertyName, parsedVerbatimVersion.ToNormalizedString(), Field.Index.NOT_ANALYZED);
+                    AddField(document, LuceneConstants.NormalizedVersionPropertyName, parsedVerbatimVersion.ToNormalizedString(), Field.Index.ANALYZED);
                     AddField(document, LuceneConstants.FullVersionPropertyName, parsedVerbatimVersion.ToFullString(), Field.Index.NOT_ANALYZED);
                 }
                 else

--- a/src/NuGet.Indexing/Extraction/DocumentCreator.cs
+++ b/src/NuGet.Indexing/Extraction/DocumentCreator.cs
@@ -99,41 +99,24 @@ namespace NuGet.Indexing
         private static void AddVersion(Document document, IDictionary<string, string> package, List<string> errors)
         {
             string verbatimVersion;
-            if (package.TryGetValue(MetadataConstants.VersionPropertyName, out verbatimVersion))
+            if (package.TryGetValue(MetadataConstants.VerbatimVersionPropertyName, out verbatimVersion))
             {
-                AddField(document, LuceneConstants.VersionPropertyName, verbatimVersion, Field.Index.NOT_ANALYZED);
-            }
-            else
-            {
-                errors.Add($"Required property '{MetadataConstants.VersionPropertyName}' not found.");
-            }
+                AddField(document, LuceneConstants.VerbatimVersionPropertyName, verbatimVersion, Field.Index.NOT_ANALYZED);
 
-            string version;
-            if (!package.TryGetValue(MetadataConstants.NormalizedVersionPropertyName, out version))
-            {
-                if (verbatimVersion != null)
+                NuGetVersion parsedVerbatimVersion;
+                if (NuGetVersion.TryParse(verbatimVersion, out parsedVerbatimVersion))
                 {
-                    NuGetVersion nuGetVersion;
-                    if (NuGetVersion.TryParse(verbatimVersion, out nuGetVersion))
-                    {
-                        version = nuGetVersion.ToNormalizedString();
-                    }
-                    else
-                    {
-                        errors.Add($"Unable to parse '{MetadataConstants.VersionPropertyName}' as NuGetVersion.");
-                    }
+                    AddField(document, LuceneConstants.NormalizedVersionPropertyName, parsedVerbatimVersion.ToNormalizedString(), Field.Index.NOT_ANALYZED);
+                    AddField(document, LuceneConstants.FullVersionPropertyName, parsedVerbatimVersion.ToFullString(), Field.Index.NOT_ANALYZED);
+                }
+                else
+                {
+                    errors.Add($"Unable to parse '{MetadataConstants.VerbatimVersionPropertyName}' as NuGetVersion.");
                 }
             }
-
-            if (version != null)
-            {
-                AddField(document, LuceneConstants.NormalizedVersionPropertyName, version, Field.Index.ANALYZED);
-            }
             else
             {
-                errors.Add($"Could not add field {LuceneConstants.NormalizedVersionPropertyName} as both " +
-                           $"properties '{MetadataConstants.NormalizedVersionPropertyName}' and " +
-                           $"'{MetadataConstants.VersionPropertyName}' were not found.");
+                errors.Add($"Required property '{MetadataConstants.VerbatimVersionPropertyName}' not found.");
             }
         }
 

--- a/src/NuGet.Indexing/Extraction/MetadataConstants.cs
+++ b/src/NuGet.Indexing/Extraction/MetadataConstants.cs
@@ -15,7 +15,8 @@ namespace NuGet.Indexing
 
             // Version Properties
             public const string NormalizedVersionPropertyName = "Version";
-            public const string VersionPropertyName = "OriginalVersion";
+            public const string FullVersionPropertyName = "FullVersion";
+            public const string VerbatimVersionPropertyName = "OriginalVersion";
 
             // Date Properties
             public const string LastEditedDatePropertyName = "LastEditedDate";
@@ -86,7 +87,7 @@ namespace NuGet.Indexing
         public const string SupportedFrameworksPropertyName = "supportedFrameworks";
         public const string TagsPropertyName = "tags";
         public const string TitlePropertyName = "title";
-        public const string VersionPropertyName = "verbatimVersion";
+        public const string VerbatimVersionPropertyName = "verbatimVersion";
 
         // Constant Values
         public const string DateTimeZeroStringValue = "01/01/0001 00:00:00";

--- a/src/NuGet.Indexing/Extraction/NupkgPackageMetadataExtraction.cs
+++ b/src/NuGet.Indexing/Extraction/NupkgPackageMetadataExtraction.cs
@@ -66,7 +66,7 @@ namespace NuGet.Indexing
             }
 
             ExtractProperty(package, document, MetadataConstants.IdPropertyName);
-            ExtractProperty(package, document, MetadataConstants.NuPkgMetadata.VersionPropertyName, MetadataConstants.VersionPropertyName);
+            ExtractProperty(package, document, MetadataConstants.NuPkgMetadata.VersionPropertyName, MetadataConstants.VerbatimVersionPropertyName);
             ExtractProperty(package, document, MetadataConstants.TitlePropertyName);
             ExtractProperty(package, document, MetadataConstants.SummaryPropertyName);
             ExtractProperty(package, document, MetadataConstants.TagsPropertyName);

--- a/src/NuGet.Indexing/Extraction/PackageEntityMetadataExtraction.cs
+++ b/src/NuGet.Indexing/Extraction/PackageEntityMetadataExtraction.cs
@@ -28,7 +28,7 @@ namespace NuGet.Indexing
 
                 AddString(MetadataConstants.IdPropertyName, package.PackageRegistration.Id);
                 AddString(MetadataConstants.NormalizedVersionPropertyName, package.NormalizedVersion);
-                AddString(MetadataConstants.VersionPropertyName, package.Version);
+                AddString(MetadataConstants.VerbatimVersionPropertyName, package.Version);
                 AddString(MetadataConstants.TitlePropertyName, package.Title);
                 AddString(MetadataConstants.DescriptionPropertyName, package.Description);
                 AddString(MetadataConstants.SummaryPropertyName, package.Summary);

--- a/src/NuGet.Indexing/Handlers/VersionsHandler.cs
+++ b/src/NuGet.Indexing/Handlers/VersionsHandler.cs
@@ -88,17 +88,19 @@ namespace NuGet.Indexing
 
             foreach (var registrationEntry in registrationEntries.OrderBy(r => r.Version))
             {
-                string versionStr = String.Intern(registrationEntry.Version.ToNormalizedString());
+                string fullVersion = String.Intern(registrationEntry.Version.ToFullString());
+                string normalizedVersion = String.Intern(registrationEntry.Version.ToNormalizedString());
 
                 int downloads = 0;
                 if (downloadsByVersion != null)
                 {
-                    downloads = downloadsByVersion[versionStr];
+                    downloads = downloadsByVersion[normalizedVersion];
                 }
 
                 result.AllVersionDetails.Add(new VersionDetail
                 {
-                    Version = versionStr,
+                    NormalizedVersion = normalizedVersion,
+                    FullVersion = fullVersion,
                     Downloads = downloads,
                     IsStable = !registrationEntry.Version.IsPrerelease,
                     IsListed = registrationEntry.IsListed,

--- a/src/NuGet.Indexing/IndexReaderProcessor.cs
+++ b/src/NuGet.Indexing/IndexReaderProcessor.cs
@@ -93,7 +93,7 @@ namespace NuGet.Indexing
 
         private static NuGetVersion GetVersion(Document document)
         {
-            string version = document.Get("Version");
+            string version = document.Get(MetadataConstants.LuceneMetadata.VerbatimVersionPropertyName);
             return (version == null) ? null : new NuGetVersion(version);
         }
 

--- a/src/NuGet.Indexing/NuGetIndexSearcher.cs
+++ b/src/NuGet.Indexing/NuGetIndexSearcher.cs
@@ -100,12 +100,12 @@ namespace NuGet.Indexing
             return allVersions;
         }
 
-        public static Tuple<int, int> DownloadCounts(VersionResult versions, string version)
+        public static Tuple<int, int> DownloadCounts(VersionResult versions, string normalizedVersion)
         {
             int allVersions = TotalDownloadCounts(versions);
 
             int thisVersion = versions.AllVersionDetails
-                .Where(v => v.Version.Equals(version, StringComparison.OrdinalIgnoreCase))
+                .Where(v => v.NormalizedVersion.Equals(normalizedVersion, StringComparison.OrdinalIgnoreCase))
                 .Select(v => v.Downloads)
                 .FirstOrDefault();
 

--- a/src/NuGet.Indexing/VersionDetail.cs
+++ b/src/NuGet.Indexing/VersionDetail.cs
@@ -8,7 +8,8 @@ namespace NuGet.Indexing
     [DebuggerDisplay("v: {Version} d: {Downloads} l: {IsListed}")]
     public class VersionDetail
     {
-        public string Version { get; set; }
+        public string NormalizedVersion { get; set; }
+        public string FullVersion { get; set; }
         public int Downloads { get; set; }
         public bool IsStable { get; set; }
         public bool IsListed { get; set; }

--- a/src/NuGet.Indexing/VersionResult.cs
+++ b/src/NuGet.Indexing/VersionResult.cs
@@ -23,20 +23,20 @@ namespace NuGet.Indexing
         {
             if (includeSemVer2)
             {
-                return SemVer2VersionDetails.Where(v => !onlyListed || v.IsListed).Select(v => v.Version);
+                return SemVer2VersionDetails.Where(v => !onlyListed || v.IsListed).Select(v => v.FullVersion);
             }
 
-            return LegacyVersionDetails.Where(v => !onlyListed || v.IsListed).Select(v => v.Version);
+            return LegacyVersionDetails.Where(v => !onlyListed || v.IsListed).Select(v => v.FullVersion);
         }
 
         public IEnumerable<string> GetStableVersions(bool onlyListed, bool includeSemVer2)
         {
             if (includeSemVer2)
             {
-                return StableSemVer2VersionDetails.Where(v => !onlyListed || v.IsListed).Select(v => v.Version);
+                return StableSemVer2VersionDetails.Where(v => !onlyListed || v.IsListed).Select(v => v.FullVersion);
             }
 
-            return StableLegacyVersionDetails.Where(v => !onlyListed || v.IsListed).Select(v => v.Version);
+            return StableLegacyVersionDetails.Where(v => !onlyListed || v.IsListed).Select(v => v.FullVersion);
         }
 
         public IEnumerable<VersionDetail> StableLegacyVersionDetails { get { return AllVersionDetails.Where(v => v.IsStable && !v.IsSemVer2); } }

--- a/tests/NuGet.IndexingTests/Extraction/DocumentCreatorTests.cs
+++ b/tests/NuGet.IndexingTests/Extraction/DocumentCreatorTests.cs
@@ -43,14 +43,11 @@ namespace NuGet.IndexingTests
             // Arrange
             var package = GetPackage();
             package.Remove(MetadataConstants.NormalizedVersionPropertyName);
-            package.Remove(MetadataConstants.VersionPropertyName);
+            package.Remove(MetadataConstants.VerbatimVersionPropertyName);
 
             // Act, Assert
             var exception = Assert.Throws<Exception>(() => DocumentCreator.CreateDocument(package));
-            Assert.Equal($"Required property '{MetadataConstants.VersionPropertyName}' not found.\r\n" +
-                         $"Could not add field {LuceneConstants.NormalizedVersionPropertyName} as both " +
-                         $"properties '{MetadataConstants.NormalizedVersionPropertyName}' and " +
-                         $"'{MetadataConstants.VersionPropertyName}' were not found.\r\n", exception.Message);
+            Assert.Equal($"Required property '{MetadataConstants.VerbatimVersionPropertyName}' not found.\r\n", exception.Message);
         }
 
         [Fact]
@@ -59,14 +56,11 @@ namespace NuGet.IndexingTests
             // Arrange
             var package = GetPackage();
             package.Remove(MetadataConstants.NormalizedVersionPropertyName);
-            package[MetadataConstants.VersionPropertyName] = "bad";
+            package[MetadataConstants.VerbatimVersionPropertyName] = "bad";
 
             // Act, Assert
             var exception = Assert.Throws<Exception>(() => DocumentCreator.CreateDocument(package));
-            Assert.Equal($"Unable to parse '{MetadataConstants.VersionPropertyName}' as NuGetVersion.\r\n" +
-                         $"Could not add field {LuceneConstants.NormalizedVersionPropertyName} as both " +
-                         $"properties '{MetadataConstants.NormalizedVersionPropertyName}' and " +
-                         $"'{MetadataConstants.VersionPropertyName}' were not found.\r\n", exception.Message);
+            Assert.Equal($"Unable to parse '{MetadataConstants.VerbatimVersionPropertyName}' as NuGetVersion.\r\n", exception.Message);
         }
 
         [Fact]
@@ -157,13 +151,13 @@ namespace NuGet.IndexingTests
             // Arrange
             var package = GetPackage();
             package.Remove(MetadataConstants.NormalizedVersionPropertyName);
-            package[MetadataConstants.VersionPropertyName] = "1.02.003";
+            package[MetadataConstants.VerbatimVersionPropertyName] = "1.02.003";
 
             // Act
             var document = DocumentCreator.CreateDocument(package);
 
             // Assert
-            Assert.Equal("1.02.003", document.GetFieldable(LuceneConstants.VersionPropertyName).StringValue);
+            Assert.Equal("1.02.003", document.GetFieldable(LuceneConstants.VerbatimVersionPropertyName).StringValue);
             Assert.Equal("1.2.3", document.GetFieldable(LuceneConstants.NormalizedVersionPropertyName).StringValue);
         }
 
@@ -178,8 +172,9 @@ namespace NuGet.IndexingTests
                 new KeyValuePair<string, string>(LuceneConstants.IdAutocompletePropertyName, "DotNetZip"),
                 new KeyValuePair<string, string>(LuceneConstants.TokenizedIdPropertyName, "DotNetZip"),
                 new KeyValuePair<string, string>(LuceneConstants.ShingledIdPropertyName, "DotNetZip"),
-                new KeyValuePair<string, string>(LuceneConstants.VersionPropertyName, "1.00.000"),
+                new KeyValuePair<string, string>(LuceneConstants.VerbatimVersionPropertyName, "1.00.000"),
                 new KeyValuePair<string, string>(LuceneConstants.NormalizedVersionPropertyName, "1.0.0"),
+                new KeyValuePair<string, string>(LuceneConstants.FullVersionPropertyName, "1.0.0"),
                 new KeyValuePair<string, string>(LuceneConstants.TitlePropertyName, "The Famous DotNetZip"),
                 new KeyValuePair<string, string>(LuceneConstants.DescriptionPropertyName, "The description."),
                 new KeyValuePair<string, string>(LuceneConstants.SummaryPropertyName, "The summary."),
@@ -260,7 +255,7 @@ namespace NuGet.IndexingTests
 
                 // not required
                 { MetadataConstants.SemVerLevelKeyPropertyName, "" },
-                { MetadataConstants.VersionPropertyName, "1.00.000" },
+                { MetadataConstants.VerbatimVersionPropertyName, "1.00.000" },
                 { MetadataConstants.TitlePropertyName, "The Famous DotNetZip" },
                 { MetadataConstants.DescriptionPropertyName, "The description." },
                 { MetadataConstants.SummaryPropertyName, "The summary." },

--- a/tests/NuGet.IndexingTests/ResponseFormatterTests.cs
+++ b/tests/NuGet.IndexingTests/ResponseFormatterTests.cs
@@ -180,7 +180,7 @@ namespace NuGet.IndexingTests
                     Constants.LucenePropertyId.ToLower(),
                     Constants.MockBase,
                     Constants.LucenePropertyId,
-                    Constants.LucenePropertyOriginalVersion,
+                    Constants.LucenePropertyFullVersion,
                     Constants.LucenePropertyDescription,
                     Constants.LucenePropertySummary,
                     Constants.LucenePropertyTitle,

--- a/tests/NuGet.IndexingTests/ResponseFormatterTests.cs
+++ b/tests/NuGet.IndexingTests/ResponseFormatterTests.cs
@@ -54,7 +54,8 @@ namespace NuGet.IndexingTests
             {
                 ResponseFormatter.WriteV2Result(writer, searcher, topDocs, skip, take, SemVerHelpers.SemVer2Level);
 
-                Assert.Equal(expected, sb.ToString());
+                var result = sb.ToString();
+                Assert.Equal(expected, result);
             }
         }
 
@@ -179,7 +180,7 @@ namespace NuGet.IndexingTests
                     Constants.LucenePropertyId.ToLower(),
                     Constants.MockBase,
                     Constants.LucenePropertyId,
-                    Constants.LucenePropertyVersion,
+                    Constants.LucenePropertyOriginalVersion,
                     Constants.LucenePropertyDescription,
                     Constants.LucenePropertySummary,
                     Constants.LucenePropertyTitle,
@@ -323,17 +324,18 @@ namespace NuGet.IndexingTests
                     1.0,  // Top Docs Max Score
                     0,    // skip
                     2,    // take
-                    string.Format("{{\"totalHits\":2,\"index\":\"mockTakeDocuments\",\"indexTimestamp\":\"{0:G}\",\"data\":[{{\"PackageRegistration\":{{\"{2}\":\"{1}{2}0\",\"DownloadCount\":0,\"Owners\":[]}},\"NormalizedVersion\":\"{1}{3}0\",\"{4}\":\"{1}{4}0\",\"{5}\":\"{1}{5}0\",\"{6}\":\"{1}{6}0\",\"{7}\":\"{1}{7}0\",\"{8}\":\"{1}{8}0\",\"IsLatestStable\":false,\"IsLatest\":false,\"Listed\":true,\"DownloadCount\":0,\"Dependencies\":[],\"SupportedFrameworks\":[],\"PackageFileSize\":0,\"{9}\":\"{1}{9}0\",\"RequiresLicenseAcceptance\":false}},{{\"PackageRegistration\":{{\"{2}\":\"{1}{2}1\",\"DownloadCount\":0,\"Owners\":[]}},\"NormalizedVersion\":\"{1}{3}1\",\"{4}\":\"{1}{4}1\",\"{5}\":\"{1}{5}1\",\"{6}\":\"{1}{6}1\",\"{7}\":\"{1}{7}1\",\"{8}\":\"{1}{8}1\",\"IsLatestStable\":false,\"IsLatest\":false,\"Listed\":true,\"DownloadCount\":0,\"Dependencies\":[],\"SupportedFrameworks\":[],\"PackageFileSize\":0,\"{9}\":\"{1}{9}1\",\"RequiresLicenseAcceptance\":false}}]}}",
+                    string.Format("{{\"totalHits\":2,\"index\":\"mockTakeDocuments\",\"indexTimestamp\":\"{0:G}\",\"data\":[{{\"PackageRegistration\":{{\"{2}\":\"{1}{2}0\",\"DownloadCount\":0,\"Owners\":[]}},\"Version\":\"{1}{10}0\",\"NormalizedVersion\":\"{1}{3}0\",\"{4}\":\"{1}{4}0\",\"{5}\":\"{1}{5}0\",\"{6}\":\"{1}{6}0\",\"{7}\":\"{1}{7}0\",\"{8}\":\"{1}{8}0\",\"IsLatestStable\":false,\"IsLatest\":false,\"Listed\":true,\"DownloadCount\":0,\"Dependencies\":[],\"SupportedFrameworks\":[],\"PackageFileSize\":0,\"{9}\":\"{1}{9}0\",\"RequiresLicenseAcceptance\":false}},{{\"PackageRegistration\":{{\"{2}\":\"{1}{2}1\",\"DownloadCount\":0,\"Owners\":[]}},\"Version\":\"{1}{10}1\",\"NormalizedVersion\":\"{1}{3}1\",\"{4}\":\"{1}{4}1\",\"{5}\":\"{1}{5}1\",\"{6}\":\"{1}{6}1\",\"{7}\":\"{1}{7}1\",\"{8}\":\"{1}{8}1\",\"IsLatestStable\":false,\"IsLatest\":false,\"Listed\":true,\"DownloadCount\":0,\"Dependencies\":[],\"SupportedFrameworks\":[],\"PackageFileSize\":0,\"{9}\":\"{1}{9}1\",\"RequiresLicenseAcceptance\":false}}]}}",
                     new DateTime(2000, 1, 1).ToUniversalTime(),
                     Constants.MockBase,
                     Constants.LucenePropertyId,
-                    Constants.LucenePropertyVersion,
+                    Constants.LucenePropertyNormalizedVersion,
                     Constants.LucenePropertyTitle,
                     Constants.LucenePropertyDescription,
                     Constants.LucenePropertySummary,
                     Constants.LucenePropertyProjectUrl,
                     Constants.LucenePropertyIconUrl,
-                    Constants.LucenePropertyLicenseUrl)
+                    Constants.LucenePropertyLicenseUrl,
+                    Constants.LucenePropertyOriginalVersion)
                 };
 
                 // timestamp in commitUserData

--- a/tests/NuGet.IndexingTests/TestSupport/Constants.cs
+++ b/tests/NuGet.IndexingTests/TestSupport/Constants.cs
@@ -24,7 +24,9 @@ namespace NuGet.IndexingTests.TestSupport
         public static readonly string LucenePropertyProjectUrl = "ProjectUrl";
         public static readonly string LucenePropertySummary = "Summary";
         public static readonly string LucenePropertyTitle = "Title";
-        public static readonly string LucenePropertyVersion = "FullVersion";
+        public static readonly string LucenePropertyFullVersion = "FullVersion";
+        public static readonly string LucenePropertyNormalizedVersion = "Version";
+        public static readonly string LucenePropertyOriginalVersion = "OriginalVersion";
         public static readonly string LucenePropertySemVerLevel = "SemVerLevel";
         public static readonly string MockBase = "Mock";
         public static readonly string MockExplanationBase = MockBase + "Explanation";

--- a/tests/NuGet.IndexingTests/TestSupport/Constants.cs
+++ b/tests/NuGet.IndexingTests/TestSupport/Constants.cs
@@ -24,7 +24,7 @@ namespace NuGet.IndexingTests.TestSupport
         public static readonly string LucenePropertyProjectUrl = "ProjectUrl";
         public static readonly string LucenePropertySummary = "Summary";
         public static readonly string LucenePropertyTitle = "Title";
-        public static readonly string LucenePropertyVersion = "Version";
+        public static readonly string LucenePropertyVersion = "FullVersion";
         public static readonly string LucenePropertySemVerLevel = "SemVerLevel";
         public static readonly string MockBase = "Mock";
         public static readonly string MockExplanationBase = MockBase + "Explanation";

--- a/tests/NuGet.IndexingTests/TestSupport/MockObjectFactory.cs
+++ b/tests/NuGet.IndexingTests/TestSupport/MockObjectFactory.cs
@@ -24,7 +24,9 @@ namespace NuGet.IndexingTests.TestSupport
         {
             var mockDocument = new Document();
             mockDocument.Add(new Field(Constants.LucenePropertyId, MockPrefix + Constants.LucenePropertyId + MockId, Field.Store.YES, Field.Index.NO));
-            mockDocument.Add(new Field(Constants.LucenePropertyVersion, MockPrefix + Constants.LucenePropertyVersion + MockId, Field.Store.YES, Field.Index.NO));
+            mockDocument.Add(new Field(Constants.LucenePropertyFullVersion, MockPrefix + Constants.LucenePropertyFullVersion + MockId, Field.Store.YES, Field.Index.NO));
+            mockDocument.Add(new Field(Constants.LucenePropertyNormalizedVersion, MockPrefix + Constants.LucenePropertyNormalizedVersion + MockId, Field.Store.YES, Field.Index.NO));
+            mockDocument.Add(new Field(Constants.LucenePropertyOriginalVersion, MockPrefix + Constants.LucenePropertyOriginalVersion + MockId, Field.Store.YES, Field.Index.NO));
             mockDocument.Add(new Field(Constants.LucenePropertyDescription, MockPrefix + Constants.LucenePropertyDescription + MockId, Field.Store.YES, Field.Index.NO));
             mockDocument.Add(new Field(Constants.LucenePropertySummary, MockPrefix + Constants.LucenePropertySummary + MockId, Field.Store.YES, Field.Index.NO));
             mockDocument.Add(new Field(Constants.LucenePropertyTitle, MockPrefix + Constants.LucenePropertyTitle + MockId, Field.Store.YES, Field.Index.NO));

--- a/tests/NuGet.IndexingTests/VersionResultTests.cs
+++ b/tests/NuGet.IndexingTests/VersionResultTests.cs
@@ -100,7 +100,7 @@ namespace NuGet.IndexingTests
             var listedPackages = result.AllVersionDetails.Where(x => x.IsListed);
             foreach(var detail in listedPackages)
             {
-                listedMap.Add(detail.Version, detail);
+                listedMap.Add(detail.FullVersion, detail);
             }
 
             var semVer2ListedResult = result.GetVersions(onlyListed: true, includeSemVer2: true);
@@ -143,7 +143,8 @@ namespace NuGet.IndexingTests
                 return new VersionDetail
                 {
                     Downloads = 0,
-                    Version = parsedVersion.ToNormalizedString(),
+                    FullVersion = parsedVersion.ToFullString(),
+                    NormalizedVersion = parsedVersion.ToNormalizedString(),
                     IsListed = listed,
                     IsStable = !parsedVersion.IsPrerelease,
                     IsSemVer2 = parsedVersion.IsSemVer2
@@ -153,7 +154,8 @@ namespace NuGet.IndexingTests
             return new VersionDetail
             {
                 Downloads = 0,
-                Version = parsedVersion.ToNormalizedString(),
+                FullVersion = parsedVersion.ToFullString(),
+                NormalizedVersion = parsedVersion.ToNormalizedString(),
                 IsListed = listed,
                 IsStable = !parsedVersion.IsPrerelease,
                 IsSemVer2 = parsedVersion.IsSemVer2


### PR DESCRIPTION
Normalize use of VerbatimVersion,NormalizedVersion, and FullVersion names

@joelverhagen @xavierdecoster 