### PR TITLE
Move header from web.config to web.release.config

### DIFF
--- a/src/NuGet.Services.BasicSearch/Web.Release.config
+++ b/src/NuGet.Services.BasicSearch/Web.Release.config
@@ -9,6 +9,7 @@
     <httpProtocol xdt:Transform="Insert">
       <customHeaders>
         <add name="Arr-Disable-Session-Affinity" value="true" />
+        <add name="X-Content-Type-Options" value="nosniff" />
       </customHeaders>
     </httpProtocol>
     <httpCompression xdt:Transform="Insert">

--- a/src/NuGet.Services.BasicSearch/Web.config
+++ b/src/NuGet.Services.BasicSearch/Web.config
@@ -60,11 +60,6 @@
       <remove name="TRACEVerbHandler" />
       <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers>
-    <httpProtocol>
-      <customHeaders>
-        <add name="X-Content-Type-Options" value="nosniff" />
-      </customHeaders>
-    </httpProtocol>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">


### PR DESCRIPTION
The merge on build was causing a duplication of the httpProtocol section, which would cause the service to fail to start up.

Move this to the web.release.config where the other header lives.