### PR TITLE
Don't no-op added package in catalog2dnx if version is missing

### DIFF
--- a/src/Catalog/Persistence/AzureStorage.cs
+++ b/src/Catalog/Persistence/AzureStorage.cs
@@ -283,7 +283,7 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             return new Uri(_directory.Uri, name);
         }
 
-        public override async Task<bool> AreSyncronized(Uri firstResourceUri, Uri secondResourceUri)
+        public override async Task<bool> AreSynchronized(Uri firstResourceUri, Uri secondResourceUri)
         {
             var destination = _directory.GetBlockBlobReference(GetName(secondResourceUri));
             var source = new CloudBlockBlob(firstResourceUri);

--- a/src/Catalog/Persistence/Storage.cs
+++ b/src/Catalog/Persistence/Storage.cs
@@ -176,7 +176,7 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
         /// <param name="firstResourceUri">The first uri.</param>
         /// <param name="secondResourceUri">The second uri.</param>
         /// <returns>Default returns false.</returns>
-        public virtual Task<bool> AreSyncronized(Uri firstResourceUri, Uri secondResourceUri)
+        public virtual Task<bool> AreSynchronized(Uri firstResourceUri, Uri secondResourceUri)
         {
             return Task.FromResult(false);
         }


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/5473.
Depends on https://github.com/NuGet/NuGet.Services.Metadata/pull/278.

If the added package version is not in the `{id}/index.json`, then don't no-op the add. This can happen if on first attempt that .nupkg is uploaded properly but the .nuspec upload or index.json upload fails and the job retries.

This does make catalog2dnx slower but ideally the index.json download is relatively small compared to the .nupkg upload so we still get a big win.

This is one instance of this happening: https://github.com/NuGet/NuGetGallery/issues/5720