### PR TITLE
Add VersionLists to handle the 4 different views of the latest version

### DIFF
--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -35,10 +35,14 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="VersionList\KeyValuePair.cs" />
+    <Compile Include="VersionList\VersionProperties.cs" />
     <Compile Include="VersionList\FilteredVersionProperties.cs" />
     <Compile Include="VersionList\ResultAndAccessCondition.cs" />
+    <Compile Include="VersionList\SearchFilters.cs" />
     <Compile Include="VersionList\SearchIndexChangeType.cs" />
     <Compile Include="VersionList\SemVerOrderedDictionaryJsonConverter.cs" />
+    <Compile Include="VersionList\VersionLists.cs" />
     <Compile Include="VersionList\VersionListDataClient.cs" />
     <Compile Include="VersionList\VersionListData.cs" />
     <Compile Include="VersionList\FilteredVersionList.cs" />

--- a/src/NuGet.Services.AzureSearch/VersionList/KeyValuePair.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/KeyValuePair.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGet.Services.AzureSearch
+{
+    internal static class KeyValuePair
+    {
+        public static KeyValuePair<TKey, TValue> Create<TKey, TValue>(TKey key, TValue value)
+        {
+            return new KeyValuePair<TKey, TValue>(key, value);
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/VersionList/SearchFilters.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/SearchFilters.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.AzureSearch
+{
+    [Flags]
+    public enum SearchFilters
+    {
+        /// <summary>
+        /// Exclude SemVer 2.0.0 and prerelease packages.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// Include packages that have prerelease versions. Note that a package's dependency version ranges do not
+        /// affect the prerelease status of the package. This is in contrast of <see cref="IncludeSemVer2"/>.
+        /// </summary>
+        IncludePrerelease = 1 << 0,
+
+        /// <summary>
+        /// Include SemVer 2.0.0 packages. Note that SemVer 2.0.0 dependency version ranges make a package into a SemVer
+        /// 2.0.0 even if the package's own version string is SemVer 1.0.0.
+        /// </summary>
+        IncludeSemVer2 = 1 << 1,
+
+        /// <summary>
+        /// Include package that have prerelease versions and include SemVer 2.0.0 packages.
+        /// </summary>
+        IncludePrereleaseAndSemVer2 = IncludePrerelease | IncludeSemVer2,
+    }
+}

--- a/src/NuGet.Services.AzureSearch/VersionList/VersionLists.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/VersionLists.cs
@@ -1,0 +1,126 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Versioning;
+
+namespace NuGet.Services.AzureSearch
+{
+    /// <summary>
+    /// A container for all versions lists. There is one version list tracked per combination of
+    /// <see cref="SearchFilters"/> flags.
+    /// </summary>
+    public class VersionLists
+    {
+        private static readonly IReadOnlyDictionary<SearchFilters, Func<VersionProperties, bool>> SearchFilterPredicates
+            = new Dictionary<SearchFilters, Func<VersionProperties, bool>>
+            {
+                {
+                    SearchFilters.Default,
+                    p => !p.ParsedVersion.IsPrerelease && !p.Data.SemVer2
+                },
+                {
+                    SearchFilters.IncludePrerelease,
+                    p => !p.Data.SemVer2
+                },
+                {
+                    SearchFilters.IncludeSemVer2,
+                    p => !p.ParsedVersion.IsPrerelease
+                },
+                {
+                    SearchFilters.IncludePrereleaseAndSemVer2,
+                    p => true
+                },
+            };
+
+        private static readonly IReadOnlyList<SearchFilters> AllSearchFilters = SearchFilterPredicates
+            .Select(x => x.Key)
+            .ToList();
+
+        internal readonly Dictionary<SearchFilters, FilteredVersionList> _versionLists;
+        internal readonly SortedDictionary<NuGetVersion, KeyValuePair<string, VersionPropertiesData>> _versionProperties;
+
+        public VersionLists(VersionListData data)
+        {
+            var allVersions = data
+                .VersionProperties
+                .Select(p => new VersionProperties(p.Key, p.Value))
+                .OrderBy(x => x.ParsedVersion)
+                .ToList();
+
+            _versionProperties = new SortedDictionary<NuGetVersion, KeyValuePair<string, VersionPropertiesData>>();
+            foreach (var version in allVersions)
+            {
+                _versionProperties.Add(version.ParsedVersion, KeyValuePair.Create(version.FullVersion, version.Data));
+            }
+
+            _versionLists = new Dictionary<SearchFilters, FilteredVersionList>();
+            foreach (var pair in SearchFilterPredicates)
+            {
+                var searchFilter = pair.Key;
+                var predicate = pair.Value;
+                var listState = new FilteredVersionList(allVersions
+                    .Where(predicate)
+                    .Select(x => x.Filtered));
+                _versionLists.Add(searchFilter, listState);
+            }
+        }
+
+        public VersionListData GetVersionListData()
+        {
+            return new VersionListData(_versionProperties.Values.ToDictionary(x => x.Key, x => x.Value));
+        }
+
+        public IReadOnlyDictionary<SearchFilters, SearchIndexChangeType> Upsert(
+            string fullOrOriginalVersion,
+            VersionPropertiesData data)
+        {
+            var added = new VersionProperties(fullOrOriginalVersion, data);
+            _versionProperties[added.ParsedVersion] = KeyValuePair.Create(added.FullVersion, data);
+
+            var output = new Dictionary<SearchFilters, SearchIndexChangeType>();
+            foreach (var pair in _versionLists)
+            {
+                var searchFilter = pair.Key;
+                var listState = pair.Value;
+                var predicate = SearchFilterPredicates[searchFilter];
+
+                SearchIndexChangeType changeType;
+                if (predicate(added))
+                {
+                    changeType = listState.Upsert(added.Filtered);
+                }
+                else
+                {
+                    changeType = listState.Remove(added.ParsedVersion);
+                }
+
+                output[searchFilter] = changeType;
+            }
+
+            return output;
+        }
+
+        public IReadOnlyDictionary<SearchFilters, SearchIndexChangeType> Delete(string version)
+        {
+            var parsedVersion = NuGetVersion.Parse(version);
+            _versionProperties.Remove(parsedVersion);
+
+            var output = new Dictionary<SearchFilters, SearchIndexChangeType>();
+            foreach (var pair in _versionLists)
+            {
+                var searchFilter = pair.Key;
+                var listState = pair.Value;
+
+                // We can execute this on all lists, no matter the search filter predicate because removing a version
+                // that was never added will result in recalculating the version list, which supports the reflow
+                // scenario.
+                output[searchFilter] = listState.Delete(parsedVersion);
+            }
+
+            return output;
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/VersionList/VersionProperties.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/VersionProperties.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Versioning;
+
+namespace NuGet.Services.AzureSearch
+{
+    /// <summary>
+    /// All properties related to a specific version. This type exists to avoid parsing the <see cref="FullVersion"/>
+    /// over and over to get the <see cref="ParsedVersion"/>.
+    /// </summary>
+    internal class VersionProperties
+    {
+        public VersionProperties(string fullOrOriginalVersion, VersionPropertiesData data)
+        {
+            Data = data ?? throw new ArgumentNullException(nameof(data));
+            Filtered = new FilteredVersionProperties(fullOrOriginalVersion, Data.Listed);
+        }
+
+        public string FullVersion => Filtered.FullVersion;
+        public NuGetVersion ParsedVersion => Filtered.ParsedVersion;
+
+        public VersionPropertiesData Data { get; }
+        public FilteredVersionProperties Filtered { get; }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -41,6 +41,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="VersionListDataClientFacts.cs" />
     <Compile Include="TestExtensionMethods.cs" />
+    <Compile Include="VersionListsFacts.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\NuGet.Services.AzureSearch\NuGet.Services.AzureSearch.csproj">

--- a/tests/NuGet.Services.AzureSearch.Tests/TestExtensionMethods.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/TestExtensionMethods.cs
@@ -8,11 +8,32 @@ namespace NuGet.Services.AzureSearch
 {
     internal static class TestExtensionMethods
     {
+        public static IReadOnlyDictionary<SearchFilters, SearchIndexChangeType> Upsert(
+            this VersionLists versionList,
+            VersionProperties version)
+        {
+            return versionList.Upsert(version.FullVersion, version.Data);
+        }
+
+        public static IReadOnlyDictionary<SearchFilters, SearchIndexChangeType> Delete(
+            this VersionLists versionList,
+            VersionProperties version)
+        {
+            return versionList.Delete(version.FullVersion);
+        }
+
         public static SearchIndexChangeType Delete(
             this FilteredVersionList list,
             string version)
         {
             return list.Delete(NuGetVersion.Parse(version));
+        }
+
+        public static SearchIndexChangeType Remove(
+            this FilteredVersionList list,
+            string version)
+        {
+            return list.Remove(NuGetVersion.Parse(version));
         }
     }
 }

--- a/tests/NuGet.Services.AzureSearch.Tests/VersionListsFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/VersionListsFacts.cs
@@ -1,0 +1,372 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class VersionListsFacts
+    {
+        public class Constructor : BaseFacts
+        {
+            [Fact]
+            public void CategorizesVersionsByFilterPredicate()
+            {
+                var list = Create(
+                    _stableSemVer1Listed,
+                    _prereleaseSemVer1Listed,
+                    _stableSemVer2Listed,
+                    _prereleaseSemVer2Listed);
+
+                Assert.Equal(
+                    new[]
+                    {
+                        SearchFilters.Default,
+                        SearchFilters.IncludePrerelease,
+                        SearchFilters.IncludeSemVer2,
+                        SearchFilters.IncludePrereleaseAndSemVer2,
+                    },
+                    list._versionLists.Keys);
+                Assert.Equal(
+                    new[] { "1.0.0" },
+                    list._versionLists[SearchFilters.Default].FullVersions.ToArray());
+                Assert.Equal(
+                    new[] { "1.0.0-alpha", "1.0.0" },
+                    list._versionLists[SearchFilters.IncludePrerelease].FullVersions.ToArray());
+                Assert.Equal(
+                    new[] { "1.0.0", "2.0.0" },
+                    list._versionLists[SearchFilters.IncludeSemVer2].FullVersions.ToArray());
+                Assert.Equal(
+                    new[] { "1.0.0-alpha", "1.0.0", "2.0.0-alpha", "2.0.0" },
+                    list._versionLists[SearchFilters.IncludePrereleaseAndSemVer2].FullVersions.ToArray());
+            }
+
+            [Fact]
+            public void AllowsAllEmptyLists()
+            {
+                var list = Create();
+
+                Assert.Equal(
+                    new[]
+                    {
+                        SearchFilters.Default,
+                        SearchFilters.IncludePrerelease,
+                        SearchFilters.IncludeSemVer2,
+                        SearchFilters.IncludePrereleaseAndSemVer2,
+                    },
+                    list._versionLists.Keys);
+                Assert.Empty(list._versionLists[SearchFilters.Default]._versions);
+                Assert.Empty(list._versionLists[SearchFilters.IncludePrerelease]._versions);
+                Assert.Empty(list._versionLists[SearchFilters.IncludeSemVer2]._versions);
+                Assert.Empty(list._versionLists[SearchFilters.IncludePrereleaseAndSemVer2]._versions);
+            }
+
+            [Fact]
+            public void AllowsSomeEmptyLists()
+            {
+                var list = Create(_prereleaseSemVer2Listed);
+
+                Assert.Equal(
+                    new[]
+                    {
+                        SearchFilters.Default,
+                        SearchFilters.IncludePrerelease,
+                        SearchFilters.IncludeSemVer2,
+                        SearchFilters.IncludePrereleaseAndSemVer2,
+                    },
+                    list._versionLists.Keys);
+                Assert.Empty(list._versionLists[SearchFilters.Default]._versions);
+                Assert.Empty(list._versionLists[SearchFilters.IncludePrerelease]._versions);
+                Assert.Empty(list._versionLists[SearchFilters.IncludeSemVer2]._versions);
+                Assert.Equal(
+                    new[] { "2.0.0-alpha" },
+                    list._versionLists[SearchFilters.IncludePrereleaseAndSemVer2].FullVersions.ToArray());
+            }
+        }
+
+        public class GetVersionListData : BaseFacts
+        {
+            [Fact]
+            public void ReturnsCurrentSetOfVersions()
+            {
+                var list = new VersionLists(new VersionListData(new Dictionary<string, VersionPropertiesData>()));
+
+                // add
+                list.Upsert(_stableSemVer1Listed);
+
+                // delete
+                list.Upsert(_stableSemVer2Listed);
+                list.Delete(_stableSemVer2Listed.FullVersion);
+
+                // delete with different case
+                list.Upsert(_prereleaseSemVer1Listed);
+                list.Delete(_prereleaseSemVer1Listed.FullVersion.ToUpper());
+
+                // unlist with different case
+                list.Upsert(_prereleaseSemVer2Listed);
+                list.Upsert(new VersionProperties(
+                    _prereleaseSemVer2Listed.FullVersion.ToUpper(),
+                    new VersionPropertiesData(listed: false, semVer2: true)));
+
+                var data = list.GetVersionListData();
+                Assert.Equal(
+                    new[] { "1.0.0", "2.0.0-ALPHA" },
+                    data.VersionProperties.Keys.ToArray());
+            }
+        }
+
+        public class Upsert : BaseFacts
+        {
+            [Fact]
+            public void ReplacesLatestFullVersionByNormalizedVersion()
+            {
+                var list = Create(
+                    new VersionProperties("1.02.0-Alpha.1+git", new VersionPropertiesData(listed: true, semVer2: true)));
+
+                var type = list.Upsert("1.2.0.0-ALPHA.1+somethingelse", new VersionPropertiesData(listed: true, semVer2: true));
+
+                Assert.Equal(
+                    new[] { "1.2.0-ALPHA.1+somethingelse" },
+                    list.GetVersionListData().VersionProperties.Keys.ToArray());
+            }
+
+            [Fact]
+            public void ReplacesNonLatestFullVersionByNormalizedVersion()
+            {
+                var list = Create(
+                    new VersionProperties("2.0.0", new VersionPropertiesData(listed: true, semVer2: true)),
+                    new VersionProperties("1.02.0-Alpha.1+git", new VersionPropertiesData(listed: true, semVer2: true)));
+
+                var type = list.Upsert("1.2.0.0-ALPHA.1+somethingelse", new VersionPropertiesData(listed: true, semVer2: true));
+
+                Assert.Equal(
+                    new[] { "1.2.0-ALPHA.1+somethingelse", "2.0.0" },
+                    list.GetVersionListData().VersionProperties.Keys.ToArray());
+            }
+
+            [Theory]
+            [InlineData(SearchFilters.Default, SearchIndexChangeType.UpdateVersionList)]
+            [InlineData(SearchFilters.IncludePrerelease, SearchIndexChangeType.UpdateVersionList)]
+            [InlineData(SearchFilters.IncludeSemVer2, SearchIndexChangeType.UpdateVersionList)]
+            [InlineData(SearchFilters.IncludePrereleaseAndSemVer2, SearchIndexChangeType.UpdateLatest)]
+            public void AddListedVersionWhenSingleListedVersionExists(SearchFilters searchFilters, SearchIndexChangeType expected)
+            {
+                var list = Create(_stableSemVer1Listed);
+
+                var output = list.Upsert(_prereleaseSemVer2Listed);
+
+                Assert.Equal(expected, output[searchFilters]);
+            }
+
+            [Theory]
+            [InlineData(SearchFilters.Default, SearchIndexChangeType.UpdateVersionList)]
+            [InlineData(SearchFilters.IncludePrerelease, SearchIndexChangeType.UpdateVersionList)]
+            [InlineData(SearchFilters.IncludeSemVer2, SearchIndexChangeType.UpdateVersionList)]
+            [InlineData(SearchFilters.IncludePrereleaseAndSemVer2, SearchIndexChangeType.UpdateVersionList)]
+            public void AddUnlistedVersionWhenSingleListedVersionExists(SearchFilters searchFilters, SearchIndexChangeType expected)
+            {
+                var list = Create(_stableSemVer1Listed);
+
+                var output = list.Upsert(_prereleaseSemVer2Unlisted);
+
+                Assert.Equal(expected, output[searchFilters]);
+            }
+
+            [Theory]
+            [InlineData(SearchFilters.Default, SearchIndexChangeType.Delete)]
+            [InlineData(SearchFilters.IncludePrerelease, SearchIndexChangeType.Delete)]
+            [InlineData(SearchFilters.IncludeSemVer2, SearchIndexChangeType.Delete)]
+            [InlineData(SearchFilters.IncludePrereleaseAndSemVer2, SearchIndexChangeType.AddFirst)]
+            public void AddListedVersionWhenSingleUnlistedVersionExists(SearchFilters searchFilters, SearchIndexChangeType expected)
+            {
+                var list = Create(_stableSemVer1Unlisted);
+
+                var output = list.Upsert(_prereleaseSemVer2Listed);
+
+                Assert.Equal(expected, output[searchFilters]);
+            }
+
+            [Theory]
+            [InlineData(SearchFilters.Default, SearchIndexChangeType.Delete)]
+            [InlineData(SearchFilters.IncludePrerelease, SearchIndexChangeType.Delete)]
+            [InlineData(SearchFilters.IncludeSemVer2, SearchIndexChangeType.Delete)]
+            [InlineData(SearchFilters.IncludePrereleaseAndSemVer2, SearchIndexChangeType.Delete)]
+            public void AddUnlistedVersionWhenSingleUnlistedVersionExists(SearchFilters searchFilters, SearchIndexChangeType expected)
+            {
+                var list = Create(_stableSemVer1Unlisted);
+
+                var output = list.Upsert(_prereleaseSemVer2Unlisted);
+
+                Assert.Equal(expected, output[searchFilters]);
+            }
+
+            [Theory]
+            [InlineData(SearchFilters.Default, SearchIndexChangeType.Delete)]
+            [InlineData(SearchFilters.IncludePrerelease, SearchIndexChangeType.Delete)]
+            [InlineData(SearchFilters.IncludeSemVer2, SearchIndexChangeType.Delete)]
+            [InlineData(SearchFilters.IncludePrereleaseAndSemVer2, SearchIndexChangeType.Delete)]
+            public void UnlistLatestVersionWhenSingleListedVersionExists(SearchFilters searchFilters, SearchIndexChangeType expected)
+            {
+                var list = Create(_prereleaseSemVer2Listed);
+
+                var output = list.Upsert(_prereleaseSemVer2Unlisted);
+
+                Assert.Equal(expected, output[searchFilters]);
+            }
+
+            [Theory]
+            [InlineData(SearchFilters.Default, SearchIndexChangeType.UpdateVersionList)]
+            [InlineData(SearchFilters.IncludePrerelease, SearchIndexChangeType.UpdateVersionList)]
+            [InlineData(SearchFilters.IncludeSemVer2, SearchIndexChangeType.UpdateVersionList)]
+            [InlineData(SearchFilters.IncludePrereleaseAndSemVer2, SearchIndexChangeType.DowngradeLatest)]
+            public void UnlistLatestVersionWhenOtherListedVersionExists(SearchFilters searchFilters, SearchIndexChangeType expected)
+            {
+                var list = Create(_stableSemVer1Listed, _prereleaseSemVer2Listed);
+
+                var output = list.Upsert(_prereleaseSemVer2Unlisted);
+
+                Assert.Equal(expected, output[searchFilters]);
+            }
+        }
+
+        public class Delete : BaseFacts
+        {
+            [Fact]
+            public void DeletesByNormalizedVersion()
+            {
+                var list = Create(
+                    new VersionProperties("1.02.0-Alpha.1+git", new VersionPropertiesData(listed: true, semVer2: true)));
+
+                var type = list.Delete("1.2.0.0-ALPHA.1+somethingelse");
+
+                Assert.Empty(list.GetVersionListData().VersionProperties);
+            }
+
+            [Theory]
+            [InlineData(SearchFilters.Default, SearchIndexChangeType.UpdateVersionList)]
+            [InlineData(SearchFilters.IncludePrerelease, SearchIndexChangeType.UpdateVersionList)]
+            [InlineData(SearchFilters.IncludeSemVer2, SearchIndexChangeType.UpdateVersionList)]
+            [InlineData(SearchFilters.IncludePrereleaseAndSemVer2, SearchIndexChangeType.UpdateVersionList)]
+            public void DeleteListedVersionWhenSingleListedVersionExists(SearchFilters searchFilters, SearchIndexChangeType expected)
+            {
+                var list = Create(_stableSemVer1Listed);
+
+                var output = list.Delete(_prereleaseSemVer2Listed);
+
+                Assert.Equal(expected, output[searchFilters]);
+            }
+
+            [Theory]
+            [InlineData(SearchFilters.Default, SearchIndexChangeType.Delete)]
+            [InlineData(SearchFilters.IncludePrerelease, SearchIndexChangeType.Delete)]
+            [InlineData(SearchFilters.IncludeSemVer2, SearchIndexChangeType.Delete)]
+            [InlineData(SearchFilters.IncludePrereleaseAndSemVer2, SearchIndexChangeType.Delete)]
+            public void DeleteLatestVersionWhenSingleListedVersionExists(SearchFilters searchFilters, SearchIndexChangeType expected)
+            {
+                var list = Create(_prereleaseSemVer2Listed);
+
+                var output = list.Delete(_prereleaseSemVer2Listed);
+
+                Assert.Equal(expected, output[searchFilters]);
+            }
+
+            [Theory]
+            [InlineData(SearchFilters.Default, SearchIndexChangeType.UpdateVersionList)]
+            [InlineData(SearchFilters.IncludePrerelease, SearchIndexChangeType.UpdateVersionList)]
+            [InlineData(SearchFilters.IncludeSemVer2, SearchIndexChangeType.UpdateVersionList)]
+            [InlineData(SearchFilters.IncludePrereleaseAndSemVer2, SearchIndexChangeType.DowngradeLatest)]
+            public void DeleteLatestVersionWhenTwoListedVersionsExists(SearchFilters searchFilters, SearchIndexChangeType expected)
+            {
+                var list = Create(_stableSemVer1Listed, _prereleaseSemVer2Listed);
+
+                var output = list.Delete(_prereleaseSemVer2Listed);
+
+                Assert.Equal(expected, output[searchFilters]);
+            }
+
+            [Theory]
+            [InlineData(SearchFilters.Default, SearchIndexChangeType.UpdateVersionList)]
+            [InlineData(SearchFilters.IncludePrerelease, SearchIndexChangeType.UpdateVersionList)]
+            [InlineData(SearchFilters.IncludeSemVer2, SearchIndexChangeType.UpdateVersionList)]
+            [InlineData(SearchFilters.IncludePrereleaseAndSemVer2, SearchIndexChangeType.UpdateVersionList)]
+            public void DeleteUnlistedVersionWhenSingleListedVersionExists(SearchFilters searchFilters, SearchIndexChangeType expected)
+            {
+                var list = Create(_stableSemVer1Listed);
+
+                var output = list.Delete(_prereleaseSemVer2Unlisted);
+
+                Assert.Equal(expected, output[searchFilters]);
+            }
+
+            [Theory]
+            [InlineData(SearchFilters.Default, SearchIndexChangeType.Delete)]
+            [InlineData(SearchFilters.IncludePrerelease, SearchIndexChangeType.Delete)]
+            [InlineData(SearchFilters.IncludeSemVer2, SearchIndexChangeType.Delete)]
+            [InlineData(SearchFilters.IncludePrereleaseAndSemVer2, SearchIndexChangeType.Delete)]
+            public void DeleteListedVersionWhenSingleUnlistedVersionExists(SearchFilters searchFilters, SearchIndexChangeType expected)
+            {
+                var list = Create(_stableSemVer1Unlisted);
+
+                var output = list.Delete(_prereleaseSemVer2Listed);
+
+                Assert.Equal(expected, output[searchFilters]);
+            }
+
+            [Theory]
+            [InlineData(SearchFilters.Default, SearchIndexChangeType.Delete)]
+            [InlineData(SearchFilters.IncludePrerelease, SearchIndexChangeType.Delete)]
+            [InlineData(SearchFilters.IncludeSemVer2, SearchIndexChangeType.Delete)]
+            [InlineData(SearchFilters.IncludePrereleaseAndSemVer2, SearchIndexChangeType.Delete)]
+            public void DeleteUnlistedVersionWhenSingleUnlistedVersionExists(SearchFilters searchFilters, SearchIndexChangeType expected)
+            {
+                var list = Create(_stableSemVer1Unlisted);
+
+                var output = list.Delete(_prereleaseSemVer2Unlisted);
+
+                Assert.Equal(expected, output[searchFilters]);
+            }
+        }
+
+        public abstract class BaseFacts
+        {
+            internal const string StableSemVer1 = "1.0.0";
+            internal const string PrereleaseSemVer1 = "1.0.0-alpha";
+            internal const string StableSemVer2 = "2.0.0";
+            internal const string PrereleaseSemVer2 = "2.0.0-alpha";
+
+            internal readonly VersionProperties _stableSemVer1Listed;
+            internal readonly VersionProperties _stableSemVer1Unlisted;
+            internal readonly VersionProperties _prereleaseSemVer1Listed;
+            internal readonly VersionProperties _prereleaseSemVer1Unlisted;
+            internal readonly VersionProperties _stableSemVer2Listed;
+            internal readonly VersionProperties _stableSemVer2Unlisted;
+            internal readonly VersionProperties _prereleaseSemVer2Listed;
+            internal readonly VersionProperties _prereleaseSemVer2Unlisted;
+
+            protected BaseFacts()
+            {
+                _stableSemVer1Listed = Create(StableSemVer1, true, false);
+                _stableSemVer1Unlisted = Create(StableSemVer1, false, false);
+                _prereleaseSemVer1Listed = Create(PrereleaseSemVer1, true, false);
+                _prereleaseSemVer1Unlisted = Create(PrereleaseSemVer1, false, false);
+                _stableSemVer2Listed = Create(StableSemVer2, true, true);
+                _stableSemVer2Unlisted = Create(StableSemVer2, false, true);
+                _prereleaseSemVer2Listed = Create(PrereleaseSemVer2, true, true);
+                _prereleaseSemVer2Unlisted = Create(PrereleaseSemVer2, false, true);
+            }
+
+            private VersionProperties Create(string version, bool listed, bool semVer2)
+            {
+                return new VersionProperties(version, new VersionPropertiesData(listed, semVer2));
+            }
+
+            internal VersionLists Create(params VersionProperties[] versions)
+            {
+                var data = new VersionListData(versions.ToDictionary(x => x.FullVersion, x => x.Data));
+                return new VersionLists(data);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/6442.

I also introduced a `Remove` method to `FilteredVersionList`. This has the same behavior as `Delete` for the search service, but will have a different behavior when I introduce the changes related to the service index.

When a non-applicable version is encountered, the search index should make sure it doesn't have that version at all (much like a `Delete`). For the hijack index, the non-applicable version should not be deleted but the `Latest` booleans should still be updated, for reflow. These specifics will come in a subsequent PR, but that is the motivation for treating `Delete` and `Remove` as separate gestures.