### PR TITLE
More verbose error reporting for the IndexIsFresh

### DIFF
--- a/tests/BasicSearchTests.FunctionalTests.Core/StartupFunctionalTests.cs
+++ b/tests/BasicSearchTests.FunctionalTests.Core/StartupFunctionalTests.cs
@@ -54,7 +54,12 @@ namespace BasicSearchTests.FunctionalTests.Core
             var lastRegistrationCommitTime = GetLastRegistrationCommitTime().Result;
             var diffTimes = lastRegistrationCommitTime.Subtract(content.CommitUserData.CommitTimeStamp).TotalHours;
             //Last CommitTimeStamp for search service shouldn't be far off from the last registration timestamp.
-            Assert.True(diffTimes >= 0 && diffTimes <= IndexDifferenceLimitInHrs, "Search index is ahead of last registration timestamp");
+            Assert.True(diffTimes >= 0, 
+                $"[{DateTime.UtcNow:O}] Search index is ahead of last registration timestamp " +
+                $"(Registration: {lastRegistrationCommitTime:O}, Search: {content.CommitUserData.CommitTimeStamp:O})");
+            Assert.True(diffTimes <= IndexDifferenceLimitInHrs, 
+                $"[{DateTime.UtcNow:O}] Search index is too much behind the last registration timestamp " +
+                $"(Registration: {lastRegistrationCommitTime:O}, Search: {content.CommitUserData.CommitTimeStamp:O})");
         }
 
         private static string[] PathsToTest => new[]


### PR DESCRIPTION
`IndexIsFresh` test failed in last deployment attempt but it is not clear what exactly happened and why. Better error messaging should provide more information for investigation if it happens again.
Fix for [eng-#547](https://github.com/NuGet/Engineering/issues/547)