### PR TITLE
When searching, use the case-insensitive package version field in the Lucene document

### DIFF
--- a/src/NuGet.Indexing/NuGetQuery.cs
+++ b/src/NuGet.Indexing/NuGetQuery.cs
@@ -166,7 +166,12 @@ namespace NuGet.Indexing
 
         private static void VersionClause(BooleanQuery query, Analyzer analyzer, IEnumerable<string> values, Occur occur)
         {
-            query.Add(ConstructClauseQuery(analyzer, LuceneConstants.NormalizedVersionPropertyName, values), occur);
+            query.Add(
+                ConstructClauseQuery(
+                    analyzer,
+                    LuceneConstants.CaseInsensitiveNormalizedVersionPropertyName,
+                    values),
+                occur);
         }
 
         private static void TitleClause(BooleanQuery query, Analyzer analyzer, IEnumerable<string> values, Occur occur)

--- a/tests/NuGet.IndexingTests/NuGetQueryTests.cs
+++ b/tests/NuGet.IndexingTests/NuGetQueryTests.cs
@@ -54,9 +54,9 @@ namespace NuGet.IndexingTests
         {
             // arrange
             var owners = CreateOwnersResult(new Dictionary<string, HashSet<string>>
-                {
-                    {  "dot", new HashSet<string> { "dot" } }
-                });
+            {
+                {  "dot", new HashSet<string> { "dot" } }
+            });
             var queryText = $"{inputField}:dot";
 
             // act
@@ -101,7 +101,7 @@ namespace NuGet.IndexingTests
                 new BooleanClause(new BooleanQuery { Clauses = { new BooleanClause(new TermQuery(new Term("Id", "dot")), Occur.SHOULD) }, Boost = 8 }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("ShingledId", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("TokenizedId", "dot")), Occur.SHOULD) }, Occur.SHOULD),
-                new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Version", "dot")), Occur.SHOULD) }, Occur.SHOULD),
+                new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("CaseInsensitiveNormalizedVersion", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Title", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Description", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Summary", "dot")), Occur.SHOULD) }, Occur.SHOULD),
@@ -132,7 +132,7 @@ namespace NuGet.IndexingTests
                     new BooleanClause(new BooleanQuery { Clauses = { new BooleanClause(new TermQuery(new Term("Id", "dot")), Occur.SHOULD) }, Boost = 8 }, Occur.SHOULD),
                     new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("ShingledId", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                     new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("TokenizedId", "dot")), Occur.SHOULD) }, Occur.SHOULD),
-                    new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Version", "dot")), Occur.SHOULD) }, Occur.SHOULD),
+                    new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("CaseInsensitiveNormalizedVersion", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                     new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Title", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                     new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Description", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                     new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Summary", "dot")), Occur.SHOULD) }, Occur.SHOULD),
@@ -197,7 +197,7 @@ namespace NuGet.IndexingTests
                 new BooleanClause(new BooleanQuery { Clauses = { new BooleanClause(new TermQuery(new Term("Id", "dot")), Occur.SHOULD) }, Boost = 8 }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("ShingledId", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("TokenizedId", "dot")), Occur.SHOULD) }, Occur.SHOULD),
-                new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Version", "dot")), Occur.SHOULD) }, Occur.SHOULD),
+                new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("CaseInsensitiveNormalizedVersion", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Title", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Description", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Summary", "dot")), Occur.SHOULD) }, Occur.SHOULD),
@@ -324,7 +324,22 @@ namespace NuGet.IndexingTests
                 };
 
                 // version
-                yield return GetSimpleFieldQuery("Version");
+                yield return new object[]
+                {
+                    "version:dot version:bar",
+                    new BooleanQuery
+                    {
+                        new BooleanClause(new BooleanQuery
+                        {
+                            Clauses =
+                            {
+                                new BooleanClause(new TermQuery(new Term("CaseInsensitiveNormalizedVersion", "dot")), Occur.SHOULD),
+                                new BooleanClause(new TermQuery(new Term("CaseInsensitiveNormalizedVersion", "bar")), Occur.SHOULD)
+                            },
+                            Boost = 1
+                        }, Occur.MUST)
+                    }
+                };
                 
                 // title
                 yield return new object[]
@@ -372,7 +387,7 @@ namespace NuGet.IndexingTests
             {
                 yield return new object[] { "id", "Id" };
                 yield return new object[] { "packageid", "Id" };
-                yield return new object[] { "version", "Version" };
+                yield return new object[] { "version", "CaseInsensitiveNormalizedVersion" };
                 yield return new object[] { "title", "Title" };
                 yield return new object[] { "description", "Description" };
                 yield return new object[] { "tag", "Tags" };

--- a/tests/NuGet.Services.BasicSearchTests/DictionaryConfigurationProvider.cs
+++ b/tests/NuGet.Services.BasicSearchTests/DictionaryConfigurationProvider.cs
@@ -18,7 +18,12 @@ namespace NuGet.Services.BasicSearchTests
 
         protected override Task<string> Get(string key)
         {
-            return Task.FromResult(_configuration[key]);
+            if (_configuration.TryGetValue(key, out var value))
+            {
+                return Task.FromResult(value);
+            }
+
+            return Task.FromResult<string>(null);
         }
     }
 }

--- a/tests/NuGet.Services.BasicSearchTests/V3SearchFunctionalTests.cs
+++ b/tests/NuGet.Services.BasicSearchTests/V3SearchFunctionalTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -68,6 +67,38 @@ namespace NuGet.Services.BasicSearchTests
                 Assert.False(withoutPrerelease.ContainsPackage("angularjs"));              // the only version available is prerelease and is therefore excluded
                 Assert.Equal("3.1.3.42154", withoutPrerelease.GetPackageVersion("Antlr")); // this is the latest non-release version
                 Assert.Equal("1.6.0", withoutPrerelease.GetPackageVersion("WebGrease"));   // the only version available is non-prerelease
+            }
+        }
+
+        [Fact]
+        public async Task SupportsCaseInsensitiveVersionSearch()
+        {
+            // Arrange
+            var packages = new[]
+            {
+                new PackageVersion("angularjs", "1.2.0-RC1"),
+            };
+
+            using (var app = await StartedWebApp.StartAsync(packages))
+            {
+                // Act
+                var mismatchedCaseResponse = await app.Client.GetAsync(new V3SearchBuilder
+                {
+                    Query = "packageid:angularjs version:1.2.0-rc1",
+                    Prerelease = true,
+                }.RequestUri);
+                var mismatchedCase = await mismatchedCaseResponse.Content.ReadAsAsync<V3SearchResult>();
+
+                var matchingCaseResponse = await app.Client.GetAsync(new V3SearchBuilder
+                {
+                    Query = "packageid:angularjs version:1.2.0-RC1",
+                    Prerelease = true,
+                }.RequestUri);
+                var matchingCase = await matchingCaseResponse.Content.ReadAsAsync<V3SearchResult>();
+
+                // Assert
+                Assert.Equal("1.2.0-RC1", mismatchedCase.GetPackageVersion("angularjs"));
+                Assert.Equal("1.2.0-RC1", matchingCase.GetPackageVersion("angularjs"));
             }
         }
 


### PR DESCRIPTION
Fix https://github.com/NuGet/NuGetGallery/issues/5051.

Added some tests, and fixed a previously skipped test that was just plain wrong.

I will only merge this after https://github.com/NuGet/NuGetGallery/issues/5052 has been deployed (along with https://github.com/NuGet/NuGetGallery/issues/5010).