### PR TITLE
Merge dev into master

### DIFF
--- a/src/NuGet.Indexing/DescriptionAnalyzer.cs
+++ b/src/NuGet.Indexing/DescriptionAnalyzer.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-using Lucene.Net.Analysis;
-using System.Collections.Generic;
+
 using System.IO;
+using Lucene.Net.Analysis;
 
 namespace NuGet.Indexing
 {
@@ -10,7 +10,10 @@ namespace NuGet.Indexing
     {
         public override TokenStream TokenStream(string fieldName, TextReader reader)
         {
-            return new StopFilter(true, new LowerCaseFilter(new CamelCaseFilter(new DotTokenizer(reader))), TokenizingHelper.GetStopWords());
+            return new StopFilter(
+                enablePositionIncrements: true,
+                @in: new LowerInvariantFilter(new CamelCaseFilter(new DotTokenizer(reader))),
+                stopWords: TokenizingHelper.GetStopWords());
         }
     }
 }

--- a/src/NuGet.Indexing/IdentifierAnalyzer.cs
+++ b/src/NuGet.Indexing/IdentifierAnalyzer.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-using Lucene.Net.Analysis;
+
 using System.IO;
+using Lucene.Net.Analysis;
 
 namespace NuGet.Indexing
 {
@@ -9,9 +10,11 @@ namespace NuGet.Indexing
     {
         public override TokenStream TokenStream(string fieldName, TextReader reader)
         {
-            return new LowerCaseFilter(
+            return new LowerInvariantFilter(
                 new ExpandAcronymsFilter(
-                    new CamelCaseFilter(new DotTokenizer(reader)), NuGetAcronymExpansionProvider.Instance));
+                    new CamelCaseFilter(
+                        new DotTokenizer(reader)),
+                    NuGetAcronymExpansionProvider.Instance));
         }
     }
 }

--- a/src/NuGet.Indexing/IdentifierAutocompleteAnalyzer.cs
+++ b/src/NuGet.Indexing/IdentifierAutocompleteAnalyzer.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-﻿using Lucene.Net.Analysis;
-using Lucene.Net.Analysis.NGram;
+
 using System.IO;
+using Lucene.Net.Analysis;
+using Lucene.Net.Analysis.NGram;
 
 namespace NuGet.Indexing
 {
@@ -10,7 +11,12 @@ namespace NuGet.Indexing
     {
         public override TokenStream TokenStream(string fieldName, TextReader reader)
         {
-            return new EdgeNGramTokenFilter(new LowerCaseFilter(new CamelCaseFilter(new DotTokenizer(reader))), Side.FRONT, 1, 8);
+            return new EdgeNGramTokenFilter(
+                new LowerInvariantFilter(
+                    new CamelCaseFilter(new DotTokenizer(reader))),
+                side: Side.FRONT,
+                minGram: 1,
+                maxGram: 8);
         }
     }
 }

--- a/src/NuGet.Indexing/IdentifierKeywordAnalyzer.cs
+++ b/src/NuGet.Indexing/IdentifierKeywordAnalyzer.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-using Lucene.Net.Analysis;
+
 using System.IO;
+using Lucene.Net.Analysis;
 
 namespace NuGet.Indexing
 {
@@ -9,7 +10,7 @@ namespace NuGet.Indexing
     {
         public override TokenStream TokenStream(string fieldName, TextReader reader)
         {
-            return new LowerCaseFilter(new KeywordTokenizer(reader));
+            return new LowerInvariantFilter(new KeywordTokenizer(reader));
         }
     }
 }

--- a/src/NuGet.Indexing/LowerCaseFilter.cs
+++ b/src/NuGet.Indexing/LowerCaseFilter.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Lucene.Net.Analysis;
+
+namespace NuGet.Indexing
+{
+    [Obsolete("Lucene.Net.Analysis.LowerCaseFilter uses char.ToLower, which is incorrect.")]
+    public class LowerCaseFilter : TokenFilter
+    {
+        public LowerCaseFilter(TokenStream input) : base(input)
+        {
+        }
+
+        public override bool IncrementToken()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/NuGet.Indexing/LowerInvariantFilter.cs
+++ b/src/NuGet.Indexing/LowerInvariantFilter.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Lucene.Net.Analysis;
+using Lucene.Net.Analysis.Tokenattributes;
+
+namespace NuGet.Indexing
+{
+    /// <summary>
+    /// Uses <see cref="char.ToLowerInvariant(char)"/> instead of <see cref="char.ToLower(char)"/>. Based off of
+    /// <see cref="https://github.com/apache/lucenenet/blob/19c02b21064f1232132c46f8eb22db7ee3f819f7/src/core/Analysis/LowerCaseFilter.cs"/>.
+    /// </summary>
+    public class LowerInvariantFilter : TokenFilter
+    {
+        private readonly ITermAttribute _termAttribute;
+
+        public LowerInvariantFilter(TokenStream input) : base(input)
+        {
+            _termAttribute = AddAttribute<ITermAttribute>();
+        }
+
+        public override bool IncrementToken()
+        {
+            if (input.IncrementToken())
+            {
+                var buffer = _termAttribute.TermBuffer();
+                var length = _termAttribute.TermLength();
+                for (int i = 0; i < length; i++)
+                {
+                    buffer[i] = char.ToLowerInvariant(buffer[i]);
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/NuGet.Indexing/NuGet.Indexing.csproj
+++ b/src/NuGet.Indexing/NuGet.Indexing.csproj
@@ -281,6 +281,8 @@
     <Compile Include="IndexDirectoryProvider\IIndexDirectoryProvider.cs" />
     <Compile Include="IndexDirectoryProvider\CloudIndexDirectoryProvider.cs" />
     <Compile Include="LatestListedMask.cs" />
+    <Compile Include="LowerCaseFilter.cs" />
+    <Compile Include="LowerInvariantFilter.cs" />
     <Compile Include="NuGetAcronymExpansionProvider.cs" />
     <Compile Include="NuGetMergePolicyApplyer.cs" />
     <Compile Include="NuGetQueryParser.cs" />

--- a/src/NuGet.Indexing/NuGetQuery.cs
+++ b/src/NuGet.Indexing/NuGetQuery.cs
@@ -166,7 +166,12 @@ namespace NuGet.Indexing
 
         private static void VersionClause(BooleanQuery query, Analyzer analyzer, IEnumerable<string> values, Occur occur)
         {
-            query.Add(ConstructClauseQuery(analyzer, LuceneConstants.NormalizedVersionPropertyName, values), occur);
+            query.Add(
+                ConstructClauseQuery(
+                    analyzer,
+                    LuceneConstants.CaseInsensitiveNormalizedVersionPropertyName,
+                    values),
+                occur);
         }
 
         private static void TitleClause(BooleanQuery query, Analyzer analyzer, IEnumerable<string> values, Occur occur)

--- a/src/NuGet.Indexing/ShingledIdentifierAnalyzer.cs
+++ b/src/NuGet.Indexing/ShingledIdentifierAnalyzer.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
 using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.Shingle;
-using System.IO;
 
 namespace NuGet.Indexing
 {
@@ -10,7 +11,7 @@ namespace NuGet.Indexing
     {
         public override TokenStream TokenStream(string fieldName, TextReader reader)
         {
-            return new LowerCaseFilter(new ShingleFilter(new DotTokenizer(reader)));
+            return new LowerInvariantFilter(new ShingleFilter(new DotTokenizer(reader)));
         }
     }
 }

--- a/src/NuGet.Indexing/TagsAnalyzer.cs
+++ b/src/NuGet.Indexing/TagsAnalyzer.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Lucene.Net.Analysis;
 using System.IO;
+using Lucene.Net.Analysis;
 
 namespace NuGet.Indexing
 {
@@ -10,7 +10,7 @@ namespace NuGet.Indexing
     {
         public override TokenStream TokenStream(string fieldName, TextReader reader)
         {
-            return new LowerCaseFilter(new DotTokenizer(reader));
+            return new LowerInvariantFilter(new DotTokenizer(reader));
         }
     }
 }

--- a/src/NuGet.Indexing/VersionAnalyzer.cs
+++ b/src/NuGet.Indexing/VersionAnalyzer.cs
@@ -21,7 +21,7 @@ namespace NuGet.Indexing
 
             if (!_caseSensitive)
             {
-                stream = new LowerCaseFilter(stream);
+                stream = new LowerInvariantFilter(stream);
             }
 
             return stream;

--- a/tests/NuGet.IndexingTests/DescriptionAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/DescriptionAnalyzerTests.cs
@@ -103,6 +103,17 @@ namespace NuGet.IndexingTests
                         new TokenAttributes("net", 47, 50, 1)
                     }
                 };
+
+                // lower (invariant)
+                yield return new object[]
+                {
+                    "İ a ı a I a i",
+                    new[]
+                    {
+                        new TokenAttributes("İ", 0, 1, 1),
+                        new TokenAttributes("ı", 4, 5, 2),
+                    }
+                };
             }
         }
 

--- a/tests/NuGet.IndexingTests/DotTokenizerTests.cs
+++ b/tests/NuGet.IndexingTests/DotTokenizerTests.cs
@@ -47,7 +47,6 @@ namespace NuGet.IndexingTests
                 yield return new object[] { '!' };
                 yield return new object[] { '~' };
                 yield return new object[] { '+' };
-                yield return new object[] { '-' };
                 yield return new object[] { '(' };
                 yield return new object[] { ')' };
                 yield return new object[] { '[' };

--- a/tests/NuGet.IndexingTests/IdentifierAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/IdentifierAnalyzerTests.cs
@@ -57,6 +57,18 @@ namespace NuGet.IndexingTests
                         new TokenAttributes("d", 0, 1, 1)
                     }
                 };
+
+                // lower case (invariant)
+                yield return new object[]
+                {
+                    "İıIi",
+                    new[]
+                    {
+                        new TokenAttributes("İıii", 0, 4, 1),
+                        new TokenAttributes("İı", 0, 2, 0),
+                        new TokenAttributes("ii", 2, 4, 1),
+                    }
+                };
             }
         }
     }

--- a/tests/NuGet.IndexingTests/IdentifierAutocompleteAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/IdentifierAutocompleteAnalyzerTests.cs
@@ -113,6 +113,23 @@ namespace NuGet.IndexingTests
                         new TokenAttributes("new", 11, 14, 1)
                     }
                 };
+
+                // lower case (invariant)
+                yield return new object[]
+                {
+                    "İıIi",
+                    new[]
+                    {
+                        new TokenAttributes("İ", 0, 1, 1),
+                        new TokenAttributes("İı", 0, 2, 1),
+                        new TokenAttributes("İıi", 0, 3, 1),
+                        new TokenAttributes("İıii", 0, 4, 1),
+                        new TokenAttributes("İ", 0, 1, 1),
+                        new TokenAttributes("İı", 0, 2, 1),
+                        new TokenAttributes("i", 2, 3, 1),
+                        new TokenAttributes("ii", 2, 4, 1),
+                    }
+                };
             }
         }
     }

--- a/tests/NuGet.IndexingTests/IdentifierKeywordAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/IdentifierKeywordAnalyzerTests.cs
@@ -39,6 +39,9 @@ namespace NuGet.IndexingTests
 
                 // mixed
                 yield return new object[] { "DotNet.ZIP-Unofficial is a BAD identifier.", new TokenAttributes("dotnet.zip-unofficial is a bad identifier.", 0, 42) };
+
+                // lower case (invariant)
+                yield return new object[] { "İıIi", new TokenAttributes("İıii", 0, 4) };
             }
 
         }

--- a/tests/NuGet.IndexingTests/NuGetQueryTests.cs
+++ b/tests/NuGet.IndexingTests/NuGetQueryTests.cs
@@ -54,9 +54,9 @@ namespace NuGet.IndexingTests
         {
             // arrange
             var owners = CreateOwnersResult(new Dictionary<string, HashSet<string>>
-                {
-                    {  "dot", new HashSet<string> { "dot" } }
-                });
+            {
+                {  "dot", new HashSet<string> { "dot" } }
+            });
             var queryText = $"{inputField}:dot";
 
             // act
@@ -101,7 +101,7 @@ namespace NuGet.IndexingTests
                 new BooleanClause(new BooleanQuery { Clauses = { new BooleanClause(new TermQuery(new Term("Id", "dot")), Occur.SHOULD) }, Boost = 8 }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("ShingledId", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("TokenizedId", "dot")), Occur.SHOULD) }, Occur.SHOULD),
-                new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Version", "dot")), Occur.SHOULD) }, Occur.SHOULD),
+                new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("CaseInsensitiveNormalizedVersion", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Title", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Description", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Summary", "dot")), Occur.SHOULD) }, Occur.SHOULD),
@@ -132,7 +132,7 @@ namespace NuGet.IndexingTests
                     new BooleanClause(new BooleanQuery { Clauses = { new BooleanClause(new TermQuery(new Term("Id", "dot")), Occur.SHOULD) }, Boost = 8 }, Occur.SHOULD),
                     new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("ShingledId", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                     new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("TokenizedId", "dot")), Occur.SHOULD) }, Occur.SHOULD),
-                    new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Version", "dot")), Occur.SHOULD) }, Occur.SHOULD),
+                    new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("CaseInsensitiveNormalizedVersion", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                     new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Title", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                     new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Description", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                     new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Summary", "dot")), Occur.SHOULD) }, Occur.SHOULD),
@@ -197,7 +197,7 @@ namespace NuGet.IndexingTests
                 new BooleanClause(new BooleanQuery { Clauses = { new BooleanClause(new TermQuery(new Term("Id", "dot")), Occur.SHOULD) }, Boost = 8 }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("ShingledId", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("TokenizedId", "dot")), Occur.SHOULD) }, Occur.SHOULD),
-                new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Version", "dot")), Occur.SHOULD) }, Occur.SHOULD),
+                new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("CaseInsensitiveNormalizedVersion", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Title", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Description", "dot")), Occur.SHOULD) }, Occur.SHOULD),
                 new BooleanClause(new BooleanQuery { new BooleanClause(new TermQuery(new Term("Summary", "dot")), Occur.SHOULD) }, Occur.SHOULD),
@@ -324,7 +324,22 @@ namespace NuGet.IndexingTests
                 };
 
                 // version
-                yield return GetSimpleFieldQuery("Version");
+                yield return new object[]
+                {
+                    "version:dot version:bar",
+                    new BooleanQuery
+                    {
+                        new BooleanClause(new BooleanQuery
+                        {
+                            Clauses =
+                            {
+                                new BooleanClause(new TermQuery(new Term("CaseInsensitiveNormalizedVersion", "dot")), Occur.SHOULD),
+                                new BooleanClause(new TermQuery(new Term("CaseInsensitiveNormalizedVersion", "bar")), Occur.SHOULD)
+                            },
+                            Boost = 1
+                        }, Occur.MUST)
+                    }
+                };
                 
                 // title
                 yield return new object[]
@@ -372,7 +387,7 @@ namespace NuGet.IndexingTests
             {
                 yield return new object[] { "id", "Id" };
                 yield return new object[] { "packageid", "Id" };
-                yield return new object[] { "version", "Version" };
+                yield return new object[] { "version", "CaseInsensitiveNormalizedVersion" };
                 yield return new object[] { "title", "Title" };
                 yield return new object[] { "description", "Description" };
                 yield return new object[] { "tag", "Tags" };

--- a/tests/NuGet.IndexingTests/ShingledIdentifierAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/ShingledIdentifierAnalyzerTests.cs
@@ -74,6 +74,22 @@ namespace NuGet.IndexingTests
                         new TokenAttributes("d", 6, 7, 1),
                     }
                 };
+
+                // lower case (invariant)
+                yield return new object[]
+                {
+                    "İ.ı.I.i",
+                    new[]
+                    {
+                        new TokenAttributes("İ", 0, 1, 1),
+                        new TokenAttributes("İ ı", 0, 3, 0),
+                        new TokenAttributes("ı", 2, 3, 1),
+                        new TokenAttributes("ı i", 2, 5, 0),
+                        new TokenAttributes("i", 4, 5, 1),
+                        new TokenAttributes("i i", 4, 7, 0),
+                        new TokenAttributes("i", 6, 7, 1),
+                    }
+                };
             }
         }
     }

--- a/tests/NuGet.IndexingTests/TagsAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/TagsAnalyzerTests.cs
@@ -62,6 +62,19 @@ namespace NuGet.IndexingTests
                         new TokenAttributes("words", 32, 37)
                     }
                 };
+
+                // lower case (invariant)
+                yield return new object[]
+                {
+                    "İ ı I i",
+                    new[]
+                    {
+                        new TokenAttributes("İ", 0, 1),
+                        new TokenAttributes("ı", 2, 3),
+                        new TokenAttributes("i", 4, 5),
+                        new TokenAttributes("i", 6, 7),
+                    }
+                };
             }
         }
     }

--- a/tests/NuGet.IndexingTests/VersionAnalyzerTests.cs
+++ b/tests/NuGet.IndexingTests/VersionAnalyzerTests.cs
@@ -79,6 +79,9 @@ namespace NuGet.IndexingTests
 
                 // dots in prerelease
                 yield return new TestCase("1.0.0-alpha.1");
+
+                // lowercase (invariant)
+                yield return new TestCase("1.0.0-İıIi");
             }
         }
 

--- a/tests/NuGet.Services.BasicSearchTests/DictionaryConfigurationProvider.cs
+++ b/tests/NuGet.Services.BasicSearchTests/DictionaryConfigurationProvider.cs
@@ -18,7 +18,12 @@ namespace NuGet.Services.BasicSearchTests
 
         protected override Task<string> Get(string key)
         {
-            return Task.FromResult(_configuration[key]);
+            if (_configuration.TryGetValue(key, out var value))
+            {
+                return Task.FromResult(value);
+            }
+
+            return Task.FromResult<string>(null);
         }
     }
 }

--- a/tests/NuGet.Services.BasicSearchTests/TestSupport/NupkgDownloader.cs
+++ b/tests/NuGet.Services.BasicSearchTests/TestSupport/NupkgDownloader.cs
@@ -46,7 +46,7 @@ namespace NuGet.Services.BasicSearchTests.TestSupport
 
         public string GetPackagePath(PackageVersion version)
         {
-            return Path.Combine(_settings.PackageDirectory, $"{version.Id}.{version.Version}.nupkg".ToLower());
+            return Path.Combine(_settings.PackageDirectory, $"{version.Id}.{version.Version}.nupkg".ToLowerInvariant());
         }
 
         private async Task DownloadPackageAsync(PackageVersion version)
@@ -63,7 +63,7 @@ namespace NuGet.Services.BasicSearchTests.TestSupport
                 _packageBaseAddress = await GetPackageBaseAddressAsync();
             }
 
-            string relativeUri = $"{version.Id}/{version.Version}/{version.Id}.{version.Version}.nupkg".ToLower();
+            string relativeUri = $"{version.Id}/{version.Version}/{version.Id}.{version.Version}.nupkg".ToLowerInvariant();
             var requestUri = new Uri(new Uri(_packageBaseAddress, UriKind.Absolute), relativeUri);
             var response = await _client.GetAsync(requestUri);
             if (response.StatusCode != HttpStatusCode.OK)

--- a/tests/NuGet.Services.BasicSearchTests/TestSupport/V2SearchBuilder.cs
+++ b/tests/NuGet.Services.BasicSearchTests/TestSupport/V2SearchBuilder.cs
@@ -16,11 +16,13 @@ namespace NuGet.Services.BasicSearchTests.TestSupport
         {
             get
             {
-                var queryString = System.Web.HttpUtility.ParseQueryString(string.Empty);
-                queryString["q"] = Query;
-                queryString["prerelease"] = Prerelease.ToString();
-                queryString["ignoreFilter"] = IgnoreFilter.ToString();
-                queryString["semVerLevel"] = SemVerLevel;
+                var queryStringBuilder = System.Web.HttpUtility.ParseQueryString(string.Empty);
+                queryStringBuilder["prerelease"] = Prerelease.ToString();
+                queryStringBuilder["ignoreFilter"] = IgnoreFilter.ToString();
+                queryStringBuilder["semVerLevel"] = SemVerLevel;
+
+                // Use Uri.EscapeDataString to handle obscure Unicode characters properly.
+                var queryString = $"q={Uri.EscapeDataString(Query ?? string.Empty)}&{queryStringBuilder}";
 
                 return new Uri("/search/query?" + queryString, UriKind.Relative);
             }

--- a/tests/NuGet.Services.BasicSearchTests/V3SearchFunctionalTests.cs
+++ b/tests/NuGet.Services.BasicSearchTests/V3SearchFunctionalTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -68,6 +67,38 @@ namespace NuGet.Services.BasicSearchTests
                 Assert.False(withoutPrerelease.ContainsPackage("angularjs"));              // the only version available is prerelease and is therefore excluded
                 Assert.Equal("3.1.3.42154", withoutPrerelease.GetPackageVersion("Antlr")); // this is the latest non-release version
                 Assert.Equal("1.6.0", withoutPrerelease.GetPackageVersion("WebGrease"));   // the only version available is non-prerelease
+            }
+        }
+
+        [Fact]
+        public async Task SupportsCaseInsensitiveVersionSearch()
+        {
+            // Arrange
+            var packages = new[]
+            {
+                new PackageVersion("angularjs", "1.2.0-RC1"),
+            };
+
+            using (var app = await StartedWebApp.StartAsync(packages))
+            {
+                // Act
+                var mismatchedCaseResponse = await app.Client.GetAsync(new V3SearchBuilder
+                {
+                    Query = "packageid:angularjs version:1.2.0-rc1",
+                    Prerelease = true,
+                }.RequestUri);
+                var mismatchedCase = await mismatchedCaseResponse.Content.ReadAsAsync<V3SearchResult>();
+
+                var matchingCaseResponse = await app.Client.GetAsync(new V3SearchBuilder
+                {
+                    Query = "packageid:angularjs version:1.2.0-RC1",
+                    Prerelease = true,
+                }.RequestUri);
+                var matchingCase = await matchingCaseResponse.Content.ReadAsAsync<V3SearchResult>();
+
+                // Assert
+                Assert.Equal("1.2.0-RC1", mismatchedCase.GetPackageVersion("angularjs"));
+                Assert.Equal("1.2.0-RC1", matchingCase.GetPackageVersion("angularjs"));
             }
         }
 


### PR DESCRIPTION
This fixes:

- Search service treat versions as case sensitive strings (https://github.com/NuGet/NuGetGallery/issues/4583)
- Package with Turkish "i" collides with ASCII "i" in V2 search results (https://github.com/NuGet/Engineering/issues/958)

This will require an out-of-band deployment I will be driving:

1. Make copy old catalog2lucene on jobs machine
2. Use new db2lucene to generate a new index
    - Download the new Ng package from Octopus and extract it to C:\nuget\LuceneIndexCreation
    - Follow the standard index rebuild steps
    - The script uploads the new indexes (both primary and secondary) to blob storage
4. Deploy new catalog2lucene pointed at new index
    - This requires updating the catalog2lucene (both primary and secondary) configuration to point to the new index location
5. Run backed up catalog2lucene against old index location
    - Remember, both primary and secondary! This step should be done very quickly after the deployment of step 4 completes (during e2e tests).
6. Deploy new search pointed at new index
7. Wait 24 hours and deploy ussc
8. Wait 24 hours and turn off old catalog2lucene