### PR TITLE
Increase HTTP client timeout in catalog2dnx

### DIFF
--- a/src/Catalog/CommitCollector.cs
+++ b/src/Catalog/CommitCollector.cs
@@ -14,8 +14,12 @@ namespace NuGet.Services.Metadata.Catalog
 {
     public abstract class CommitCollector : CollectorBase
     {
-        public CommitCollector(Uri index, ITelemetryService telemetryService, Func<HttpMessageHandler> handlerFunc = null)
-            : base(index, telemetryService, handlerFunc)
+        public CommitCollector(
+            Uri index,
+            ITelemetryService telemetryService,
+            Func<HttpMessageHandler> handlerFunc = null,
+            TimeSpan? httpClientTimeout = null)
+            : base(index, telemetryService, handlerFunc, httpClientTimeout)
         {
         }
 

--- a/src/Catalog/Dnx/DnxCatalogCollector.cs
+++ b/src/Catalog/Dnx/DnxCatalogCollector.cs
@@ -9,6 +9,7 @@ using System.IO.Compression;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using NuGet.Services.Metadata.Catalog.Helpers;
 using NuGet.Services.Metadata.Catalog.Persistence;
@@ -17,14 +18,22 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
 {
     public class DnxCatalogCollector : CommitCollector
     {
-        DnxMaker _dnxMaker;
-        StorageFactory _storageFactory;
+        private readonly StorageFactory _storageFactory;
+        private readonly DnxMaker _dnxMaker;
+        private readonly ILogger _logger;
 
-        public DnxCatalogCollector(Uri index, StorageFactory storageFactory, ITelemetryService telemetryService, Func<HttpMessageHandler> handlerFunc = null)
-            : base(index, telemetryService, handlerFunc)
+        public DnxCatalogCollector(
+            Uri index,
+            StorageFactory storageFactory,
+            ITelemetryService telemetryService,
+            ILogger logger,
+            Func<HttpMessageHandler> handlerFunc = null,
+            TimeSpan? httpClientTimeout = null)
+            : base(index, telemetryService, handlerFunc, httpClientTimeout)
         {
             _storageFactory = storageFactory;
             _dnxMaker = new DnxMaker(storageFactory);
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public Uri ContentBaseAddress { get; set; }
@@ -36,67 +45,67 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
                 string id = item["nuget:id"].ToString().ToLowerInvariant();
                 string version = NuGetVersionUtility.NormalizeVersion(item["nuget:version"].ToString().ToLowerInvariant());
                 string type = item["@type"].ToString().Replace("nuget:", Schema.Prefixes.NuGet);
-                var destinationStorage = _storageFactory.Create(id);
 
                 if (type == Schema.DataTypes.PackageDetails.ToString())
                 {
-                    var sourceUri = new Uri(ContentBaseAddress, string.Format("{0}.{1}.nupkg", id, version));
-                    var destinationUri = destinationStorage.GetUri(DnxMaker.GetRelativeAddressNupkg(id, version));
-                    if (!await destinationStorage.AreSyncronized(sourceUri, destinationUri))
-                    {
-                        // Add/update package
-                        string nuspec = await LoadNuspec(client, id, version, cancellationToken);
-                        if (nuspec != null)
-                        {
-                            var requestUri = Utilities.GetNugetCacheBustingUri(sourceUri);
-                            using (Stream stream = await client.GetStreamAsync(requestUri))
-                            {
-                                await _dnxMaker.AddPackage(stream, nuspec, id, version, cancellationToken);
-                            }
-                            Trace.TraceInformation("commit: {0}/{1}", id, version);
-                        }
-                        else
-                        {
-                            Trace.TraceWarning("no nuspec available for {0}/{1} skipping", id, version);
-                        }
-                    }
-                    else
-                    {
-                        Trace.TraceInformation("No changes detected: {0}/{1}", id, version);
-                    }
+                    await ProcessPackageDetailsAsync(client, id, version, cancellationToken);
                 }
                 else if (type == Schema.DataTypes.PackageDelete.ToString())
                 {
-                    await _dnxMaker.DeletePackage(id, version, cancellationToken);
-
-                    Trace.TraceInformation("commit delete: {0}/{1}", id, version);
+                    await ProcessPackageDeleteAsync(id, version, cancellationToken);
                 }
             }
 
             return true;
         }
 
-        private async Task<string> LoadNuspec(HttpClient client, string id, string version, CancellationToken cancellationToken)
+        private async Task ProcessPackageDetailsAsync(
+            HttpClient client,
+            string id,
+            string version,
+            CancellationToken cancellationToken)
         {
-            var requestUri = Utilities.GetNugetCacheBustingUri(new Uri(ContentBaseAddress, string.Format("{0}.{1}.nupkg", id, version)));
-            HttpResponseMessage httpResponseMessage = await client.GetAsync(requestUri, cancellationToken);
-            if (httpResponseMessage.IsSuccessStatusCode)
+            var sourceUri = new Uri(ContentBaseAddress, string.Format("{0}.{1}.nupkg", id, version));
+
+            var destinationStorage = _storageFactory.Create(id);
+            var destinationUri = destinationStorage.GetUri(DnxMaker.GetRelativeAddressNupkg(id, version));
+
+            if (await destinationStorage.AreSyncronized(sourceUri, destinationUri))
             {
-                using (Stream stream = await httpResponseMessage.Content.ReadAsStreamAsync())
+                _logger.LogInformation("No changes detected: {Id}/{Version}", id, version);
+                return;
+            }
+
+            var packageDownloader = new PackageDownloader(client, _logger);
+            var requestUri = Utilities.GetNugetCacheBustingUri(sourceUri);
+
+            using (var stream = await packageDownloader.DownloadAsync(requestUri, cancellationToken))
+            {
+                if (stream == null)
                 {
-                    string nuspec = GetNuspec(stream, id);
-                    return nuspec;
+                    _logger.LogWarning("Package {Id}/{Version} not found.", id, version);
+                    return;
                 }
+
+                var nuspec = GetNuspec(stream, id);
+                if (nuspec == null)
+                {
+                    _logger.LogWarning("No .nuspec available for {Id}/{Version}. Skipping.", id, version);
+                    return;
+                }
+
+                stream.Position = 0;
+
+                await _dnxMaker.AddPackage(stream, nuspec, id, version, cancellationToken);
+                _logger.LogInformation("Commit: {Id}/{Version}", id, version);
             }
-            else if (httpResponseMessage.StatusCode == System.Net.HttpStatusCode.NotFound)
-            {
-                Trace.TraceInformation("package not found...");
-            }
-            else
-            {
-                httpResponseMessage.EnsureSuccessStatusCode();
-            }
-            return null;
+        }
+
+        private async Task ProcessPackageDeleteAsync(string id, string version, CancellationToken cancellationToken)
+        {
+            await _dnxMaker.DeletePackage(id, version, cancellationToken);
+
+            _logger.LogInformation("Commit delete: {Id}/{Version}", id, version);
         }
 
         private static string GetNuspec(Stream stream, string id)

--- a/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
+++ b/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
@@ -144,6 +144,7 @@
     <Compile Include="CloudBlobStorageExtensions.cs" />
     <Compile Include="CommitCollector.cs" />
     <Compile Include="CommitMetadata.cs" />
+    <Compile Include="PackageDownloader.cs" />
     <Compile Include="Helpers\CatalogProperties.cs" />
     <Compile Include="Helpers\DeletionAuditEntry.cs" />
     <Compile Include="Helpers\FeedHelpers.cs" />

--- a/src/Catalog/PackageDownloader.cs
+++ b/src/Catalog/PackageDownloader.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace NuGet.Services.Metadata.Catalog
+{
+    public class PackageDownloader
+    {
+        private const int BufferSize = 8192;
+
+        private readonly HttpClient _httpClient;
+        private readonly ILogger _logger;
+
+        public PackageDownloader(HttpClient httpClient, ILogger logger)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<Stream> DownloadAsync(Uri packageUri, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Attempting to download package from {PackageUri}...", packageUri);
+
+            Stream packageStream = null;
+            var stopwatch = Stopwatch.StartNew();
+
+            try
+            {
+                // Download the package from the network to a temporary file.
+                using (var response = await _httpClient.GetAsync(packageUri, HttpCompletionOption.ResponseHeadersRead))
+                {
+                    _logger.LogInformation(
+                        "Received response {StatusCode}: {ReasonPhrase} of type {ContentType} for request {PackageUri}",
+                        response.StatusCode,
+                        response.ReasonPhrase,
+                        response.Content.Headers.ContentType,
+                        packageUri);
+
+                    if (response.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        return null;
+                    }
+                    if (response.StatusCode != HttpStatusCode.OK)
+                    {
+                        throw new InvalidOperationException($"Expected status code {HttpStatusCode.OK} for package download, actual: {response.StatusCode}");
+                    }
+
+                    using (var networkStream = await response.Content.ReadAsStreamAsync())
+                    {
+                        packageStream = new FileStream(
+                            Path.GetTempFileName(),
+                            FileMode.Create,
+                            FileAccess.ReadWrite,
+                            FileShare.None,
+                            BufferSize,
+                            FileOptions.DeleteOnClose | FileOptions.Asynchronous);
+
+                        await networkStream.CopyToAsync(packageStream, BufferSize, cancellationToken);
+                    }
+                }
+
+                packageStream.Position = 0;
+
+                stopwatch.Stop();
+
+                _logger.LogInformation(
+                    "Downloaded {PackageSizeInBytes} bytes in {DownloadElapsedTime} seconds for request {PackageUri}",
+                    packageStream.Length,
+                    stopwatch.Elapsed.TotalSeconds,
+                    packageUri);
+
+                return packageStream;
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(
+                    (EventId)0,
+                    e,
+                    "Exception thrown when trying to download package from {PackageUri}",
+                    packageUri);
+
+                packageStream?.Dispose();
+
+                throw;
+            }
+        }
+    }
+}

--- a/src/Catalog/Telemetry/ITelemetryService.cs
+++ b/src/Catalog/Telemetry/ITelemetryService.cs
@@ -10,7 +10,19 @@ namespace NuGet.Services.Metadata.Catalog
     public interface ITelemetryService
     {
         void TrackCatalogIndexWriteDuration(TimeSpan duration, Uri uri);
+
         void TrackCatalogIndexReadDuration(TimeSpan duration, Uri uri);
-        void TrackHttpDuration(TimeSpan duration, HttpMethod method, Uri uri, HttpStatusCode statusCode, bool success);
+
+        /// <summary>
+        /// Tracks the duration to fetch the HTTP response headers. Note that this duration does not include the time
+        /// it takes to fetch response body. In other words, this metric is not interesting for bandwidth analysis.
+        /// </summary>
+        void TrackHttpHeaderDuration(
+            TimeSpan duration,
+            HttpMethod method,
+            Uri uri,
+            bool success,
+            HttpStatusCode? statusCode,
+            long? contentLength);
     }
 }

--- a/src/Catalog/Telemetry/TelemetryService.cs
+++ b/src/Catalog/Telemetry/TelemetryService.cs
@@ -13,11 +13,12 @@ namespace NuGet.Services.Metadata.Catalog
     {
         private readonly TelemetryClient _telemetryClient;
 
-        private const string HttpDurationSeconds = "HttpDurationSeconds";
+        private const string HttpHeaderDurationSeconds = "HttpHeaderDurationSeconds";
         private const string Method = "Method";
         private const string Uri = "Uri";
-        private const string StatusCode = "StatusCode";
         private const string Success = "Success";
+        private const string StatusCode = "StatusCode";
+        private const string ContentLength = "ContentLength";
 
         private const string CatalogIndexReadDurationSeconds = "CatalogIndexReadDurationSeconds";
 
@@ -28,7 +29,13 @@ namespace NuGet.Services.Metadata.Catalog
             _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
         }
 
-        public void TrackHttpDuration(TimeSpan duration, HttpMethod method, Uri uri, HttpStatusCode statusCode, bool success)
+        public void TrackHttpHeaderDuration(
+            TimeSpan duration,
+            HttpMethod method,
+            Uri uri,
+            bool success,
+            HttpStatusCode? statusCode,
+            long? contentLength)
         {
             if (method == null)
             {
@@ -41,14 +48,15 @@ namespace NuGet.Services.Metadata.Catalog
             }
 
             _telemetryClient.TrackMetric(
-                HttpDurationSeconds,
+                HttpHeaderDurationSeconds,
                 duration.TotalSeconds,
                 new Dictionary<string, string>
                 {
                     { Method, method.ToString() },
                     { Uri, uri.AbsoluteUri },
-                    { StatusCode, ((int)statusCode).ToString() },
+                    { StatusCode, ((int?)statusCode)?.ToString() },
                     { Success, success.ToString() },
+                    { ContentLength, contentLength?.ToString() }
                 });
         }
 

--- a/src/Ng/Arguments.cs
+++ b/src/Ng/Arguments.cs
@@ -49,6 +49,7 @@ namespace Ng
 
         public const string StorageSuffix = "storageSuffix";
         public const string StorageOperationMaxExecutionTimeInSeconds = "storageOperationMaxExecutionTimeInSeconds";
+        public const string HttpClientTimeoutInSeconds = "httpClientTimeoutInSeconds";
 
         #endregion
 

--- a/src/Ng/Scripts/Catalog2DnxV3.cmd
+++ b/src/Ng/Scripts/Catalog2DnxV3.cmd
@@ -1,14 +1,28 @@
 @echo OFF
-	
+
 cd Ng
 
 :Top
-	echo "Starting job - #{Jobs.ngcatalog2dnx.Title}"
+echo "Starting job - #{Jobs.ngcatalog2dnx.Title}"
 
-	title #{Jobs.ngcatalog2dnx.Title}
-	
-    start /w Ng.exe catalog2dnx -source #{Jobs.ngcatalog2dnx.Catalog.Source} -contentBaseAddress #{Jobs.ngcatalog2dnx.ContentBaseAddress} -storageBaseAddress #{Jobs.ngcatalog2dnx.StorageBaseAddress} -storageType azure -storageAccountName #{Jobs.ngcatalog2dnx.StorageAccount.Name} -storageKeyValue #{Jobs.ngcatalog2dnx.StorageAccount.Key} -storageContainer #{Jobs.ngcatalog2dnx.Container} -instrumentationkey #{Jobs.common.v3.Logging.InstrumentationKey} -vaultName #{Deployment.Azure.KeyVault.VaultName} -clientId #{Deployment.Azure.KeyVault.ClientId} -certificateThumbprint #{Deployment.Azure.KeyVault.CertificateThumbprint} -verbose true -interval #{Jobs.ngcatalog2dnx.Interval}
-	
-	echo "Finished #{Jobs.ngcatalog2dnx.Title}"
+title #{Jobs.ngcatalog2dnx.Title}
 
-	goto Top
+start /w Ng.exe catalog2dnx ^
+    -source #{Jobs.ngcatalog2dnx.Catalog.Source} ^
+    -contentBaseAddress #{Jobs.ngcatalog2dnx.ContentBaseAddress} ^
+    -storageBaseAddress #{Jobs.ngcatalog2dnx.StorageBaseAddress} ^
+    -storageType azure ^
+    -storageAccountName #{Jobs.ngcatalog2dnx.StorageAccount.Name} ^
+    -storageKeyValue #{Jobs.ngcatalog2dnx.StorageAccount.Key} ^
+    -storageContainer #{Jobs.ngcatalog2dnx.Container} ^
+    -instrumentationkey #{Jobs.common.v3.Logging.InstrumentationKey} ^
+    -vaultName #{Deployment.Azure.KeyVault.VaultName} ^
+    -clientId #{Deployment.Azure.KeyVault.ClientId} ^
+    -certificateThumbprint #{Deployment.Azure.KeyVault.CertificateThumbprint} ^
+    -verbose true ^
+    -interval #{Jobs.ngcatalog2dnx.Interval} ^
+    -httpClientTimeoutInSeconds #{Jobs.ngcatalog2dnx.HttpClientTimeoutInSeconds}
+
+echo "Finished #{Jobs.ngcatalog2dnx.Title}"
+
+goto Top

--- a/src/Ng/Scripts/Catalog2DnxV3China.cmd
+++ b/src/Ng/Scripts/Catalog2DnxV3China.cmd
@@ -1,5 +1,5 @@
 @echo OFF
-	
+
 cd Ng
 
 :Top
@@ -7,7 +7,8 @@ echo "Starting job - #{Jobs.ngcatalog2dnxChina.Title}"
 
 title #{Jobs.ngcatalog2dnxChina.Title}
 
-start /w Ng.exe catalog2dnx -source #{Jobs.ngcatalog2dnx.Catalog.Source} ^
+start /w Ng.exe catalog2dnx ^
+    -source #{Jobs.ngcatalog2dnx.Catalog.Source} ^
     -contentBaseAddress #{Jobs.China.ngcatalog2dnx.ContentBaseAddress} ^
     -storageBaseAddress #{Jobs.China.ngcatalog2dnx.StorageBaseAddress} ^
     -storageType azure ^
@@ -21,7 +22,8 @@ start /w Ng.exe catalog2dnx -source #{Jobs.ngcatalog2dnx.Catalog.Source} ^
     -verbose true ^
     -interval #{Jobs.ngcatalog2dnx.Interval} ^
     -storageSuffix #{Jobs.Common.China.StorageSuffix} ^
-    -storageOperationMaxExecutionTimeInSeconds #{Jobs.Common.China.AzureOperationMaxTimeout}
+    -storageOperationMaxExecutionTimeInSeconds #{Jobs.Common.China.AzureOperationMaxTimeout} ^
+    -httpClientTimeoutInSeconds #{Jobs.ngcatalog2dnx.HttpClientTimeoutInSeconds}
 
 echo "Finished #{Jobs.ngcatalog2dnxChina.Title}"
 

--- a/src/Ng/Scripts/Catalog2DnxV3Secondary.cmd
+++ b/src/Ng/Scripts/Catalog2DnxV3Secondary.cmd
@@ -1,14 +1,28 @@
 @echo OFF
-	
+
 cd Ng
 
 :Top
-	echo "Starting job - #{Jobs.ngcatalog2dnx.Title.Secondary}"
+echo "Starting job - #{Jobs.ngcatalog2dnx.Title.Secondary}"
 
-	title #{Jobs.ngcatalog2dnx.Title.Secondary}
-	
-    start /w Ng.exe catalog2dnx -source #{Jobs.ngcatalog2dnx.Catalog.Source.Secondary} -contentBaseAddress #{Jobs.ngcatalog2dnx.ContentBaseAddress.Secondary} -storageBaseAddress #{Jobs.ngcatalog2dnx.StorageBaseAddress.Secondary} -storageType azure -storageAccountName #{Jobs.common.v3.Storage.Secondary.Name} -storageKeyValue #{Jobs.common.v3.Storage.Secondary.Key} -storageContainer #{Jobs.ngcatalog2dnx.Container} -instrumentationkey #{Jobs.common.v3.Logging.InstrumentationKey} -vaultName #{Deployment.Azure.KeyVault.VaultName} -clientId #{Deployment.Azure.KeyVault.ClientId} -certificateThumbprint #{Deployment.Azure.KeyVault.CertificateThumbprint} -verbose true -interval #{Jobs.ngcatalog2dnx.Interval}
-	
-	echo "Finished #{Jobs.ngcatalog2dnx.Title.Secondary}"
+title #{Jobs.ngcatalog2dnx.Title.Secondary}
 
-	goto Top
+start /w Ng.exe catalog2dnx ^
+    -source #{Jobs.ngcatalog2dnx.Catalog.Source.Secondary} ^
+    -contentBaseAddress #{Jobs.ngcatalog2dnx.ContentBaseAddress.Secondary} ^
+    -storageBaseAddress #{Jobs.ngcatalog2dnx.StorageBaseAddress.Secondary} ^
+    -storageType azure ^
+    -storageAccountName #{Jobs.common.v3.Storage.Secondary.Name} ^
+    -storageKeyValue #{Jobs.common.v3.Storage.Secondary.Key} ^
+    -storageContainer #{Jobs.ngcatalog2dnx.Container} ^
+    -instrumentationkey #{Jobs.common.v3.Logging.InstrumentationKey} ^
+    -vaultName #{Deployment.Azure.KeyVault.VaultName} ^
+    -clientId #{Deployment.Azure.KeyVault.ClientId} ^
+    -certificateThumbprint #{Deployment.Azure.KeyVault.CertificateThumbprint} ^
+    -verbose true ^
+    -interval #{Jobs.ngcatalog2dnx.Interval} ^
+    -httpClientTimeoutInSeconds #{Jobs.ngcatalog2dnx.HttpClientTimeoutInSeconds}
+
+echo "Finished #{Jobs.ngcatalog2dnx.Title.Secondary}"
+
+goto Top

--- a/tests/CatalogTests/CatalogTests.csproj
+++ b/tests/CatalogTests/CatalogTests.csproj
@@ -70,6 +70,9 @@
     <Reference Include="JsonLD">
       <HintPath>..\..\packages\json-ld.net.1.0.4\lib\net40-Client\JsonLD.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
@@ -169,6 +172,7 @@
     <Compile Include="SortingGraphCollectorTests.cs" />
     <Compile Include="StringInternerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TelemetryHandlerTests.cs" />
     <None Include="TestData\DependencyMissingId.0.1.0.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/CatalogTests/TelemetryHandlerTests.cs
+++ b/tests/CatalogTests/TelemetryHandlerTests.cs
@@ -1,0 +1,173 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Services.Metadata.Catalog;
+using Xunit;
+
+namespace CatalogTests
+{
+    public class TelemetryHandlerTests
+    {
+        private readonly Mock<ITelemetryService> _telemetryService;
+        private Func<Task<HttpResponseMessage>> _sendAsync;
+        private readonly FuncHttpMessageHandler _innerHandler;
+        private readonly HttpRequestMessage _request;
+        private readonly TelemetryHandler _target;
+        private readonly HttpClient _httpClient;
+
+        public TelemetryHandlerTests()
+        {
+            _telemetryService = new Mock<ITelemetryService>();
+            _sendAsync = () => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("Hello, world!"),
+            });
+            _innerHandler = new FuncHttpMessageHandler(() => _sendAsync);
+            _request = new HttpRequestMessage(HttpMethod.Get, "http://example/robots.txt");
+            _target = new TelemetryHandler(_telemetryService.Object, _innerHandler);
+            _httpClient = new HttpClient(_target);
+        }
+
+        [Fact]
+        public async Task EmitsTelemetryOnException()
+        {
+            // Arrange
+            var expected = new HttpRequestException("Bad!");
+            _sendAsync = () => throw expected;
+
+            // Act & Assert
+            var actual = await Assert.ThrowsAsync<HttpRequestException>(() => _httpClient.SendAsync(_request));
+            Assert.Same(expected, actual);
+            _telemetryService.Verify(
+                x => x.TrackHttpHeaderDuration(
+                    It.Is<TimeSpan>(ts => ts > TimeSpan.Zero),
+                    _request.Method,
+                    _request.RequestUri,
+                    false,
+                    null,
+                    null),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task EmitsTelemetryOnFailedRequest()
+        {
+            // Arrange
+            var expected = new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                Content = new StringContent("Bad!"),
+            };
+            _sendAsync = () => Task.FromResult(expected);
+
+            // Act
+            var actual = await _httpClient.SendAsync(_request);
+
+            // Assert
+            Assert.Same(expected, actual);
+            _telemetryService.Verify(
+                x => x.TrackHttpHeaderDuration(
+                    It.Is<TimeSpan>(ts => ts > TimeSpan.Zero),
+                    _request.Method,
+                    _request.RequestUri,
+                    false,
+                    expected.StatusCode,
+                    expected.Content.Headers.ContentLength.Value),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task EmitsTelemetryOnSuccessfulRequest()
+        {
+            // Arrange
+            var expected = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("Hello, world!"),
+            };
+            _sendAsync = () => Task.FromResult(expected);
+
+            // Act
+            var actual = await _httpClient.SendAsync(_request);
+
+            // Assert
+            Assert.Same(expected, actual);
+            _telemetryService.Verify(
+                x => x.TrackHttpHeaderDuration(
+                    It.Is<TimeSpan>(ts => ts > TimeSpan.Zero),
+                    _request.Method,
+                    _request.RequestUri,
+                    true,
+                    expected.StatusCode,
+                    expected.Content.Headers.ContentLength.Value),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task AllowsNoContentLength()
+        {
+            // Arrange
+            var expected = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamContent(new NoLengthStream()),
+            };
+            _sendAsync = () => Task.FromResult(expected);
+
+            // Act
+            var actual = await _httpClient.SendAsync(_request, HttpCompletionOption.ResponseHeadersRead);
+
+            // Assert
+            Assert.Same(expected, actual);
+            _telemetryService.Verify(
+                x => x.TrackHttpHeaderDuration(
+                    It.Is<TimeSpan>(ts => ts > TimeSpan.Zero),
+                    _request.Method,
+                    _request.RequestUri,
+                    true,
+                    expected.StatusCode,
+                    null),
+                Times.Once);
+        }
+
+        private class NoLengthStream : Stream
+        {
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position
+            {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
+
+            public override void Flush() => throw new NotSupportedException();
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
+
+        private class FuncHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly Func<Func<Task<HttpResponseMessage>>> _getSendAsync;
+
+            public FuncHttpMessageHandler(Func<Func<Task<HttpResponseMessage>>> getSend)
+            {
+                _getSendAsync = getSend ?? throw new ArgumentNullException(nameof(getSend));
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                await Task.Yield();
+                var sendAsync = _getSendAsync();
+                return await sendAsync();
+            }
+        }
+    }
+}

--- a/tests/CatalogTests/packages.config
+++ b/tests/CatalogTests/packages.config
@@ -4,6 +4,7 @@
   <package id="dotNetRDF" version="1.0.8.3533" targetFramework="net45" />
   <package id="HtmlAgilityPack" version="1.4.9" targetFramework="net45" />
   <package id="json-ld.net" version="1.0.4" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net452" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net452" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net452" />

--- a/tests/NgTests/DnxCatalogCollectorTests.cs
+++ b/tests/NgTests/DnxCatalogCollectorTests.cs
@@ -2,19 +2,23 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json.Linq;
 using NgTests.Data;
 using NgTests.Infrastructure;
 using NuGet.Services.Metadata.Catalog;
 using NuGet.Services.Metadata.Catalog.Dnx;
+using NuGet.Services.Metadata.Catalog.Persistence;
 using Xunit;
 
 namespace NgTests
@@ -24,39 +28,175 @@ namespace NgTests
         private MemoryStorage _catalogToDnxStorage;
         private TestStorageFactory _catalogToDnxStorageFactory;
         private MockServerHttpClientHandler _mockServer;
+        private ILogger<DnxCatalogCollector> _logger;
         private DnxCatalogCollector _target;
 
-        private void SharedInit()
+        public DnxCatalogCollectorTests()
         {
             _catalogToDnxStorage = new MemoryStorage();
             _catalogToDnxStorageFactory = new TestStorageFactory(name => _catalogToDnxStorage.WithName(name));
             _mockServer = new MockServerHttpClientHandler();
             _mockServer.SetAction("/", request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
 
+            var loggerFactory = new LoggerFactory();
+            _logger = loggerFactory.CreateLogger<DnxCatalogCollector>();
+
             // Setup collector
             _target = new DnxCatalogCollector(
                 new Uri("http://tempuri.org/index.json"),
                 _catalogToDnxStorageFactory,
                 new Mock<ITelemetryService>().Object,
+                _logger,
                 () => _mockServer)
             {
-                ContentBaseAddress = new Uri("http://tempuri.org/packages")
-            };            
+                ContentBaseAddress = new Uri("http://tempuri.org/packages/")
+            };
+        }
+
+        [Fact]
+        public async Task SkipsPackagesWhenCannotFindNuspecInNupkg()
+        {
+            // Arrange
+            // This package has no nuspec, and should be ignored.
+            var zipWithNoNuspec = CreateZipStreamWithEntry("readme.txt");
+
+            // This package has a nuspec with the wrong name, which should be accepted.
+            var zipWithWrongNameNuspec = CreateZipStreamWithEntry("Newtonsoft.Json.nuspec");
+            
+            var catalogStorage = Catalogs.CreateTestCatalogWithThreePackages();
+            await _mockServer.AddStorage(catalogStorage);
+
+            _mockServer.SetAction(
+                "/packages/listedpackage.1.0.0.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(zipWithNoNuspec) }));
+            _mockServer.SetAction(
+                "/packages/listedpackage.1.0.1.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\ListedPackage.1.0.1.zip")) }));
+            _mockServer.SetAction(
+                "/packages/unlistedpackage.1.0.0.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(zipWithWrongNameNuspec) }));
+
+            // Setup collector
+            ReadWriteCursor front = new DurableCursor(_catalogToDnxStorage.ResolveUri("cursor.json"), _catalogToDnxStorage, MemoryCursor.MinValue);
+            ReadCursor back = MemoryCursor.CreateMax();
+
+            // Act
+            await _target.Run(front, back, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(7, _catalogToDnxStorage.Content.Count);
+
+            // Ensure storage has cursor.json
+            var cursorJson = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("cursor.json"));
+            Assert.NotNull(cursorJson.Key);
+
+            // Check package entries - ListedPackage
+            var package1Index = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("/listedpackage/index.json"));
+            Assert.NotNull(package1Index.Key);
+            Assert.DoesNotContain("\"1.0.0\"", package1Index.Value.GetContentString());
+            Assert.Contains("\"1.0.1\"", package1Index.Value.GetContentString());
+
+            Assert.Empty(_catalogToDnxStorage.Content.Where(x => x.Key.PathAndQuery.Contains("/listedpackage/1.0.0")));
+
+            var packageNuspec = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("/listedpackage/1.0.1/listedpackage.nuspec"));
+            var packageNupkg = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("/listedpackage/1.0.1/listedpackage.1.0.1.nupkg"));
+            Assert.NotNull(packageNuspec.Key);
+            Assert.NotNull(packageNupkg.Key);
+
+            // Check package entries - UnlistedPackage
+            var package2Index = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("/unlistedpackage/index.json"));
+            Assert.NotNull(package2Index.Key);
+            Assert.Contains("\"1.0.0\"", package2Index.Value.GetContentString());
+
+            var package2Nuspec = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("/unlistedpackage/1.0.0/unlistedpackage.nuspec"));
+            var package2Nupkg = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("/unlistedpackage/1.0.0/unlistedpackage.1.0.0.nupkg"));
+            Assert.NotNull(package2Nuspec.Key);
+            Assert.NotNull(package2Nupkg.Key);
+        }
+
+        private static MemoryStream CreateZipStreamWithEntry(string name)
+        {
+            var zipWithNoNuspec = new MemoryStream();
+            using (var zipArchive = new ZipArchive(zipWithNoNuspec, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                var entry = zipArchive.CreateEntry(name);
+                using (var entryStream = entry.Open())
+                using (var entryWriter = new StreamWriter(entryStream))
+                {
+                    entryWriter.WriteLine("Hello, world.");
+                }
+            }
+            zipWithNoNuspec.Position = 0;
+            return zipWithNoNuspec;
+        }
+
+        [Fact]
+        public async Task SkipsPackagesWhenSourceNupkgIsNotFound()
+        {
+            // Arrange
+            var catalogStorage = Catalogs.CreateTestCatalogWithThreePackages();
+            await _mockServer.AddStorage(catalogStorage);
+
+            _mockServer.SetAction(
+                "/packages/listedpackage.1.0.0.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent("Nothing.") }));
+            _mockServer.SetAction(
+                "/packages/listedpackage.1.0.1.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\ListedPackage.1.0.1.zip")) }));
+            _mockServer.SetAction(
+                "/packages/unlistedpackage.1.0.0.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent("Nothing.") }));
+
+            // Setup collector
+            ReadWriteCursor front = new DurableCursor(_catalogToDnxStorage.ResolveUri("cursor.json"), _catalogToDnxStorage, MemoryCursor.MinValue);
+            ReadCursor back = MemoryCursor.CreateMax();
+
+            // Act
+            await _target.Run(front, back, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(4, _catalogToDnxStorage.Content.Count);
+
+            // Ensure storage has cursor.json
+            var cursorJson = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("cursor.json"));
+            Assert.NotNull(cursorJson.Key);
+
+            // Check package entries - ListedPackage
+            var package1Index = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("/listedpackage/index.json"));
+            Assert.NotNull(package1Index.Key);
+            Assert.DoesNotContain("\"1.0.0\"", package1Index.Value.GetContentString());
+            Assert.Contains("\"1.0.1\"", package1Index.Value.GetContentString());
+
+            Assert.Empty(_catalogToDnxStorage.Content.Where(x => x.Key.PathAndQuery.Contains("/listedpackage/1.0.0")));
+
+            var packageNuspec = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("/listedpackage/1.0.1/listedpackage.nuspec"));
+            var packageNupkg = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("/listedpackage/1.0.1/listedpackage.1.0.1.nupkg"));
+            Assert.NotNull(packageNuspec.Key);
+            Assert.NotNull(packageNupkg.Key);
+
+            // Check package entries - UnlistedPackage
+            Assert.Empty(_catalogToDnxStorage.Content.Where(x => x.Key.PathAndQuery.Contains("unlistedpackage")));
         }
 
         [Fact]
         public async Task CreatesFlatContainerAndRespectsDeletes()
         {
             // Arrange
-            SharedInit();
-            
             var catalogStorage = Catalogs.CreateTestCatalogWithThreePackagesAndDelete();
             await _mockServer.AddStorage(catalogStorage);
 
-            _mockServer.SetAction("/listedpackage.1.0.0.nupkg", request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\ListedPackage.1.0.0.zip")) }));
-            _mockServer.SetAction("/listedpackage.1.0.1.nupkg", request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\ListedPackage.1.0.1.zip")) }));
-            _mockServer.SetAction("/unlistedpackage.1.0.0.nupkg", request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\UnlistedPackage.1.0.0.zip")) }));
-            _mockServer.SetAction("/otherpackage.1.0.0.nupkg", request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\OtherPackage.1.0.0.zip")) }));
+            _mockServer.SetAction(
+                "/packages/listedpackage.1.0.0.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\ListedPackage.1.0.0.zip")) }));
+            _mockServer.SetAction(
+                "/packages/listedpackage.1.0.1.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\ListedPackage.1.0.1.zip")) }));
+            _mockServer.SetAction(
+                "/packages/unlistedpackage.1.0.0.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\UnlistedPackage.1.0.0.zip")) }));
+            _mockServer.SetAction(
+                "/packages/otherpackage.1.0.0.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\OtherPackage.1.0.0.zip")) }));
 
             // Setup collector
             ReadWriteCursor front = new DurableCursor(_catalogToDnxStorage.ResolveUri("cursor.json"), _catalogToDnxStorage, MemoryCursor.MinValue);
@@ -107,21 +247,240 @@ namespace NgTests
             Assert.Null(otherPackageNupkg.Key);
         }
 
+        [Fact]
+        public async Task SkipsPackagesThatAreAlreadySynchronized()
+        {
+            // Arrange
+            _catalogToDnxStorage = new SynchronizedMemoryStorage(new[]
+            {
+                new Uri("http://tempuri.org/packages/listedpackage.1.0.1.nupkg"),
+            });
+            _catalogToDnxStorageFactory = new TestStorageFactory(name => _catalogToDnxStorage.WithName(name));
+
+            // Setup collector
+            _target = new DnxCatalogCollector(
+                new Uri("http://tempuri.org/index.json"),
+                _catalogToDnxStorageFactory,
+                new Mock<ITelemetryService>().Object,
+                _logger,
+                () => _mockServer)
+            {
+                ContentBaseAddress = new Uri("http://tempuri.org/packages/")
+            };
+
+            var catalogStorage = Catalogs.CreateTestCatalogWithThreePackagesAndDelete();
+            await _mockServer.AddStorage(catalogStorage);
+
+            _mockServer.SetAction(
+                "/packages/listedpackage.1.0.0.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\ListedPackage.1.0.0.zip")) }));
+            _mockServer.SetAction(
+                "/packages/listedpackage.1.0.1.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\ListedPackage.1.0.1.zip")) }));
+            _mockServer.SetAction(
+                "/packages/unlistedpackage.1.0.0.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\UnlistedPackage.1.0.0.zip")) }));
+            _mockServer.SetAction(
+                "/packages/otherpackage.1.0.0.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\OtherPackage.1.0.0.zip")) }));
+
+            // Setup collector
+            ReadWriteCursor front = new DurableCursor(_catalogToDnxStorage.ResolveUri("cursor.json"), _catalogToDnxStorage, MemoryCursor.MinValue);
+            ReadCursor back = MemoryCursor.CreateMax();
+
+            // Act
+            await _target.Run(front, back, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(7, _catalogToDnxStorage.Content.Count);
+
+            Assert.NotEmpty(_mockServer.Requests.Where(x => x.RequestUri.AbsoluteUri.Contains("unlistedpackage.1.0.0.nupkg")));
+            Assert.NotEmpty(_mockServer.Requests.Where(x => x.RequestUri.AbsoluteUri.Contains("listedpackage.1.0.0.nupkg")));
+            Assert.Empty(_mockServer.Requests.Where(x => x.RequestUri.AbsoluteUri.Contains("listedpackage.1.0.1.nupkg")));
+
+            // Ensure storage has cursor.json
+            var cursorJson = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("cursor.json"));
+            Assert.NotNull(cursorJson.Key);
+
+            // Check package entries - ListedPackage
+            var package1Index = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("/listedpackage/index.json"));
+            Assert.NotNull(package1Index.Key);
+            Assert.Contains("\"1.0.0\"", package1Index.Value.GetContentString());
+            Assert.DoesNotContain("\"1.0.1\"", package1Index.Value.GetContentString());
+
+            var package1Nuspec = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("/listedpackage/1.0.0/listedpackage.nuspec"));
+            var package1Nupkg = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("/listedpackage/1.0.0/listedpackage.1.0.0.nupkg"));
+            Assert.NotNull(package1Nuspec.Key);
+            Assert.NotNull(package1Nupkg.Key);
+
+            Assert.Empty(_catalogToDnxStorage.Content.Where(x => x.Key.PathAndQuery.Contains("listedpackage/1.0.1")));
+
+            // Check package entries - UnlistedPackage
+            var package2Index = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("/unlistedpackage/index.json"));
+            Assert.NotNull(package2Index.Key);
+            Assert.Contains("\"1.0.0\"", package2Index.Value.GetContentString());
+
+            var package2Nuspec = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("/unlistedpackage/1.0.0/unlistedpackage.nuspec"));
+            var package2Nupkg = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("/unlistedpackage/1.0.0/unlistedpackage.1.0.0.nupkg"));
+            Assert.NotNull(package2Nuspec.Key);
+            Assert.NotNull(package2Nupkg.Key);
+
+            // Ensure storage does not have the deleted "OtherPackage"
+            var otherPackageIndex = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("/otherpackage/index.json"));
+            var otherPackageNuspec = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("/otherpackage/1.0.0/otherpackage.nuspec"));
+            var otherPackageNupkg = _catalogToDnxStorage.Content.FirstOrDefault(pair => pair.Key.PathAndQuery.EndsWith("/otherpackage/1.0.0/otherpackage.1.0.0.nupkg"));
+            Assert.Null(otherPackageIndex.Key);
+            Assert.Null(otherPackageNuspec.Key);
+            Assert.Null(otherPackageNupkg.Key);
+        }
+
         [Theory]
-        [InlineData("/unlistedpackage.1.0.0.nupkg", null)]
-        [InlineData("/listedpackage.1.0.1.nupkg", "2015-10-12T10:08:54.1506742Z")]
-        [InlineData("/anotherpackage.1.0.0.nupkg", "2015-10-12T10:08:54.1506742Z")]
+        [InlineData(HttpStatusCode.BadRequest)]
+        [InlineData(HttpStatusCode.Unauthorized)]
+        [InlineData(HttpStatusCode.Forbidden)]
+        [InlineData(HttpStatusCode.NoContent)]
+        [InlineData(HttpStatusCode.InternalServerError)]
+        [InlineData(HttpStatusCode.ServiceUnavailable)]
+        public async Task RejectsUnexpectedHttpStatusCodeWhenDownloadingPackage(HttpStatusCode statusCode)
+        {
+            // Arrange
+            var catalogStorage = Catalogs.CreateTestCatalogWithThreePackagesAndDelete();
+            await _mockServer.AddStorage(catalogStorage);
+            _mockServer.Return404OnUnknownAction = true;
+
+            _mockServer.SetAction(
+                "/packages/listedpackage.1.0.0.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(statusCode) { Content = new ByteArrayContent(new byte[0]) }));
+
+            // Setup collector
+            ReadWriteCursor front = new DurableCursor(_catalogToDnxStorage.ResolveUri("cursor.json"), _catalogToDnxStorage, MemoryCursor.MinValue);
+            ReadCursor back = MemoryCursor.CreateMax();
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => _target.Run(front, back, CancellationToken.None));
+            Assert.Equal(
+                $"Expected status code OK for package download, actual: {statusCode}",
+                ex.Message);
+            Assert.Equal(0, _catalogToDnxStorage.Content.Count);
+        }
+
+        [Fact]
+        public async Task OnlyDownloadsNupkgOncePerCatalogLeaf()
+        {
+            // Arrange
+            var catalogStorage = Catalogs.CreateTestCatalogWithThreePackagesAndDelete();
+            await _mockServer.AddStorage(catalogStorage);
+
+            _mockServer.SetAction(
+                "/packages/listedpackage.1.0.0.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\ListedPackage.1.0.0.zip")) }));
+            _mockServer.SetAction(
+                "/packages/listedpackage.1.0.1.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\ListedPackage.1.0.1.zip")) }));
+            _mockServer.SetAction(
+                "/packages/unlistedpackage.1.0.0.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\UnlistedPackage.1.0.0.zip")) }));
+            _mockServer.SetAction(
+                "/packages/otherpackage.1.0.0.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\OtherPackage.1.0.0.zip")) }));
+
+            // Setup collector
+            ReadWriteCursor front = new DurableCursor(_catalogToDnxStorage.ResolveUri("cursor.json"), _catalogToDnxStorage, MemoryCursor.MinValue);
+            ReadCursor back = MemoryCursor.CreateMax();
+
+            // Act
+            await _target.Run(front, back, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(9, _catalogToDnxStorage.Content.Count);
+
+            Assert.Equal(5, _mockServer.Requests.Count);
+            Assert.EndsWith("/index.json", _mockServer.Requests[0].RequestUri.AbsoluteUri);
+            Assert.EndsWith("/page0.json", _mockServer.Requests[1].RequestUri.AbsoluteUri);
+            Assert.Contains("/unlistedpackage.1.0.0.nupkg", _mockServer.Requests[2].RequestUri.AbsoluteUri);
+            Assert.Contains("/listedpackage.1.0.0.nupkg", _mockServer.Requests[3].RequestUri.AbsoluteUri);
+            Assert.Contains("/listedpackage.1.0.1.nupkg", _mockServer.Requests[4].RequestUri.AbsoluteUri);
+        }
+
+        [Fact]
+        public async Task StoresCorrectPackageContent()
+        {
+            // Arrange
+            var catalogStorage = Catalogs.CreateTestCatalogWithThreePackagesAndDelete();
+            await _mockServer.AddStorage(catalogStorage);
+
+            _mockServer.SetAction(
+                "/packages/listedpackage.1.0.0.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\ListedPackage.1.0.0.zip")) }));
+            _mockServer.SetAction(
+                "/packages/listedpackage.1.0.1.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\ListedPackage.1.0.1.zip")) }));
+            _mockServer.SetAction(
+                "/packages/unlistedpackage.1.0.0.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\UnlistedPackage.1.0.0.zip")) }));
+            _mockServer.SetAction(
+                "/packages/otherpackage.1.0.0.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\OtherPackage.1.0.0.zip")) }));
+
+            // Setup collector
+            ReadWriteCursor front = new DurableCursor(_catalogToDnxStorage.ResolveUri("cursor.json"), _catalogToDnxStorage, MemoryCursor.MinValue);
+            ReadCursor back = MemoryCursor.CreateMax();
+
+            // Act
+            await _target.Run(front, back, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(9, _catalogToDnxStorage.Content.Count);
+
+            VerifyContentBytes(
+                "Packages\\ListedPackage.1.0.0.zip",
+                new Uri("http://tempuri.org/listedpackage/1.0.0/listedpackage.1.0.0.nupkg"));
+            VerifyContentBytes(
+                "Packages\\ListedPackage.1.0.1.zip",
+                new Uri("http://tempuri.org/listedpackage/1.0.1/listedpackage.1.0.1.nupkg"));
+            VerifyContentBytes(
+                "Packages\\UnlistedPackage.1.0.0.zip",
+                new Uri("http://tempuri.org/unlistedpackage/1.0.0/unlistedpackage.1.0.0.nupkg"));
+        }
+
+        private void VerifyContentBytes(string srcFilePath, Uri destUri)
+        {
+            var srcBytes = GetStreamBytes(File.OpenRead(srcFilePath));
+            var destBytes = _catalogToDnxStorage.ContentBytes[destUri];
+
+            Assert.Equal(srcBytes, destBytes);
+        }
+
+        private byte[] GetStreamBytes(Stream srcStream)
+        {
+            using (srcStream)
+            using (var memoryStream = new MemoryStream())
+            {
+                srcStream.CopyTo(memoryStream);
+                return memoryStream.ToArray();
+            }
+        }
+
+        [Theory]
+        [InlineData("/packages/unlistedpackage.1.0.0.nupkg", null)]
+        [InlineData("/packages/listedpackage.1.0.1.nupkg", "2015-10-12T10:08:54.1506742Z")]
+        [InlineData("/packages/anotherpackage.1.0.0.nupkg", "2015-10-12T10:08:54.1506742Z")]
         public async Task DoesNotSkipPackagesWhenExceptionOccurs(string catalogUri, string expectedCursorBeforeRetry)
         {
-            // Arrange 
-            SharedInit();
-
+            // Arrange
             var catalogStorage = Catalogs.CreateTestCatalogWithCommitThenTwoPackageCommit();
             await _mockServer.AddStorage(catalogStorage);
 
-            _mockServer.SetAction("/unlistedpackage.1.0.0.nupkg", request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\UnlistedPackage.1.0.0.zip")) }));
-            _mockServer.SetAction("/listedpackage.1.0.1.nupkg", request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\ListedPackage.1.0.1.zip")) }));
-            _mockServer.SetAction("/anotherpackage.1.0.0.nupkg", request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\ListedPackage.1.0.0.zip")) }));
+            _mockServer.SetAction(
+                "/packages/unlistedpackage.1.0.0.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\UnlistedPackage.1.0.0.zip")) }));
+            _mockServer.SetAction(
+                "/packages/listedpackage.1.0.1.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\ListedPackage.1.0.1.zip")) }));
+            _mockServer.SetAction(
+                "/packages/anotherpackage.1.0.0.nupkg",
+                request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(File.OpenRead("Packages\\ListedPackage.1.0.0.zip")) }));
 
             // Make the first request for a catalog leaf node fail. This will cause the registration collector
             // to fail the first time but pass the second time.
@@ -270,5 +629,39 @@ namespace NgTests
             Assert.Equal(catalogToDnxStorage.Content.Count, 0);
         }
 
+        private class SynchronizedMemoryStorage : MemoryStorage
+        {
+            private readonly HashSet<Uri> _synchronizedUris;
+            private Dictionary<Uri, StorageContent> content;
+
+            public SynchronizedMemoryStorage(IEnumerable<Uri> synchronizedUris)
+            {
+                _synchronizedUris = new HashSet<Uri>(synchronizedUris);
+            }
+
+            protected SynchronizedMemoryStorage(
+                Uri baseAddress,
+                Dictionary<Uri, StorageContent> content,
+                Dictionary<Uri, byte[]> contentBytes,
+                HashSet<Uri> synchronizedUris)
+                : base(baseAddress, content, contentBytes)
+            {
+                _synchronizedUris = synchronizedUris;
+            }
+
+            public override Task<bool> AreSyncronized(Uri firstResourceUri, Uri secondResourceUri)
+            {
+                return Task.FromResult(_synchronizedUris.Contains(firstResourceUri));
+            }
+
+            public override Storage WithName(string name)
+            {
+                return new SynchronizedMemoryStorage(
+                    new Uri(BaseAddress + name),
+                    Content,
+                    ContentBytes,
+                    _synchronizedUris);
+            }
+        }
     }
 }

--- a/tests/NgTests/NgTests.csproj
+++ b/tests/NgTests/NgTests.csproj
@@ -192,6 +192,7 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>


### PR DESCRIPTION
Address https://github.com/NuGet/Engineering/issues/1261.

- Add `-httpClientTimeoutInSeconds` option to catalog2dnx.
- Only download the .nupkg once
- Download the .nupkg to disk and use this stream for getting .nuspec and for uploading to flat container
- Improve the tests a lot
- Only accept the HTTP response if it is 200 OK. We previously allowed any 2XX.