### PR TITLE
 Merge hijack index changes by package version

### DIFF
--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -35,10 +35,13 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="VersionList\Guard.cs" />
     <Compile Include="VersionList\HijackIndexChange.cs" />
     <Compile Include="VersionList\HijackIndexChangeType.cs" />
     <Compile Include="VersionList\LatestIndexChanges.cs" />
     <Compile Include="VersionList\KeyValuePair.cs" />
+    <Compile Include="VersionList\MutableHijackIndexDocument.cs" />
+    <Compile Include="VersionList\MutableIndexChanges.cs" />
     <Compile Include="VersionList\VersionProperties.cs" />
     <Compile Include="VersionList\FilteredVersionProperties.cs" />
     <Compile Include="VersionList\ResultAndAccessCondition.cs" />

--- a/src/NuGet.Services.AzureSearch/VersionList/FilteredVersionList.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/FilteredVersionList.cs
@@ -109,9 +109,9 @@ namespace NuGet.Services.AzureSearch
             {
                 // If the latest version changes due to deletion, this can only happen if the existing latest version
                 // was the one that was deleted.
-                Assert(ctx.OldProperties != null, "This version should have existed before.");
-                Assert(ctx.OldProperties.Listed, "The existing version should have been listed.");
-                Assert(ctx.OldLatest == ctx.ChangedVersion, "The existing latest should be the deleted version.");
+                Guard.Assert(ctx.OldProperties != null, "This version should have existed before.");
+                Guard.Assert(ctx.OldProperties.Listed, "The existing version should have been listed.");
+                Guard.Assert(ctx.OldLatest == ctx.ChangedVersion, "The existing latest should be the deleted version.");
                 return SearchIndexChangeType.DowngradeLatest;
             }
 
@@ -131,7 +131,7 @@ namespace NuGet.Services.AzureSearch
             // Update the latest status of the latest version, if there is one.
             if (ctx.NewLatest != null)
             {
-                Assert(ctx.ChangedVersion != ctx.NewLatest, "The deleted version should not be the new latest version.");
+                Guard.Assert(ctx.ChangedVersion != ctx.NewLatest, "The deleted version should not be the new latest version.");
                 changes.Add(HijackIndexChange.SetLatestToTrue(ctx.NewLatest));
             }
 
@@ -150,8 +150,8 @@ namespace NuGet.Services.AzureSearch
             {
                 // If there was no latest version before but now there is a latest version, then we have just added
                 // the only listed version. The new latest version is of course the version we are adding right now.
-                Assert(ctx.NewLatest == ctx.ChangedVersion, "The first latest version must be the added version.");
-                Assert(ctx.NewProperties.Listed, "The added version should be listed for the latest version to have changed.");
+                Guard.Assert(ctx.NewLatest == ctx.ChangedVersion, "The first latest version must be the added version.");
+                Guard.Assert(ctx.NewProperties.Listed, "The added version should be listed for the latest version to have changed.");
                 return SearchIndexChangeType.AddFirst;
             }
 
@@ -166,9 +166,9 @@ namespace NuGet.Services.AzureSearch
             {
                 // If the new latest is a lower version than the old latest, this is a special case where we need to
                 // look up the old new latest's metadata.
-                Assert(ctx.NewLatest != ctx.ChangedVersion, "This case should already have been handled.");
-                Assert(ctx.OldLatest == ctx.ChangedVersion, "This case should already have been handled.");
-                Assert(
+                Guard.Assert(ctx.NewLatest != ctx.ChangedVersion, "This case should already have been handled.");
+                Guard.Assert(ctx.OldLatest == ctx.ChangedVersion, "This case should already have been handled.");
+                Guard.Assert(
                     ctx.NewProperties == null || !ctx.NewProperties.Listed,
                     "A downgrade from an upserted version can only happen from an unlist or removing a non-applicable version.");
                 return SearchIndexChangeType.DowngradeLatest;
@@ -211,16 +211,6 @@ namespace NuGet.Services.AzureSearch
             }
 
             return changes;
-        }
-
-        private static void Assert(bool condition, string message)
-        {
-            /// We could use <see cref="System.Diagnostics.Debug.Assert(bool, string)"/> here, but it's preferable
-            /// in this case to even fail on a non-Debug build.
-            if (!condition)
-            {
-                throw new InvalidOperationException(message);
-            }
         }
 
         private Context UpdateVersionList(

--- a/src/NuGet.Services.AzureSearch/VersionList/Guard.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/Guard.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.AzureSearch
+{
+    internal static class Guard
+    {
+        /// <remarks>
+        /// We could use <see cref="System.Diagnostics.Debug.Assert(bool, string)"/> here, but it's preferable in this
+        /// case to even fail on a non-Debug build. The goal of this method is to allow the implementor to embed more
+        /// intent into the implementation so that future code changes are less likely to introduce bugs and so that
+        /// the implementation makes more sense to future readers. This is, of course, in addition to unit test
+        /// coverage.
+        /// </remarks>
+        public static void Assert(bool condition, string message)
+        {
+            if (!condition)
+            {
+                throw new InvalidOperationException(message);
+            }
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/VersionList/MutableHijackIndexDocument.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/MutableHijackIndexDocument.cs
@@ -1,0 +1,162 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.Services.AzureSearch
+{
+    /// <summary>
+    /// A mutable version of <see cref="HijackIndexDocument"/>. The booleans in this class are nullable so that we can
+    /// track the "undetermined" state. Once the booleans are set to true or false, they cannot be changed again. This
+    /// helps protect against bugs in the code that calls
+    /// <see cref="ApplyChange(SearchFilters, HijackIndexChangeType)"/> in an inconsistent manner. Technically, the
+    /// <see cref="Delete"/> and <see cref="UpdateMetadata"/> do not need to be nullable because there is no code path
+    /// that can set them explicitly to false. However it's better to be consistent with the latest booleans and employ
+    /// the same strategy. Null booleans can be assumed by the caller to be false.
+    /// </summary>
+    internal class MutableHijackIndexDocument : IEquatable<MutableHijackIndexDocument>
+    {
+        public MutableHijackIndexDocument()
+        {
+        }
+
+        public MutableHijackIndexDocument(
+            bool? delete,
+            bool? updateMetadata,
+            bool? latestStableSemVer1,
+            bool? latestSemVer1,
+            bool? latestStableSemVer2,
+            bool? latestSemVer2)
+        {
+            Delete = delete;
+            UpdateMetadata = updateMetadata;
+            LatestStableSemVer1 = latestStableSemVer1;
+            LatestSemVer1 = latestSemVer1;
+            LatestStableSemVer2 = latestStableSemVer2;
+            LatestSemVer2 = latestSemVer2;
+        }
+
+        public bool? Delete { get; private set; }
+        public bool? UpdateMetadata { get; private set; }
+        public bool? LatestStableSemVer1 { get; private set; }
+        public bool? LatestSemVer1 { get; private set; }
+        public bool? LatestStableSemVer2 { get; private set; }
+        public bool? LatestSemVer2 { get; private set; }
+
+        public void ApplyChange(SearchFilters searchFilters, HijackIndexChangeType changeType)
+        {
+            bool latest;
+            switch (changeType)
+            {
+                case HijackIndexChangeType.Delete:
+                    Guard.Assert(
+                        Delete != false,
+                        "The hijack document has already been set to not delete.");
+                    Guard.Assert(
+                        UpdateMetadata != true,
+                        "The hijack document has already been set to update metadata.");
+                    Delete = true;
+                    return;
+                case HijackIndexChangeType.UpdateMetadata:
+                    Guard.Assert(
+                        UpdateMetadata != false,
+                        "The hijack document has already been set to not update metadata.");
+                    Guard.Assert(
+                        Delete != true,
+                        "The hijack document has already been set to delete so metadata can't be updated.");
+                    UpdateMetadata = true;
+                    return;
+                case HijackIndexChangeType.SetLatestToFalse:
+                    latest = false;
+                    break;
+                case HijackIndexChangeType.SetLatestToTrue:
+                    latest = true;
+                    break;
+                default:
+                    throw new NotImplementedException($"The change type '{changeType}' is not supported.");
+            }
+
+            Guard.Assert(
+                Delete != true,
+                "The hijack document has already been set to delete so the latest value can't be updated.");
+            var oldValue = GetLatest(searchFilters);
+            Guard.Assert(
+                !oldValue.HasValue || oldValue.Value == latest,
+                $"The latest value for search filters '{searchFilters}' cannot change from {oldValue} to {latest}.");
+            SetLatest(searchFilters, latest);
+        }
+
+        public bool? GetLatest(SearchFilters searchFilters)
+        {
+            switch (searchFilters)
+            {
+                case SearchFilters.Default:
+                    return LatestStableSemVer1;
+                case SearchFilters.IncludePrerelease:
+                    return LatestSemVer1;
+                case SearchFilters.IncludeSemVer2:
+                    return LatestStableSemVer2;
+                case SearchFilters.IncludePrereleaseAndSemVer2:
+                    return LatestSemVer2;
+                default:
+                    throw new NotImplementedException($"The search filters '{searchFilters}' is not supported.");
+            }
+        }
+
+        private void SetLatest(SearchFilters searchFilters, bool latest)
+        {
+            switch (searchFilters)
+            {
+                case SearchFilters.Default:
+                    LatestStableSemVer1 = latest;
+                    break;
+                case SearchFilters.IncludePrerelease:
+                    LatestSemVer1 = latest;
+                    break;
+                case SearchFilters.IncludeSemVer2:
+                    LatestStableSemVer2 = latest;
+                    break;
+                case SearchFilters.IncludePrereleaseAndSemVer2:
+                    LatestSemVer2 = latest;
+                    break;
+                default:
+                    throw new NotImplementedException($"The search filters '{searchFilters}' is not supported.");
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as MutableHijackIndexDocument);
+        }
+
+        /// <summary>
+        /// This was generated using Visual Studio.
+        /// </summary>
+        public bool Equals(MutableHijackIndexDocument document)
+        {
+            return document != null &&
+                   Delete == document.Delete &&
+                   UpdateMetadata == document.UpdateMetadata &&
+                   EqualityComparer<bool?>.Default.Equals(LatestStableSemVer1, document.LatestStableSemVer1) &&
+                   EqualityComparer<bool?>.Default.Equals(LatestSemVer1, document.LatestSemVer1) &&
+                   EqualityComparer<bool?>.Default.Equals(LatestStableSemVer2, document.LatestStableSemVer2) &&
+                   EqualityComparer<bool?>.Default.Equals(LatestSemVer2, document.LatestSemVer2);
+        }
+
+        /// <summary>
+        /// This was generated using Visual Studio.
+        /// </summary>
+        public override int GetHashCode()
+        {
+            var hashCode = -1628679267;
+            hashCode = hashCode * -1521134295 + Delete.GetHashCode();
+            hashCode = hashCode * -1521134295 + UpdateMetadata.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<bool?>.Default.GetHashCode(LatestStableSemVer1);
+            hashCode = hashCode * -1521134295 + EqualityComparer<bool?>.Default.GetHashCode(LatestSemVer1);
+            hashCode = hashCode * -1521134295 + EqualityComparer<bool?>.Default.GetHashCode(LatestStableSemVer2);
+            hashCode = hashCode * -1521134295 + EqualityComparer<bool?>.Default.GetHashCode(LatestSemVer2);
+            return hashCode;
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/VersionList/MutableIndexChanges.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/MutableIndexChanges.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Versioning;
+
+namespace NuGet.Services.AzureSearch
+{
+    /// <summary>
+    /// A mutable version of <see cref="IndexChanges"/>.
+    /// </summary>
+    internal class MutableIndexChanges
+    {
+        public MutableIndexChanges()
+        {
+            Search = new Dictionary<SearchFilters, SearchIndexChangeType>();
+            Hijack = new Dictionary<NuGetVersion, MutableHijackIndexDocument>();
+        }
+
+        public MutableIndexChanges(
+            Dictionary<SearchFilters, SearchIndexChangeType> search,
+            Dictionary<NuGetVersion, MutableHijackIndexDocument> hijack)
+        {
+            Search = search ?? throw new ArgumentNullException(nameof(search));
+            Hijack = hijack ?? throw new ArgumentNullException(nameof(hijack));
+        }
+
+        public Dictionary<SearchFilters, SearchIndexChangeType> Search { get; }
+        public Dictionary<NuGetVersion, MutableHijackIndexDocument> Hijack { get; }
+
+        public static MutableIndexChanges FromLatestIndexChanges(
+            IReadOnlyDictionary<SearchFilters, LatestIndexChanges> latestIndexChanges)
+        {
+            // Take the search index changes as-is.
+            var search = latestIndexChanges.ToDictionary(x => x.Key, x => x.Value.Search);
+
+            // Group hijack index changes by version.
+            var versionGroups = latestIndexChanges
+                .SelectMany(pair => pair
+                    .Value
+                    .Hijack
+                    .Select(change => new { SearchFilters = pair.Key, change.Type, change.Version }))
+                .GroupBy(x => x.Version);
+
+            // Apply all of the changes related to each version.
+            var hijack = new Dictionary<NuGetVersion, MutableHijackIndexDocument>();
+            foreach (var group in versionGroups)
+            {
+                var document = new MutableHijackIndexDocument();
+                foreach (var change in group)
+                {
+                    document.ApplyChange(change.SearchFilters, change.Type);
+                }
+
+                hijack.Add(group.Key, document);
+            }
+
+            // Verify that there are not multiple versions set to latest, per search filter.
+            foreach (var searchFilters in latestIndexChanges.Keys)
+            {
+                var latestVersions = hijack
+                    .Where(x => x.Value.GetLatest(searchFilters).GetValueOrDefault(false))
+                    .Select(x => x.Key.ToFullString())
+                    .ToList();
+
+                Guard.Assert(
+                    latestVersions.Count <= 1,
+                    $"There are multiple latest versions for search filters '{searchFilters}': {string.Join(", ", latestVersions)}");
+            }
+
+            return new MutableIndexChanges(search, hijack);
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/TestExtensionMethods.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/TestExtensionMethods.cs
@@ -1,24 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-
 namespace NuGet.Services.AzureSearch
 {
     internal static class TestExtensionMethods
     {
-        public static IReadOnlyDictionary<SearchFilters, LatestIndexChanges> Upsert(
-            this VersionLists versionList,
-            VersionProperties version)
+        public static MutableIndexChanges Upsert(this VersionLists versionList, VersionProperties version)
         {
             return versionList.Upsert(version.FullVersion, version.Data);
-        }
-
-        public static IReadOnlyDictionary<SearchFilters, LatestIndexChanges> Delete(
-            this VersionLists versionList,
-            VersionProperties version)
-        {
-            return versionList.Delete(version.FullVersion);
         }
     }
 }


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/6445.

Map the previously added `(NuGetVersion, HijackIndexChangeType)` pairs to a `MutableHijackIndexDocument` per version. The main goal of this work is to ensure that when a batch of catalog leafs comes in, we only issue a single update per Azure Search document.

This aggregation will be used twice:

1. To group together changes to the same version after a single version is upserted/deleted (this PR).
1. To group together changes to the same version after a batch of versions is upserted/deleted (future PR).

This adds a lot of guards to embed more intent into the implementation.

Also, added `IEquatable` on `MutableHijackIndexDocument` to ease unit testing.