### PR TITLE
Polish V3PerPackage now that it's tested against all packages

### DIFF
--- a/src/V3PerPackage/PerWorkerProcessor.cs
+++ b/src/V3PerPackage/PerWorkerProcessor.cs
@@ -73,7 +73,7 @@ namespace NuGet.Services.V3PerPackage
                     packageContexts.Add(new PerPackageContext(batchContext, packageId, packageVersion));
                 }
             }
-            while (messages.Count < batchSize && lastMessage != null && lastDequeueCount <= 1);
+            while (messages.Count < batchSize && lastMessage != null && lastDequeueCount < 10);
 
             if (packageContexts.Count == 0)
             {

--- a/src/V3PerPackage/Program.cs
+++ b/src/V3PerPackage/Program.cs
@@ -144,6 +144,7 @@ namespace NuGet.Services.V3PerPackage
 
             serviceCollection.AddSingleton(new ControlledDisposeHttpClientHandler());
             serviceCollection.AddTransient<HttpMessageHandler>(x => x.GetRequiredService<ControlledDisposeHttpClientHandler>());
+            serviceCollection.AddSingleton(x => new HttpClient(x.GetRequiredService<HttpMessageHandler>()));
             serviceCollection.AddTransient<Func<HttpMessageHandler>>(x => () => x.GetRequiredService<HttpMessageHandler>());
             serviceCollection.AddTransient<PerBatchProcessor>();
             serviceCollection.AddTransient<ITelemetryService, TelemetryService>();


### PR DESCRIPTION
1. Don't process deleted packages
1. Allow messages to be batches if they have 10 or fewer attempts. There is no automatic DLQ on Azure Storage Queues. This allows us to quickly get through messages that failed due to transient issues.

I have run the tool over all of PROD and these are two changes I made locally to get through everything quickly.