### PR TITLE
Enable multiple version upserts or deletes at once

### DIFF
--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -42,6 +42,7 @@
     <Compile Include="VersionList\KeyValuePair.cs" />
     <Compile Include="VersionList\MutableHijackIndexDocument.cs" />
     <Compile Include="VersionList\MutableIndexChanges.cs" />
+    <Compile Include="VersionList\VersionListChange.cs" />
     <Compile Include="VersionList\VersionProperties.cs" />
     <Compile Include="VersionList\FilteredVersionProperties.cs" />
     <Compile Include="VersionList\ResultAndAccessCondition.cs" />

--- a/src/NuGet.Services.AzureSearch/VersionList/FilteredVersionProperties.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/FilteredVersionProperties.cs
@@ -13,6 +13,13 @@ namespace NuGet.Services.AzureSearch
     /// </summary>
     internal class FilteredVersionProperties
     {
+        public FilteredVersionProperties(string fullVersion, NuGetVersion parsedVersion, bool listed)
+        {
+            FullVersion = fullVersion ?? throw new ArgumentNullException(nameof(fullVersion));
+            ParsedVersion = parsedVersion ?? throw new ArgumentNullException(nameof(parsedVersion));
+            Listed = listed;
+        }
+
         public FilteredVersionProperties(string fullVersion, bool listed)
         {
             if (fullVersion == null)

--- a/src/NuGet.Services.AzureSearch/VersionList/Guard.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/Guard.cs
@@ -21,5 +21,13 @@ namespace NuGet.Services.AzureSearch
                 throw new InvalidOperationException(message);
             }
         }
+
+        /// <remarks>
+        /// Similar to <see cref="System.Diagnostics.Debug.Fail(string)"/> but run in Release builds.
+        /// </remarks>
+        public static void Fail(string message)
+        {
+            Assert(false, message);
+        }
     }
 }

--- a/src/NuGet.Services.AzureSearch/VersionList/MutableHijackIndexDocument.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/MutableHijackIndexDocument.cs
@@ -57,6 +57,10 @@ namespace NuGet.Services.AzureSearch
                         UpdateMetadata != true,
                         "The hijack document has already been set to update metadata.");
                     Delete = true;
+                    foreach (var eachSearchFilters in MutableIndexChanges.AllSearchFilters)
+                    {
+                        SetLatest(eachSearchFilters, latest: null);
+                    }
                     return;
                 case HijackIndexChangeType.UpdateMetadata:
                     Guard.Assert(
@@ -74,16 +78,12 @@ namespace NuGet.Services.AzureSearch
                     latest = true;
                     break;
                 default:
-                    throw new NotImplementedException($"The change type '{changeType}' is not supported.");
+                    throw new NotImplementedException($"The hijack index change type '{changeType}' is not supported.");
             }
 
             Guard.Assert(
                 Delete != true,
                 "The hijack document has already been set to delete so the latest value can't be updated.");
-            var oldValue = GetLatest(searchFilters);
-            Guard.Assert(
-                !oldValue.HasValue || oldValue.Value == latest,
-                $"The latest value for search filters '{searchFilters}' cannot change from {oldValue} to {latest}.");
             SetLatest(searchFilters, latest);
         }
 
@@ -104,7 +104,7 @@ namespace NuGet.Services.AzureSearch
             }
         }
 
-        private void SetLatest(SearchFilters searchFilters, bool latest)
+        private void SetLatest(SearchFilters searchFilters, bool? latest)
         {
             switch (searchFilters)
             {

--- a/src/NuGet.Services.AzureSearch/VersionList/VersionListChange.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/VersionListChange.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Versioning;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class VersionListChange
+    {
+        private VersionListChange(string fullOrOriginalVersion, bool isDelete, VersionPropertiesData data)
+        {
+            if (fullOrOriginalVersion == null)
+            {
+                throw new ArgumentNullException(nameof(fullOrOriginalVersion));
+            }
+
+            IsDelete = isDelete;
+            ParsedVersion = NuGetVersion.Parse(fullOrOriginalVersion);
+            FullVersion = ParsedVersion.ToFullString();
+            Data = data;
+        }
+
+        public bool IsDelete { get; }
+        public string FullVersion { get; }
+        public NuGetVersion ParsedVersion { get; }
+        public VersionPropertiesData Data { get; }
+
+        public static VersionListChange Delete(string fullOrOriginalVersion)
+        {
+            return new VersionListChange(fullOrOriginalVersion, isDelete: true, data: null);
+        }
+
+        public static VersionListChange Upsert(string fullOrOriginalVersion, VersionPropertiesData data)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            return new VersionListChange(fullOrOriginalVersion, isDelete: false, data: data);
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/VersionList/VersionLists.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/VersionLists.cs
@@ -73,11 +73,76 @@ namespace NuGet.Services.AzureSearch
             return new VersionListData(_versionProperties.Values.ToDictionary(x => x.Key, x => x.Value));
         }
 
-        internal MutableIndexChanges Upsert(
-            string fullOrOriginalVersion,
+        internal MutableIndexChanges ApplyChangesInternal(IEnumerable<VersionListChange> changes)
+        {
+            var mutableChanges = new MutableIndexChanges();
+
+            // Process the changes in descending order.
+            var sortedChanges = changes
+                .OrderByDescending(x => x.ParsedVersion)
+                .ToList();
+
+            // Verify that there is only one change per version.
+            var versionsWithMultipleChanges = sortedChanges
+                .GroupBy(x => x.ParsedVersion)
+                .OrderBy(x => x.Key)
+                .Select(x => KeyValuePair.Create(x.Key.ToFullString(), x.Count()))
+                .Where(x => x.Value > 1)
+                .ToList();
+            if (versionsWithMultipleChanges.Any())
+            {
+                throw new ArgumentException(
+                    $"There are multiple changes for the following version(s): " +
+                    string.Join(", ", versionsWithMultipleChanges.Select(x => $"{x.Key} ({x.Value} changes)")),
+                    nameof(changes));
+            }
+
+            foreach (var change in sortedChanges)
+            {
+                MutableIndexChanges versionChanges;
+                if (!change.IsDelete)
+                {
+                    versionChanges = Upsert(change.FullVersion, change.ParsedVersion, change.Data);
+                }
+                else
+                {
+                    versionChanges = Delete(change.ParsedVersion);
+                }
+
+                mutableChanges.Merge(versionChanges);
+            }
+
+            // Verify that we are updating the metadata of all non-delete changes.
+            foreach (var change in changes)
+            {
+                Guard.Assert(
+                    mutableChanges.HijackDocuments.ContainsKey(change.ParsedVersion),
+                    $"The should be a hijack document for each changed version. Version {change.FullVersion} does " +
+                    "not have a hijack document.");
+                
+                if (!change.IsDelete)
+                {
+                    Guard.Assert(
+                        mutableChanges.HijackDocuments[change.ParsedVersion].UpdateMetadata == true,
+                        $"The metadata of version {change.FullVersion} should be updated.");
+                }
+            }
+
+            return mutableChanges;
+        }
+
+        internal MutableIndexChanges Upsert(string fullOrOriginalVersion, VersionPropertiesData data)
+        {
+            var parsedVersion = NuGetVersion.Parse(fullOrOriginalVersion);
+            return Upsert(parsedVersion.ToFullString(), parsedVersion, data);
+        }
+
+        private MutableIndexChanges Upsert(
+            string fullVersion,
+            NuGetVersion parsedVersion,
             VersionPropertiesData data)
         {
-            var added = new VersionProperties(fullOrOriginalVersion, data);
+            var added = new VersionProperties(fullVersion, parsedVersion, data);
             _versionProperties[added.ParsedVersion] = KeyValuePair.Create(added.FullVersion, data);
 
             // Detect changes related to the latest versions, per search filter.
@@ -104,9 +169,8 @@ namespace NuGet.Services.AzureSearch
             return MutableIndexChanges.FromLatestIndexChanges(output);
         }
 
-        internal MutableIndexChanges Delete(string version)
+        internal MutableIndexChanges Delete(NuGetVersion parsedVersion)
         {
-            var parsedVersion = NuGetVersion.Parse(version);
             _versionProperties.Remove(parsedVersion);
 
             // Detect changes related to the latest versions, per search filter.

--- a/src/NuGet.Services.AzureSearch/VersionList/VersionProperties.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/VersionProperties.cs
@@ -12,6 +12,12 @@ namespace NuGet.Services.AzureSearch
     /// </summary>
     internal class VersionProperties
     {
+        public VersionProperties(string fullVersion, NuGetVersion parsedVersion, VersionPropertiesData data)
+        {
+            Data = data ?? throw new ArgumentNullException(nameof(data));
+            Filtered = new FilteredVersionProperties(fullVersion, parsedVersion, Data.Listed);
+        }
+
         public VersionProperties(string fullOrOriginalVersion, VersionPropertiesData data)
         {
             Data = data ?? throw new ArgumentNullException(nameof(data));

--- a/tests/NuGet.Services.AzureSearch.Tests/TestExtensionMethods.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/TestExtensionMethods.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using NuGet.Versioning;
+
 namespace NuGet.Services.AzureSearch
 {
     internal static class TestExtensionMethods
@@ -8,6 +10,11 @@ namespace NuGet.Services.AzureSearch
         public static MutableIndexChanges Upsert(this VersionLists versionList, VersionProperties version)
         {
             return versionList.Upsert(version.FullVersion, version.Data);
+        }
+
+        public static MutableIndexChanges Delete(this VersionLists versionList, string fullOrOriginalVersion)
+        {
+            return versionList.Delete(NuGetVersion.Parse(fullOrOriginalVersion));
         }
     }
 }


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/6444
Progress on https://github.com/NuGet/NuGetGallery/issues/6445

This PR allows a batch of version upserts or deletes to be applied to the version list at once. Note that the version list is an ID-specific thing so all of these changes are for a single package ID. The result new `ApplyChangesInternal` method of this will be a set of Azure Search document changes that the caller needs to push to the search and hijack Azure Search indexes.

The basic idea of the method is to apply the changes in descending SemVer 2.0.0 order. Descending order minimizes changes to the latest version. Each individual `VersionListChange` produces in a set of index changes (`MutableIndexChanges`). These index changes are merged into the index changes gotten from the applying the previous change to the version list.

Some existing method signatures changed to require the caller to call `NuGetVersion.Parse` before calling the method (instead of accepting a string and parsing in the method implementation). This simplifies the interface as it means the caller doesn't have to think about whether a string version parameter means full vs normalized vs original version.

For the hijack index, this is basically keeping track of all version document's latest booleans.

For the search index, this is managing some nuanced state transitions.
