### PR TITLE
Make IgnoreFilter on search/query respect passed SemVerLevel

### DIFF
--- a/src/NuGet.Indexing/Extraction/NupkgPackageMetadataExtraction.cs
+++ b/src/NuGet.Indexing/Extraction/NupkgPackageMetadataExtraction.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Xml;
 using System.Xml.Linq;
+using NuGet.Versioning;
 
 namespace NuGet.Indexing
 {
@@ -80,6 +81,13 @@ namespace NuGet.Indexing
             ExtractProperty(package, document, MetadataConstants.LanguagePropertyName);
             ExtractProperty(package, document, MetadataConstants.LicenseUrlPropertyName);
             ExtractProperty(package, document, MetadataConstants.RequiresLicenseAcceptancePropertyName);
+
+            // This check is currently in place to allow us to test filtering. Correct way to do it is to extract dependencies and iterate, in addition to the check that is currently here.
+            NuGetVersion version;
+            if (NuGetVersion.TryParse(package[MetadataConstants.VerbatimVersionPropertyName], out version))
+            {
+                package[MetadataConstants.SemVerLevelKeyPropertyName] = version.IsSemVer2 ? SemVerHelpers.SemVerLevelKeySemVer2 : String.Empty;
+            }
 
             // TODO: extract from the XML - refer to the XSLT for an accurate definition of the generic structure
 

--- a/src/NuGet.Indexing/NuGetQuery.cs
+++ b/src/NuGet.Indexing/NuGetQuery.cs
@@ -54,49 +54,49 @@ namespace NuGet.Indexing
             {
                 switch (clause.Key)
                 {
-                case QueryField.Id:
-                    IdClause(booleanQuery, analyzer, clause.Value, Occur.MUST);
-                    break;
-                case QueryField.PackageId:
-                    PackageIdClause(booleanQuery, analyzer, clause.Value);
-                    break;
-                case QueryField.Version:
-                    VersionClause(booleanQuery, analyzer, clause.Value, Occur.MUST);
-                    break;
-                case QueryField.Title:
-                    TitleClause(booleanQuery, analyzer, clause.Value, Occur.MUST);
-                    break;
-                case QueryField.Description:
-                    DescriptionClause(booleanQuery, analyzer, clause.Value, Occur.MUST);
-                    break;
-                case QueryField.Tag:
-                    TagClause(booleanQuery, analyzer, clause.Value, Occur.MUST);
-                    break;
-                case QueryField.Author:
-                    AuthorClause(booleanQuery, analyzer, clause.Value, Occur.MUST);
-                    break;
-                case QueryField.Summary:
-                    SummaryClause(booleanQuery, analyzer, clause.Value, Occur.MUST);
-                    break;
-                case QueryField.Owner:
-                    if (owners != null)
-                    {
-                        filters.AddRange(OwnerFilters(owners, clause.Value));
-                    }
-                    break;
-                default:
-                    AnyClause(booleanQuery, analyzer, clause.Value);
-
-                    if (owners != null)
-                    {
-                        var ownerFilters = OwnerFilters(owners, clause.Value).ToList();
-                        if (ownerFilters.Any())
+                    case QueryField.Id:
+                        IdClause(booleanQuery, analyzer, clause.Value, Occur.MUST);
+                        break;
+                    case QueryField.PackageId:
+                        PackageIdClause(booleanQuery, analyzer, clause.Value);
+                        break;
+                    case QueryField.Version:
+                        VersionClause(booleanQuery, analyzer, clause.Value, Occur.MUST);
+                        break;
+                    case QueryField.Title:
+                        TitleClause(booleanQuery, analyzer, clause.Value, Occur.MUST);
+                        break;
+                    case QueryField.Description:
+                        DescriptionClause(booleanQuery, analyzer, clause.Value, Occur.MUST);
+                        break;
+                    case QueryField.Tag:
+                        TagClause(booleanQuery, analyzer, clause.Value, Occur.MUST);
+                        break;
+                    case QueryField.Author:
+                        AuthorClause(booleanQuery, analyzer, clause.Value, Occur.MUST);
+                        break;
+                    case QueryField.Summary:
+                        SummaryClause(booleanQuery, analyzer, clause.Value, Occur.MUST);
+                        break;
+                    case QueryField.Owner:
+                        if (owners != null)
                         {
-                            booleanQuery.Add(ConstructFilteredQuery(new MatchAllDocsQuery(), ownerFilters), Occur.SHOULD);
+                            filters.AddRange(OwnerFilters(owners, clause.Value));
                         }
-                    }
+                        break;
+                    default:
+                        AnyClause(booleanQuery, analyzer, clause.Value);
 
-                    break;
+                        if (owners != null)
+                        {
+                            var ownerFilters = OwnerFilters(owners, clause.Value).ToList();
+                            if (ownerFilters.Any())
+                            {
+                                booleanQuery.Add(ConstructFilteredQuery(new MatchAllDocsQuery(), ownerFilters), Occur.SHOULD);
+                            }
+                        }
+
+                        break;
                 }
             }
 
@@ -127,7 +127,7 @@ namespace NuGet.Indexing
             return query;
         }
 
-        private static Query ConstructClauseQuery(Analyzer analyzer, string field, IEnumerable<string> values, Occur occur = Occur.SHOULD, float queryBoost = 1.0f, float termBoost = 1.0f)
+        public static Query ConstructClauseQuery(Analyzer analyzer, string field, IEnumerable<string> values, Occur occur = Occur.SHOULD, float queryBoost = 1.0f, float termBoost = 1.0f)
         {
             BooleanQuery query = new BooleanQuery();
             foreach (string text in values)

--- a/src/NuGet.Indexing/SemVerHelpers.cs
+++ b/src/NuGet.Indexing/SemVerHelpers.cs
@@ -7,11 +7,17 @@ namespace NuGet.Indexing
 {
     public class SemVerHelpers
     {
+        public static readonly string SemVerLevelKeySemVer2 = "2";
         public static readonly NuGetVersion SemVer1Level = new NuGetVersion("1.0.0");
         public static readonly NuGetVersion SemVer2Level = new NuGetVersion("2.0.0");
 
         public static bool ShouldIncludeSemVer2Results(NuGetVersion semVerLevel)
         {
+            if (semVerLevel == null)
+            {
+                return false;
+            }
+
             return semVerLevel >= SemVer2Level;
         }
     }

--- a/tests/NuGet.IndexingTests/TestSupport/MockSearcher.cs
+++ b/tests/NuGet.IndexingTests/TestSupport/MockSearcher.cs
@@ -34,7 +34,7 @@ namespace NuGet.IndexingTests.TestSupport
             MockObjectFactory.MockPrefix = Constants.MockBase;
         }
 
-        private static NuGetSearcherManager InitNuGetSearcherManager(string indexName, DateTime? reloadTime, Dictionary<string, DateTime?> lastModifiedTimeForAuxFiles, string machineName)
+        public static NuGetSearcherManager InitNuGetSearcherManager(string indexName, DateTime? reloadTime, Dictionary<string, DateTime?> lastModifiedTimeForAuxFiles, string machineName)
         {
             var mockSearcherManager = new Mock<NuGetSearcherManager>(new Mock<ILogger>().Object, null, null,
                 int.MaxValue, int.MaxValue)

--- a/tests/NuGet.Services.BasicSearchTests/TestSupport/V2SearchBuilder.cs
+++ b/tests/NuGet.Services.BasicSearchTests/TestSupport/V2SearchBuilder.cs
@@ -10,6 +10,7 @@ namespace NuGet.Services.BasicSearchTests.TestSupport
         public string Query { get; set; }
         public bool Prerelease { get; set; }
         public bool IgnoreFilter { get; set; }
+        public string SemVerLevel { get; set; }
 
         public Uri RequestUri
         {
@@ -19,6 +20,7 @@ namespace NuGet.Services.BasicSearchTests.TestSupport
                 queryString["q"] = Query;
                 queryString["prerelease"] = Prerelease.ToString();
                 queryString["ignoreFilter"] = IgnoreFilter.ToString();
+                queryString["semVerLevel"] = SemVerLevel;
 
                 return new Uri("/search/query?" + queryString, UriKind.Relative);
             }

--- a/tests/NuGet.Services.BasicSearchTests/V2SearchFunctionalTests.cs
+++ b/tests/NuGet.Services.BasicSearchTests/V2SearchFunctionalTests.cs
@@ -100,12 +100,13 @@ namespace NuGet.Services.BasicSearchTests
                 new PackageVersion("bootstrap", "3.3.5"),
                 new PackageVersion("bootstrap", "4.0.0-alpha",  listed: false),
                 new PackageVersion("bootstrap", "4.0.0-alpha2", listed: true),
-                new PackageVersion("bootstrap", "3.3.6")
+                new PackageVersion("bootstrap", "3.3.6"),
+                new PackageVersion("semverA", "1.0.0")
             };
 
             using (var app = await StartedWebApp.StartAsync(packages))
             {
-                string query = "Id:bootstrap";
+                string query = "";
 
                 // Act
                 var withPrereleaseResponse = await app.Client.GetAsync(new V2SearchBuilder { Query = query, Prerelease = true, IgnoreFilter = true }.RequestUri);
@@ -114,12 +115,19 @@ namespace NuGet.Services.BasicSearchTests
                 var withoutPrereleaseResponse = await app.Client.GetAsync(new V2SearchBuilder { Query = query, Prerelease = false, IgnoreFilter = true }.RequestUri);
                 var withoutPrerelease = await withoutPrereleaseResponse.Content.ReadAsAsync<V2SearchResult>();
 
+                var withPrereleaseResponseSemVer2 = await app.Client.GetAsync(new V2SearchBuilder { Query = query, Prerelease = true, IgnoreFilter = true, SemVerLevel = "2.0.0" }.RequestUri);
+                var withPrereleaseSemVer2 = await withPrereleaseResponseSemVer2.Content.ReadAsAsync<V2SearchResult>();
+
+                var withoutPrereleaseResponseSemVer2 = await app.Client.GetAsync(new V2SearchBuilder { Query = query, Prerelease = false, IgnoreFilter = true, SemVerLevel = "2.0.0" }.RequestUri);
+                var withoutPrereleaseSemVer2 = await withoutPrereleaseResponseSemVer2.Content.ReadAsAsync<V2SearchResult>();
+
                 // Assert
                 Assert.True(withPrerelease.ContainsPackage("bootstrap"));                       // bootstrap is in the results
                 Assert.True(withPrerelease.ContainsPackage("bootstrap", "3.3.5"));              // stable version is in the results
                 Assert.True(withPrerelease.ContainsPackage("bootstrap", "3.3.6"));              // stable version is in the results
                 Assert.True(withPrerelease.ContainsPackage("bootstrap", "4.0.0-alpha"));        // prerelease version is in the results
                 Assert.True(withPrerelease.ContainsPackage("bootstrap", "4.0.0-alpha2"));       // prerelease version is in the results
+                Assert.False(withPrerelease.ContainsPackage("semverA", "1.0.0"));               // SemVerLevel 2 packages are filtered
                 var prerelease1 = withPrerelease.GetPackage("bootstrap", "4.0.0-alpha");
                 Assert.False(prerelease1.Listed);                                               // unlisted version is in the results
 
@@ -128,8 +136,27 @@ namespace NuGet.Services.BasicSearchTests
                 Assert.True(withoutPrerelease.ContainsPackage("bootstrap", "3.3.6"));           // stable version is in the results
                 Assert.True(withoutPrerelease.ContainsPackage("bootstrap", "4.0.0-alpha"));     // prerelease version is in the results
                 Assert.True(withoutPrerelease.ContainsPackage("bootstrap", "4.0.0-alpha2"));    // prerelease version is in the results
+                Assert.False(withPrerelease.ContainsPackage("semverA", "1.0.0"));               // SemVerLevel 2 packages are filtered
                 var prerelease2 = withoutPrerelease.GetPackage("bootstrap", "4.0.0-alpha");
                 Assert.False(prerelease2.Listed);                                               // unlisted version is in the results
+
+                Assert.True(withPrereleaseSemVer2.ContainsPackage("bootstrap"));                       // bootstrap is in the results
+                Assert.True(withPrereleaseSemVer2.ContainsPackage("bootstrap", "3.3.5"));              // stable version is in the results
+                Assert.True(withPrereleaseSemVer2.ContainsPackage("bootstrap", "3.3.6"));              // stable version is in the results
+                Assert.True(withPrereleaseSemVer2.ContainsPackage("bootstrap", "4.0.0-alpha"));        // prerelease version is in the results
+                Assert.True(withPrereleaseSemVer2.ContainsPackage("bootstrap", "4.0.0-alpha2"));       // prerelease version is in the results
+                Assert.True(withPrereleaseSemVer2.ContainsPackage("semverA", "1.0.0"));                // SemVerLevel 2 packages are included
+                var prerelease1SemVer2 = withPrereleaseSemVer2.GetPackage("bootstrap", "4.0.0-alpha");
+                Assert.False(prerelease1SemVer2.Listed);                                               // unlisted version is in the results
+
+                Assert.True(withoutPrereleaseSemVer2.ContainsPackage("bootstrap"));                    // bootstrap is in the results
+                Assert.True(withoutPrereleaseSemVer2.ContainsPackage("bootstrap", "3.3.5"));           // stable version is in the results
+                Assert.True(withoutPrereleaseSemVer2.ContainsPackage("bootstrap", "3.3.6"));           // stable version is in the results
+                Assert.True(withoutPrereleaseSemVer2.ContainsPackage("bootstrap", "4.0.0-alpha"));     // prerelease version is in the results
+                Assert.True(withoutPrereleaseSemVer2.ContainsPackage("bootstrap", "4.0.0-alpha2"));    // prerelease version is in the results
+                Assert.True(withoutPrereleaseSemVer2.ContainsPackage("semverA", "1.0.0"));             // SemVerLevel 2 packages are included
+                var prerelease2SemVer2 = withoutPrereleaseSemVer2.GetPackage("bootstrap", "4.0.0-alpha");
+                Assert.False(prerelease2SemVer2.Listed);                                               // unlisted version is in the results
             }
         }
     }


### PR DESCRIPTION
A search side fix for https://github.com/NuGet/NuGetGallery/issues/3914
IgnoreFilter being passed made search ignore ALL filters, including semVerLevel filters.
This adds a query clause that acts on semVerLevel regardless of IgnoreFilter.

@xavierdecoster @joelverhagen 