### PR TITLE
Add FilteredVersionList to determine SearchIndexChangeType

### DIFF
--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -35,10 +35,13 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="VersionList\FilteredVersionProperties.cs" />
     <Compile Include="VersionList\ResultAndAccessCondition.cs" />
+    <Compile Include="VersionList\SearchIndexChangeType.cs" />
     <Compile Include="VersionList\SemVerOrderedDictionaryJsonConverter.cs" />
     <Compile Include="VersionList\VersionListDataClient.cs" />
     <Compile Include="VersionList\VersionListData.cs" />
+    <Compile Include="VersionList\FilteredVersionList.cs" />
     <Compile Include="VersionList\VersionPropertiesData.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />

--- a/src/NuGet.Services.AzureSearch/VersionList/FilteredVersionList.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/FilteredVersionList.cs
@@ -1,0 +1,203 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Versioning;
+
+namespace NuGet.Services.AzureSearch
+{
+    /// <summary>
+    /// This type tracks a version list for a specific <see cref="SearchFilters"/>. In other words, this implementation
+    /// assumes that a non-applicable version is never added to the list. In practice, <see cref="VersionLists"/> does
+    /// this filtering before adding a version to this list.
+    /// </summary>
+    internal class FilteredVersionList
+    {
+        internal NuGetVersion _latestOrNull;
+        internal readonly SortedList<NuGetVersion, FilteredVersionProperties> _versions;
+
+        public FilteredVersionList(IEnumerable<FilteredVersionProperties> versions)
+        {
+            if (versions == null)
+            {
+                throw new ArgumentNullException(nameof(versions));
+            }
+
+            _versions = new SortedList<NuGetVersion, FilteredVersionProperties>();
+
+            foreach (var version in versions)
+            {
+                _versions[version.ParsedVersion] = version;
+            }
+
+            _latestOrNull = CalculateLatest();
+        }
+
+        public string LatestOrNull
+        {
+            get
+            {
+                if (_latestOrNull == null)
+                {
+                    return null;
+                }
+
+                return _versions[_latestOrNull].FullVersion;
+            }
+        }
+
+        public IReadOnlyList<string> FullVersions => _versions
+            .Where(x => x.Value.Listed)
+            .Select(x => x.Value.FullVersion)
+            .ToList();
+
+        public SearchIndexChangeType Delete(NuGetVersion deleted)
+        {
+            var ctx = UpdateVersionList(
+                (v, p) => _versions.Remove(v),
+                deleted,
+                newProperties: null);
+
+            return DeleteFromSearchIndex(ctx);
+        }
+
+        public SearchIndexChangeType Upsert(FilteredVersionProperties addedProperties)
+        {
+            var ctx = UpdateVersionList(
+                (v, p) => _versions[v] = p,
+                addedProperties.ParsedVersion,
+                addedProperties);
+
+            return UpsertToSearchIndex(ctx);
+        }
+
+        private static SearchIndexChangeType DeleteFromSearchIndex(Context ctx)
+        {
+            if (ctx.NewLatest == null)
+            {
+                // If there is no longer a latest version, the search document should be deleted.
+                return SearchIndexChangeType.Delete;
+            }
+
+            if (ctx.NewLatest != ctx.OldLatest)
+            {
+                // If the latest version changes due to deletion, this can only happen if the existing latest version
+                // was the one that was deleted.
+                Assert(ctx.OldProperties != null, "This version should have existed before.");
+                Assert(ctx.OldProperties.Listed, "The existing version should have been listed.");
+                Assert(ctx.OldLatest == ctx.ChangedVersion, "The existing latest should be the deleted version.");
+                return SearchIndexChangeType.DowngradeLatest;
+            }
+
+            // It's possible some cases (such as removing a version that didn't exist in the first place) could be
+            // handled without any change to the search index. However, to support the reflow case, we update the
+            // version list to make sure it is consistent.
+            return SearchIndexChangeType.UpdateVersionList;
+        }
+
+        private static SearchIndexChangeType UpsertToSearchIndex(Context ctx)
+        {
+            if (ctx.NewLatest == null)
+            {
+                // If there is no longer a latest version, the search document should be deleted.
+                return SearchIndexChangeType.Delete;
+            }
+
+            if (ctx.OldLatest == null && ctx.NewLatest != null)
+            {
+                // If there was no latest version before but now there is a latest version, then we have just added
+                // the only listed version. The new latest version is of course the version we are adding right now.
+                Assert(ctx.NewLatest == ctx.ChangedVersion, "The first latest version must be the added version.");
+                Assert(ctx.NewProperties.Listed, "The added version should be listed for the latest version to have changed.");
+                return SearchIndexChangeType.AddFirst;
+            }
+
+            if (ctx.NewLatest == ctx.ChangedVersion)
+            {
+                // If the latest version has not changed or the latest version is the version we just added,
+                // then we need to update the existing metadata. This includes updating the latest version string.
+                return SearchIndexChangeType.UpdateLatest;
+            }
+
+            if (ctx.NewLatest < ctx.OldLatest)
+            {
+                // If the new latest is a lower version than the old latest, this is a special case where we need to
+                // look up the old new latest's metadata.
+                Assert(ctx.NewLatest != ctx.ChangedVersion, "This case should already have been handled.");
+                Assert(ctx.OldLatest == ctx.ChangedVersion, "This case should already have been handled.");
+                Assert(!ctx.NewProperties.Listed, "A downgrade from an upserted version can only happen from an unlist.");
+                return SearchIndexChangeType.DowngradeLatest;
+            }
+
+            // It's possible some cases (such as unlisting a version that didn't exist in the first place) could be
+            // handled without any change to the search index. However, to support the reflow case, we update the
+            // version list to make sure it is consistent.
+            return SearchIndexChangeType.UpdateVersionList;
+        }
+
+        private static void Assert(bool condition, string message)
+        {
+            /// We could use <see cref="System.Diagnostics.Debug.Assert(bool, string)"/> here, but it's preferable
+            /// in this case to even fail on a non-Debug build.
+            if (!condition)
+            {
+                throw new InvalidOperationException(message);
+            }
+        }
+
+        private Context UpdateVersionList(
+            Action<NuGetVersion, FilteredVersionProperties> update,
+            NuGetVersion version,
+            FilteredVersionProperties newProperties)
+        {
+            var oldLatest = _latestOrNull;
+
+            _versions.TryGetValue(version, out var oldProperties);
+
+            update(version, newProperties);
+
+            _latestOrNull = CalculateLatest();
+
+            return new Context(
+                version,
+                oldProperties,
+                newProperties,
+                oldLatest,
+                _latestOrNull);
+        }
+
+        private NuGetVersion CalculateLatest()
+        {
+            return _versions
+                .Reverse()
+                .Where(x => x.Value.Listed)
+                .Select(x => x.Key)
+                .FirstOrDefault();
+        }
+
+        private class Context
+        {
+            public Context(
+                NuGetVersion changedVersion,
+                FilteredVersionProperties oldProperties,
+                FilteredVersionProperties newProperties,
+                NuGetVersion oldLatest,
+                NuGetVersion newLatest)
+            {
+                ChangedVersion = changedVersion ?? throw new ArgumentNullException(nameof(changedVersion));
+                OldProperties = oldProperties;
+                NewProperties = newProperties;
+                OldLatest = oldLatest;
+                NewLatest = newLatest;
+            }
+
+            public NuGetVersion ChangedVersion { get; }
+            public FilteredVersionProperties OldProperties { get; }
+            public FilteredVersionProperties NewProperties { get; }
+            public NuGetVersion OldLatest { get; }
+            public NuGetVersion NewLatest { get; }
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/VersionList/FilteredVersionProperties.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/FilteredVersionProperties.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Versioning;
+
+namespace NuGet.Services.AzureSearch
+{
+    /// <summary>
+    /// Version properties needed by <see cref="FilteredVersionList"/>. This is a subset of information needed by
+    /// <see cref="VersionLists"/>. The extra information not contained in this class (such as
+    /// <see cref="VersionPropertiesData.SemVer2"/>) is only used for filtering.
+    /// </summary>
+    internal class FilteredVersionProperties
+    {
+        public FilteredVersionProperties(string fullVersion, bool listed)
+        {
+            if (fullVersion == null)
+            {
+                throw new ArgumentNullException(nameof(fullVersion));
+            }
+
+            ParsedVersion = NuGetVersion.Parse(fullVersion);
+            FullVersion = ParsedVersion.ToFullString();
+            Listed = listed;
+        }
+
+        public string FullVersion { get; }
+        public NuGetVersion ParsedVersion { get; }
+        public bool Listed { get; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/VersionList/SearchIndexChangeType.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/SearchIndexChangeType.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.AzureSearch
+{
+    public enum SearchIndexChangeType
+    {
+        /// <summary>
+        /// The only change necessary is updating the version list. Some potentially no-op cases also fall into this
+        /// category to support reflowing.
+        /// </summary>
+        UpdateVersionList,
+
+        /// <summary>
+        /// The latest version has been deleted or unlisted, so we need to replace the latest version metadata with an
+        /// older version's metadata.
+        /// </summary>
+        DowngradeLatest,
+
+        /// <summary>
+        /// Update the latest version's metadata and version list. This represents both updating the metadata of the
+        /// existing latest version and changing the latest version and metadata to a later version.
+        /// </summary>
+        UpdateLatest,
+
+        /// <summary>
+        /// The first listed version has been added, so we need to fetch owner information in addition to replacing
+        /// metadata and version list.
+        /// </summary>
+        AddFirst,
+
+        /// <summary>
+        /// The last version was unlisted or deleted, so we need to delete the document from the index. Some
+        /// potentially no-op cases also fall into this category to support reflowing.
+        /// </summary>
+        Delete,
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/FilteredVersionListFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/FilteredVersionListFacts.cs
@@ -1,0 +1,489 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Versioning;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class FilteredVersionListFacts
+    {
+        public class Upsert : BaseFacts
+        {
+            [Fact]
+            public void ReplacesLatestFullVersionByNormalizedVersion()
+            {
+                ClearList();
+                _list.Upsert(new FilteredVersionProperties("1.02.0-Alpha.1+git", listed: true));
+
+                var type = _list.Upsert(new FilteredVersionProperties("1.2.0.0-ALPHA.1+somethingelse", listed: true));
+
+                Assert.Equal(SearchIndexChangeType.UpdateLatest, type);
+                Assert.Equal(new[] { "1.2.0-ALPHA.1+somethingelse" }, _list.FullVersions.ToArray());
+            }
+
+            [Fact]
+            public void ReplacesNonLatestFullVersionByNormalizedVersion()
+            {
+                ClearList();
+                _list.Upsert(new FilteredVersionProperties("2.0.0", listed: true));
+                _list.Upsert(new FilteredVersionProperties("1.02.0-Alpha.1+git", listed: true));
+
+                var type = _list.Upsert(new FilteredVersionProperties("1.2.0.0-ALPHA.1+somethingelse", listed: true));
+
+                Assert.Equal(SearchIndexChangeType.UpdateVersionList, type);
+                Assert.Equal(new[] { "1.2.0-ALPHA.1+somethingelse", "2.0.0" }, _list.FullVersions.ToArray());
+            }
+
+            [Theory]
+            [MemberData(nameof(PreviousAndNextVersions))]
+            public void UpdateVersionListForAddingUnlistedVersion(string version)
+            {
+                var unlisted = new FilteredVersionProperties(version, listed: false);
+
+                var type = _list.Upsert(unlisted);
+
+                Assert.Equal(SearchIndexChangeType.UpdateVersionList, type);
+                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialParsedVersion, _list._latestOrNull);
+                Assert.Equal(new[] { InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(
+                    new[] { unlisted.ParsedVersion, InitialParsedVersion }.OrderBy(x => x).ToArray(),
+                    _list._versions.Keys.ToArray());
+            }
+
+            [Fact]
+            public void AddFirstWhenAddingVeryFirstVersion()
+            {
+                ClearList();
+
+                var type = _list.Upsert(_initialVersionProperties);
+
+                Assert.Equal(SearchIndexChangeType.AddFirst, type);
+                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialParsedVersion, _list._latestOrNull);
+                Assert.Equal(new[] { InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
+            }
+
+            [Theory]
+            [MemberData(nameof(PreviousAndNextVersions))]
+            public void AddFirstWhenAddingFirstListedVersion(string version)
+            {
+                StartWithUnlisted();
+                var listed = new FilteredVersionProperties(version, listed: true);
+
+                var type = _list.Upsert(listed);
+
+                Assert.Equal(SearchIndexChangeType.AddFirst, type);
+                Assert.Equal(listed.FullVersion, _list.LatestOrNull);
+                Assert.Equal(listed.ParsedVersion, _list._latestOrNull);
+                Assert.Equal(new[] { listed.FullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(
+                    new[] { InitialParsedVersion, listed.ParsedVersion }.OrderBy(x => x).ToArray(),
+                    _list._versions.Keys.ToArray());
+            }
+
+            [Fact]
+            public void DeleteWhenUnlistingLatestAndNoOtherVersions()
+            {
+                var type = _list.Upsert(_unlistedVersionProperties);
+
+                Assert.Equal(SearchIndexChangeType.Delete, type);
+                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list._latestOrNull);
+                Assert.Empty(_list.FullVersions);
+                Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
+            }
+
+            [Theory]
+            [MemberData(nameof(PreviousAndNextVersions))]
+            public void DeleteWhenUnlistingLatestWithOtherUnlistedVersions(string version)
+            {
+                var unlisted = new FilteredVersionProperties(version, listed: false);
+                _list.Upsert(unlisted);
+
+                var type = _list.Upsert(_unlistedVersionProperties);
+
+                Assert.Equal(SearchIndexChangeType.Delete, type);
+                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list._latestOrNull);
+                Assert.Empty(_list.FullVersions);
+                Assert.Equal(
+                    new[] { InitialParsedVersion, unlisted.ParsedVersion }.OrderBy(x => x).ToArray(),
+                    _list._versions.Keys.ToArray());
+            }
+
+            [Fact]
+            public void DowngradeLatestWhenUnlistingLatestWithOtherListedVersion()
+            {
+                var listed = new FilteredVersionProperties(PreviousVersion, listed: true);
+                _list.Upsert(listed);
+
+                var type = _list.Upsert(_unlistedVersionProperties);
+
+                Assert.Equal(SearchIndexChangeType.DowngradeLatest, type);
+                Assert.Equal(listed.FullVersion, _list.LatestOrNull);
+                Assert.Equal(listed.ParsedVersion, _list._latestOrNull);
+                Assert.Equal(new[] { listed.FullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { listed.ParsedVersion, InitialParsedVersion }, _list._versions.Keys.ToArray());
+            }
+
+            [Fact]
+            public void UpdateVersionListWhenUnlistingNonLatestVersion()
+            {
+                var listed = new FilteredVersionProperties(NextVersion, listed: true);
+                _list.Upsert(listed);
+
+                var type = _list.Upsert(_unlistedVersionProperties);
+
+                Assert.Equal(SearchIndexChangeType.UpdateVersionList, type);
+                Assert.Equal(listed.FullVersion, _list.LatestOrNull);
+                Assert.Equal(listed.ParsedVersion, _list._latestOrNull);
+                Assert.Equal(new[] { listed.FullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { InitialParsedVersion, listed.ParsedVersion }, _list._versions.Keys.ToArray());
+            }
+
+            [Fact]
+            public void UpdateVersionListWhenAddingListedNonLatestVersion()
+            {
+                var listed = new FilteredVersionProperties(PreviousVersion, listed: true);
+
+                var type = _list.Upsert(listed);
+
+                Assert.Equal(SearchIndexChangeType.UpdateVersionList, type);
+                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialParsedVersion, _list._latestOrNull);
+                Assert.Equal(new[] { PreviousVersion, InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { listed.ParsedVersion, InitialParsedVersion }, _list._versions.Keys.ToArray());
+            }
+
+            [Fact]
+            public void UpdateVersionListWhenRelistingNonLatestVersion()
+            {
+                var listed = new FilteredVersionProperties(PreviousVersion, listed: true);
+                _list.Upsert(listed);
+
+                var type = _list.Upsert(listed);
+
+                Assert.Equal(SearchIndexChangeType.UpdateVersionList, type);
+                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialParsedVersion, _list._latestOrNull);
+                Assert.Equal(new[] { PreviousVersion, InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { listed.ParsedVersion, InitialParsedVersion }, _list._versions.Keys.ToArray());
+            }
+
+            [Fact]
+            public void DeleteWhenUnlistingUnlistedVersionAndNoOtherVersions()
+            {
+                StartWithUnlisted();
+
+                var type = _list.Upsert(_unlistedVersionProperties);
+
+                Assert.Equal(SearchIndexChangeType.Delete, type);
+                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list._latestOrNull);
+                Assert.Empty(_list.FullVersions);
+                Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
+            }
+
+            [Fact]
+            public void DeleteWhenUnlistingNewVersionAndNoOtherVersions()
+            {
+                ClearList();
+
+                var type = _list.Upsert(_unlistedVersionProperties);
+
+                Assert.Equal(SearchIndexChangeType.Delete, type);
+                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list._latestOrNull);
+                Assert.Empty(_list.FullVersions);
+                Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
+            }
+
+            [Fact]
+            public void UpdateExistingWhenRelistingLatestVersion()
+            {
+                var type = _list.Upsert(_initialVersionProperties);
+
+                Assert.Equal(SearchIndexChangeType.UpdateLatest, type);
+                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialParsedVersion, _list._latestOrNull);
+                Assert.Equal(new[] { InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
+            }
+
+            [Fact]
+            public void UpdateExistingNewVersionIsIntroduced()
+            {
+                ClearList();
+                var listed = new FilteredVersionProperties(PreviousVersion, listed: true);
+                _list.Upsert(listed);
+
+                var type = _list.Upsert(_initialVersionProperties);
+
+                Assert.Equal(SearchIndexChangeType.UpdateLatest, type);
+                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialParsedVersion, _list._latestOrNull);
+                Assert.Equal(new[] { listed.FullVersion, InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { listed.ParsedVersion, InitialParsedVersion }, _list._versions.Keys.ToArray());
+            }
+        }
+
+        public class Delete : BaseFacts
+        {
+            [Fact]
+            public void DeletesByNormalizedVersion()
+            {
+                ClearList();
+                _list.Upsert(new FilteredVersionProperties("1.02.0-Alpha.1+git", listed: true));
+
+                var type = _list.Delete("1.2.0.0-ALPHA.1+somethingelse");
+
+                Assert.Equal(SearchIndexChangeType.Delete, type);
+                Assert.Empty(_list._versions);
+            }
+
+            [Theory]
+            [MemberData(nameof(PreviousAndNextVersions))]
+            public void UpdateVersionListForDeletingNewVersion(string version)
+            {
+                var type = _list.Delete(version);
+
+                Assert.Equal(SearchIndexChangeType.UpdateVersionList, type);
+                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialParsedVersion, _list._latestOrNull);
+                Assert.Equal(new[] { InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
+            }
+
+            [Theory]
+            [MemberData(nameof(PreviousAndNextVersions))]
+            public void UpdateVersionListForDeletingUnlistedVersion(string version)
+            {
+                var unlisted = new FilteredVersionProperties(version, listed: false);
+                _list.Upsert(unlisted);
+
+                var type = _list.Delete(unlisted.FullVersion);
+
+                Assert.Equal(SearchIndexChangeType.UpdateVersionList, type);
+                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialParsedVersion, _list._latestOrNull);
+                Assert.Equal(new[] { InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
+            }
+
+            [Fact]
+            public void DowngradeForDeletingLatestVersion()
+            {
+                var latest = new FilteredVersionProperties(NextVersion, listed: true);
+                _list.Upsert(latest);
+
+                var type = _list.Delete(latest.FullVersion);
+
+                Assert.Equal(SearchIndexChangeType.DowngradeLatest, type);
+                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialParsedVersion, _list._latestOrNull);
+                Assert.Equal(new[] { InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
+            }
+
+            [Fact]
+            public void DeleteForDeletingVeryLastVersionWhenLastVersionIsListed()
+            {
+                StartWithUnlisted();
+
+                var type = _list.Delete(InitialFullVersion);
+
+                Assert.Equal(SearchIndexChangeType.Delete, type);
+                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list._latestOrNull);
+                Assert.Empty(_list.FullVersions);
+                Assert.Empty(_list._versions);
+            }
+
+            [Fact]
+            public void DeleteForDeletingVeryLastVersionWhenLastVersionIsUnlisted()
+            {
+                var type = _list.Delete(InitialFullVersion);
+
+                Assert.Equal(SearchIndexChangeType.Delete, type);
+                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list._latestOrNull);
+                Assert.Empty(_list.FullVersions);
+                Assert.Empty(_list._versions);
+            }
+
+            /// <summary>
+            /// This behavior is important so that we can "reflow" deleted packages. Suppose there is a bug when all
+            /// versions of a package are deleted but there is still a search document left over. We should be able
+            /// to reflow a delete and force the document to be deleted.
+            /// </summary>
+            [Fact]
+            public void DeleteFromEmptyListIsDelete()
+            {
+                ClearList();
+
+                var type = _list.Delete(InitialFullVersion);
+
+                Assert.Equal(SearchIndexChangeType.Delete, type);
+                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list._latestOrNull);
+                Assert.Empty(_list.FullVersions);
+                Assert.Empty(_list._versions.Keys);
+            }
+
+            [Theory]
+            [MemberData(nameof(PreviousAndNextVersions))]
+            public void DeleteForDeletingLastListedVersion(string version)
+            {
+                var unlisted = new FilteredVersionProperties(version, listed: false);
+                _list.Upsert(unlisted);
+
+                var type = _list.Delete(InitialFullVersion);
+
+                Assert.Equal(SearchIndexChangeType.Delete, type);
+                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list._latestOrNull);
+                Assert.Empty(_list.FullVersions);
+                Assert.Equal(new[] { unlisted.ParsedVersion }, _list._versions.Keys.ToArray());
+            }
+
+            [Fact]
+            public void UpdateVersionListForDeletingNonLatestListedVersion()
+            {
+                var nonLatest = new FilteredVersionProperties(PreviousVersion, listed: true);
+                _list.Upsert(nonLatest);
+
+                var type = _list.Delete(nonLatest.FullVersion);
+
+                Assert.Equal(SearchIndexChangeType.UpdateVersionList, type);
+                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialParsedVersion, _list._latestOrNull);
+                Assert.Equal(new[] { InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
+            }
+        }
+
+        public class LatestOrNull
+        {
+            [Fact]
+            public void UnlistedIsNotLatest()
+            {
+                var versions = new[]
+                {
+                    new FilteredVersionProperties("1.0.0", listed: true),
+                    new FilteredVersionProperties("1.0.1", listed: false),
+                };
+
+                var list = new FilteredVersionList(versions);
+
+                Assert.Equal("1.0.0", list.LatestOrNull);
+            }
+
+            [Fact]
+            public void LatestIsNullForEmpty()
+            {
+                var versions = new FilteredVersionProperties[0];
+
+                var list = new FilteredVersionList(versions);
+
+                Assert.Null(list.LatestOrNull);
+            }
+
+            [Fact]
+            public void LatestIsNullForOnlyUnlisted()
+            {
+                var versions = new[]
+                {
+                    new FilteredVersionProperties("1.0.0", listed: false),
+                    new FilteredVersionProperties("1.0.1", listed: false),
+                };
+
+                var list = new FilteredVersionList(versions);
+
+                Assert.Null(list.LatestOrNull);
+            }
+        }
+
+        public class FullVersions
+        {
+            [Fact]
+            public void ExcludesListedVersions()
+            {
+                var versions = new[]
+                {
+                    new FilteredVersionProperties("1.0.0", listed: true),
+                    new FilteredVersionProperties("1.0.1", listed: false),
+                };
+
+                var list = new FilteredVersionList(versions);
+
+                Assert.Equal(new[] { "1.0.0" }, list.FullVersions.ToArray());
+            }
+
+            [Fact]
+            public void OrdersBySemVer()
+            {
+                var versions = new[]
+                {
+                    new FilteredVersionProperties("10.0.0", listed: true),
+                    new FilteredVersionProperties("10.0.0-alpha", listed: true),
+                    new FilteredVersionProperties("10.0.0-beta.10", listed: true),
+                    new FilteredVersionProperties("10.0.0-beta.2", listed: true),
+                    new FilteredVersionProperties("10.0.1", listed: true),
+                    new FilteredVersionProperties("2.0.0", listed: true),
+                };
+
+                var list = new FilteredVersionList(versions);
+
+                Assert.Equal(
+                    new[] { "2.0.0", "10.0.0-alpha", "10.0.0-beta.2", "10.0.0-beta.10", "10.0.0", "10.0.1" },
+                    list.FullVersions.ToArray());
+            }
+        }
+
+        public abstract class BaseFacts
+        {
+            protected const string PreviousVersion = "0.9.0";
+            protected const string InitialFullVersion = "1.0.0";
+            protected const string NextVersion = "1.1.0";
+            protected static readonly NuGetVersion InitialParsedVersion = NuGetVersion.Parse(InitialFullVersion);
+            internal readonly FilteredVersionProperties _initialVersionProperties;
+            internal readonly FilteredVersionProperties _unlistedVersionProperties;
+            internal readonly FilteredVersionList _list;
+
+            protected BaseFacts()
+            {
+                _initialVersionProperties = new FilteredVersionProperties(InitialFullVersion, listed: true);
+                _unlistedVersionProperties = new FilteredVersionProperties(InitialFullVersion, listed: false);
+
+                var versions = new[] { _initialVersionProperties };
+
+                _list = new FilteredVersionList(versions);
+            }
+
+            protected void ClearList()
+            {
+                foreach (var version in _list._versions.ToList())
+                {
+                    _list.Delete(version.Value.FullVersion);
+                }
+            }
+
+            protected void StartWithUnlisted()
+            {
+                ClearList();
+                _list.Upsert(_unlistedVersionProperties);
+            }
+
+            public static IEnumerable<object[]> PreviousAndNextVersions => new[]
+            {
+                new object[] { PreviousVersion },
+                new object[] { NextVersion },
+            };
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -37,8 +37,10 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FilteredVersionListFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="VersionListDataClientFacts.cs" />
+    <Compile Include="TestExtensionMethods.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\NuGet.Services.AzureSearch\NuGet.Services.AzureSearch.csproj">

--- a/tests/NuGet.Services.AzureSearch.Tests/TestExtensionMethods.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/TestExtensionMethods.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Versioning;
+
+namespace NuGet.Services.AzureSearch
+{
+    internal static class TestExtensionMethods
+    {
+        public static SearchIndexChangeType Delete(
+            this FilteredVersionList list,
+            string version)
+        {
+            return list.Delete(NuGetVersion.Parse(version));
+        }
+    }
+}


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/6442.

`SearchIndexChangeType` will be used by the caller (`catalog2azuresearch`) to determine what changes he has to make to each of 4 documents per ID.