### PR TITLE
Add initial documents for search and hijack index and improve latest API

### DIFF
--- a/src/NuGet.Services.AzureSearch/Models/BaseMetadataDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/BaseMetadataDocument.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.Search;
+
+namespace NuGet.Services.AzureSearch
+{
+    /// <summary>
+    /// Implements most of <see cref="IBaseMetadataDocument"/>. Some fields are not defined here since they have
+    /// different Azure Search attributes.
+    /// </summary>
+    public abstract class BaseMetadataDocument : KeyedDocument
+    {
+        [IsFilterable]
+        public int? SemVerLevel { get; set; }
+
+        public string Authors { get; set; }
+        public string Copyright { get; set; }
+        public DateTimeOffset? Created { get; set; }
+        public string Description { get; set; }
+        public long? FileSize { get; set; }
+        public string FlattenedDependencies { get; set; }
+        public string Hash { get; set; }
+        public string HashAlgorithm { get; set; }
+        public string IconUrl { get; set; }
+        public string Language { get; set; }
+        public string LicenseUrl { get; set; }
+        public string MinClientVersion { get; set; }
+        public string NormalizedVersion { get; set; }
+        public string OriginalVersion { get; set; }
+        public string PackageId { get; set; }
+        public bool? Prerelease { get; set; }
+        public string ProjectUrl { get; set; }
+        public string ReleaseNotes { get; set; }
+        public bool? RequiresLicenseAcceptance { get; set; }
+        public string Summary { get; set; }
+        public string[] Tags { get; set; }
+        public string Title { get; set; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Models/HijackDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/HijackDocument.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.Search;
+using Microsoft.Azure.Search.Models;
+
+namespace NuGet.Services.AzureSearch
+{
+    /// <summary>
+    /// The different models for reading from and writing to the hijack index.
+    /// </summary>
+    public static class HijackDocument
+    {
+        /// <summary>
+        /// All fields available in the hijack index. Used for reading the index and updating a document when
+        /// <see cref="HijackDocumentChanges.UpdateMetadata"/> is <c>true</c>.
+        /// </summary>
+        [SerializePropertyNamesAsCamelCase]
+        public class Full : BaseMetadataDocument, ILatest, IBaseMetadataDocument
+        {
+            [IsSortable]
+            public DateTimeOffset? LastEdited { get; set; }
+            [IsSortable]
+            public DateTimeOffset? Published { get; set; }
+            [IsSortable]
+            public string SortableTitle { get; set; }
+
+            public bool? IsLatestStableSemVer1 { get; set; }
+            public bool? IsLatestSemVer1 { get; set; }
+            public bool? IsLatestStableSemVer2 { get; set; }
+            public bool? IsLatestSemVer2 { get; set; }
+        }
+
+        /// <summary>
+        /// Used for updating a document when <see cref="HijackDocumentChanges.UpdateMetadata"/> is <c>false</c>
+        /// and <see cref="HijackDocumentChanges.Delete"/> is <c>false</c>.
+        /// </summary>
+        [SerializePropertyNamesAsCamelCase]
+        public class Latest : KeyedDocument, ILatest
+        {
+            public bool? IsLatestStableSemVer1 { get; set; }
+            public bool? IsLatestSemVer1 { get; set; }
+            public bool? IsLatestStableSemVer2 { get; set; }
+            public bool? IsLatestSemVer2 { get; set; }
+        }
+
+        /// <summary>
+        /// Allows index updating code to update the latest booleans.
+        /// </summary>
+        public interface ILatest : IKeyedDocument
+        {
+            bool? IsLatestStableSemVer1 { get; set; }
+            bool? IsLatestSemVer1 { get; set; }
+            bool? IsLatestStableSemVer2 { get; set; }
+            bool? IsLatestSemVer2 { get; set; }
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Models/IBaseMetadataDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/IBaseMetadataDocument.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.AzureSearch
+{
+    /// <summary>
+    /// The fields shared between the search index and hijack index.
+    /// </summary>
+    public interface IBaseMetadataDocument
+    {
+        string Authors { get; set; }
+        string Copyright { get; set; }
+        DateTimeOffset? Created { get; set; }
+        string Description { get; set; }
+        long? FileSize { get; set; }
+        string FlattenedDependencies { get; set; }
+        string Hash { get; set; }
+        string HashAlgorithm { get; set; }
+        string IconUrl { get; set; }
+        string Language { get; set; }
+        DateTimeOffset? LastEdited { get; set; }
+        string LicenseUrl { get; set; }
+        string MinClientVersion { get; set; }
+        string NormalizedVersion { get; set; }
+        string OriginalVersion { get; set; }
+        string PackageId { get; set; }
+        bool? Prerelease { get; set; }
+        DateTimeOffset? Published { get; set; }
+        string ProjectUrl { get; set; }
+        string ReleaseNotes { get; set; }
+        bool? RequiresLicenseAcceptance { get; set; }
+        int? SemVerLevel { get; set; }
+        string Summary { get; set; }
+        string[] Tags { get; set; }
+        string Title { get; set; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Models/IKeyedDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/IKeyedDocument.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.AzureSearch
+{
+    /// <summary>
+    /// A base interface for referring to documents by their key.
+    /// </summary>
+    public interface IKeyedDocument
+    {
+        string Key { get; set; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Models/KeyedDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/KeyedDocument.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.DataAnnotations;
+using Microsoft.Azure.Search.Models;
+
+namespace NuGet.Services.AzureSearch
+{
+    /// <summary>
+    /// This is a base type but can be used directly for operations that only require a document key, such as deleting
+    /// a document.
+    /// </summary>
+    [SerializePropertyNamesAsCamelCase]
+    public class KeyedDocument : IKeyedDocument
+    {
+        [Key]
+        public string Key { get; set; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.Search.Models;
+
+namespace NuGet.Services.AzureSearch
+{
+    /// <summary>
+    /// The different models for reading from and writing to the search index.
+    /// </summary>
+    public static class SearchDocument
+    {
+        /// <summary>
+        /// All fields available in the search index. Used for reading the index and updating the index from database,
+        /// which has all fields available (as opposed to the catalog, which does not have all fields, like total
+        /// download count).
+        /// </summary>
+        [SerializePropertyNamesAsCamelCase]
+        public class Full : AddFirst
+        {
+            public long? TotalDownloadCount { get; set; }
+        }
+
+        /// <summary>
+        /// Used when processing <see cref="SearchIndexChangeType.AddFirst"/>.
+        /// </summary>
+        [SerializePropertyNamesAsCamelCase]
+        public class AddFirst : UpdateLatest
+        {
+            public string[] Owners { get; set; }
+        }
+
+        /// <summary>
+        /// Used when processing <see cref="SearchIndexChangeType.UpdateLatest"/> or
+        /// <see cref="SearchIndexChangeType.DowngradeLatest"/>.
+        /// </summary>
+        [SerializePropertyNamesAsCamelCase]
+        public class UpdateLatest : BaseMetadataDocument, IVersions, IBaseMetadataDocument
+        {
+            public string FullVersion { get; set; }
+            public DateTimeOffset? LastEdited { get; set; }
+            public DateTimeOffset? Published { get; set; }
+            public string[] Versions { get; set; }
+        }
+
+        /// <summary>
+        /// Used when processing <see cref="SearchIndexChangeType.UpdateVersionList"/>.
+        /// </summary>
+        [SerializePropertyNamesAsCamelCase]
+        public class UpdateVersionList : KeyedDocument, IVersions
+        {
+            public string[] Versions { get; set; }
+        }
+
+        /// <summary>
+        /// Allows index updating code to apply a new version list to a document.
+        /// </summary>
+        public interface IVersions : IKeyedDocument
+        {
+            string[] Versions { get; set; }
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -35,6 +35,12 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Models\IBaseMetadataDocument.cs" />
+    <Compile Include="Models\KeyedDocument.cs" />
+    <Compile Include="Models\BaseMetadataDocument.cs" />
+    <Compile Include="Models\HijackDocument.cs" />
+    <Compile Include="Models\IKeyedDocument.cs" />
+    <Compile Include="Models\SearchDocument.cs" />
     <Compile Include="VersionList\Guard.cs" />
     <Compile Include="VersionList\HijackIndexChange.cs" />
     <Compile Include="VersionList\HijackIndexChangeType.cs" />
@@ -42,6 +48,7 @@
     <Compile Include="VersionList\IndexChanges.cs" />
     <Compile Include="VersionList\LatestIndexChanges.cs" />
     <Compile Include="VersionList\KeyValuePair.cs" />
+    <Compile Include="VersionList\LatestVersionInfo.cs" />
     <Compile Include="VersionList\MutableHijackDocumentChanges.cs" />
     <Compile Include="VersionList\MutableIndexChanges.cs" />
     <Compile Include="VersionList\VersionListChange.cs" />
@@ -64,6 +71,9 @@
       <Version>0.3.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Azure.Search">
+      <Version>5.0.2</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
       <Version>4.4.4-dev-41931</Version>

--- a/src/NuGet.Services.AzureSearch/VersionList/FilteredVersionList.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/FilteredVersionList.cs
@@ -15,8 +15,8 @@ namespace NuGet.Services.AzureSearch
     /// </summary>
     internal class FilteredVersionList
     {
-        internal NuGetVersion _latestOrNull;
         internal readonly SortedList<NuGetVersion, FilteredVersionProperties> _versions;
+        internal NuGetVersion _latestOrNull;
 
         public FilteredVersionList(IEnumerable<FilteredVersionProperties> versions)
         {
@@ -35,23 +35,21 @@ namespace NuGet.Services.AzureSearch
             _latestOrNull = CalculateLatest();
         }
 
-        public string LatestOrNull
+        public LatestVersionInfo GetLatestVersionInfo()
         {
-            get
+            if (_latestOrNull == null)
             {
-                if (_latestOrNull == null)
-                {
-                    return null;
-                }
-
-                return _versions[_latestOrNull].FullVersion;
+                return null;
             }
-        }
 
-        public IReadOnlyList<string> FullVersions => _versions
-            .Where(x => x.Value.Listed)
-            .Select(x => x.Value.FullVersion)
-            .ToList();
+            return new LatestVersionInfo(
+                _latestOrNull,
+                _versions[_latestOrNull].FullVersion,
+                _versions
+                    .Where(x => x.Value.Listed)
+                    .Select(x => x.Value.FullVersion)
+                    .ToArray());
+        }
 
         public LatestIndexChanges Delete(NuGetVersion deleted)
         {
@@ -239,7 +237,7 @@ namespace NuGet.Services.AzureSearch
             return _versions
                 .Reverse()
                 .Where(x => x.Value.Listed)
-                .Select(x => x.Key)
+                .Select(x => x.Value.ParsedVersion)
                 .FirstOrDefault();
         }
 

--- a/src/NuGet.Services.AzureSearch/VersionList/LatestVersionInfo.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/LatestVersionInfo.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Versioning;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class LatestVersionInfo
+    {
+        public LatestVersionInfo(NuGetVersion parsedVersion, string fullVersion, string[] listedFullVersions)
+        {
+            ParsedVersion = parsedVersion ?? throw new ArgumentNullException(nameof(parsedVersion));
+            FullVersion = fullVersion ?? throw new ArgumentNullException(fullVersion);
+            ListedFullVersions = listedFullVersions ?? throw new ArgumentNullException(nameof(listedFullVersions));
+        }
+
+        public NuGetVersion ParsedVersion { get; }
+        public string FullVersion { get; }
+        public string[] ListedFullVersions { get; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/VersionList/VersionLists.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/VersionLists.cs
@@ -14,6 +14,8 @@ namespace NuGet.Services.AzureSearch
     /// </summary>
     public class VersionLists
     {
+        private static readonly IReadOnlyList<string> EmptyStringList = new string[0];
+
         private static readonly IReadOnlyDictionary<SearchFilters, Func<VersionProperties, bool>> SearchFilterPredicates
             = new Dictionary<SearchFilters, Func<VersionProperties, bool>>
             {
@@ -66,6 +68,16 @@ namespace NuGet.Services.AzureSearch
                     .Select(x => x.Filtered));
                 _versionLists.Add(searchFilter, listState);
             }
+        }
+
+        public LatestVersionInfo GetLatestVersionInfoOrNull(SearchFilters searchFilters)
+        {
+            if (!_versionLists.TryGetValue(searchFilters, out var listState))
+            {
+                return null;
+            }
+
+            return listState.GetLatestVersionInfo();
         }
 
         public VersionListData GetVersionListData()

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -56,10 +56,12 @@
       <Version>4.7.25</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.1.0</Version>
+      <Version>2.4.0</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.1.0</Version>
+      <Version>2.4.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/tests/NuGet.Services.AzureSearch.Tests/VersionList/FilteredVersionListFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/VersionList/FilteredVersionListFacts.cs
@@ -29,9 +29,10 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(properties.ParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(properties.FullVersion, _list.LatestOrNull);
+                Assert.Equal(properties.FullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(properties.ParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { properties.FullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(properties.FullVersion, _list._latestOrNull.ToFullString());
+                Assert.Equal(new[] { properties.FullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { properties.ParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -55,9 +56,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(latest.ParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(latest.FullVersion, _list.LatestOrNull);
+                Assert.Equal(latest.FullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(latest.ParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { properties.FullVersion, latest.FullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { properties.FullVersion, latest.FullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(
                     new[] { properties.ParsedVersion, latest.ParsedVersion },
                     _list._versions.Keys.ToArray());
@@ -80,9 +81,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialFullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(InitialParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { InitialFullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(
                     new[] { unlisted.ParsedVersion, InitialParsedVersion }.OrderBy(x => x).ToArray(),
                     _list._versions.Keys.ToArray());
@@ -103,9 +104,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialFullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(InitialParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { InitialFullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -126,9 +127,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(listed.ParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(listed.FullVersion, _list.LatestOrNull);
+                Assert.Equal(listed.FullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(listed.ParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { listed.FullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { listed.FullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(
                     new[] { InitialParsedVersion, listed.ParsedVersion }.OrderBy(x => x).ToArray(),
                     _list._versions.Keys.ToArray());
@@ -147,9 +148,8 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToFalse(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list.GetLatestVersionInfo());
                 Assert.Null(_list._latestOrNull);
-                Assert.Empty(_list.FullVersions);
                 Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -170,9 +170,8 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToFalse(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list.GetLatestVersionInfo());
                 Assert.Null(_list._latestOrNull);
-                Assert.Empty(_list.FullVersions);
                 Assert.Equal(
                     new[] { InitialParsedVersion, unlisted.ParsedVersion }.OrderBy(x => x).ToArray(),
                     _list._versions.Keys.ToArray());
@@ -195,9 +194,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(PreviousParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(listed.FullVersion, _list.LatestOrNull);
+                Assert.Equal(listed.FullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(listed.ParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { listed.FullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { listed.FullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { listed.ParsedVersion, InitialParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -218,9 +217,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(NextParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(listed.FullVersion, _list.LatestOrNull);
+                Assert.Equal(listed.FullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(listed.ParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { listed.FullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { listed.FullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { InitialParsedVersion, listed.ParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -240,9 +239,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialFullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(InitialParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { PreviousFullVersion, InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { PreviousFullVersion, InitialFullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { listed.ParsedVersion, InitialParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -263,9 +262,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialFullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(InitialParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { listed.FullVersion, InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { listed.FullVersion, InitialFullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { listed.ParsedVersion, InitialParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -284,9 +283,8 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToFalse(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list.GetLatestVersionInfo());
                 Assert.Null(_list._latestOrNull);
-                Assert.Empty(_list.FullVersions);
                 Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -305,9 +303,8 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToFalse(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list.GetLatestVersionInfo());
                 Assert.Null(_list._latestOrNull);
-                Assert.Empty(_list.FullVersions);
                 Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -324,9 +321,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialFullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(InitialParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { InitialFullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -348,9 +345,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialFullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(InitialParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { listed.FullVersion, InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { listed.FullVersion, InitialFullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { listed.ParsedVersion, InitialParsedVersion }, _list._versions.Keys.ToArray());
             }
         }
@@ -374,9 +371,8 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToFalse(removedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list.GetLatestVersionInfo());
                 Assert.Null(_list._latestOrNull);
-                Assert.Empty(_list.FullVersions);
                 Assert.Empty(_list._versions.Keys);
             }
 
@@ -397,9 +393,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialFullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(InitialParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { InitialFullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -421,9 +417,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialFullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(InitialParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { InitialFullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -444,9 +440,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialFullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(InitialParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { InitialFullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -465,9 +461,8 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToFalse(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list.GetLatestVersionInfo());
                 Assert.Null(_list._latestOrNull);
-                Assert.Empty(_list.FullVersions);
                 Assert.Empty(_list._versions);
             }
 
@@ -484,9 +479,8 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToFalse(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list.GetLatestVersionInfo());
                 Assert.Null(_list._latestOrNull);
-                Assert.Empty(_list.FullVersions);
                 Assert.Empty(_list._versions);
             }
 
@@ -505,9 +499,8 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToFalse(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list.GetLatestVersionInfo());
                 Assert.Null(_list._latestOrNull);
-                Assert.Empty(_list.FullVersions);
                 Assert.Empty(_list._versions.Keys);
             }
 
@@ -528,9 +521,8 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToFalse(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list.GetLatestVersionInfo());
                 Assert.Null(_list._latestOrNull);
-                Assert.Empty(_list.FullVersions);
                 Assert.Equal(new[] { unlisted.ParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -551,9 +543,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialFullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(InitialParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { InitialFullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -574,9 +566,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(NextParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(NextFullVersion, _list.LatestOrNull);
+                Assert.Equal(NextFullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(NextParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { PreviousFullVersion, NextFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { PreviousFullVersion, NextFullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { PreviousParsedVersion, NextParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -597,9 +589,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(InitialParsedVersion),
                     },
                     Enumerable.ToArray(output.Hijack));
-                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialFullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(InitialParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { PreviousFullVersion, InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { PreviousFullVersion, InitialFullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { PreviousParsedVersion, InitialParsedVersion }, _list._versions.Keys.ToArray());
             }
         }
@@ -622,9 +614,8 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.Delete(deletedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list.GetLatestVersionInfo());
                 Assert.Null(_list._latestOrNull);
-                Assert.Empty(_list.FullVersions);
                 Assert.Empty(_list._versions.Keys);
             }
 
@@ -644,9 +635,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialFullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(InitialParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { InitialFullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -667,9 +658,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialFullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(InitialParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { InitialFullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -689,9 +680,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialFullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(InitialParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { InitialFullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -709,9 +700,8 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.Delete(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list.GetLatestVersionInfo());
                 Assert.Null(_list._latestOrNull);
-                Assert.Empty(_list.FullVersions);
                 Assert.Empty(_list._versions);
             }
 
@@ -727,9 +717,8 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.Delete(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list.GetLatestVersionInfo());
                 Assert.Null(_list._latestOrNull);
-                Assert.Empty(_list.FullVersions);
                 Assert.Empty(_list._versions);
             }
 
@@ -752,9 +741,8 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.Delete(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list.GetLatestVersionInfo());
                 Assert.Null(_list._latestOrNull);
-                Assert.Empty(_list.FullVersions);
                 Assert.Empty(_list._versions.Keys);
             }
 
@@ -774,9 +762,8 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.Delete(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Null(_list.LatestOrNull);
+                Assert.Null(_list.GetLatestVersionInfo());
                 Assert.Null(_list._latestOrNull);
-                Assert.Empty(_list.FullVersions);
                 Assert.Equal(new[] { unlisted.ParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -796,9 +783,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(InitialParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialFullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(InitialParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { InitialFullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { InitialParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -818,9 +805,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(NextParsedVersion),
                     },
                     output.Hijack.ToArray());
-                Assert.Equal(NextFullVersion, _list.LatestOrNull);
+                Assert.Equal(NextFullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(NextParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { PreviousFullVersion, NextFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { PreviousFullVersion, NextFullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { PreviousParsedVersion, NextParsedVersion }, _list._versions.Keys.ToArray());
             }
 
@@ -840,9 +827,9 @@ namespace NuGet.Services.AzureSearch
                         HijackIndexChange.SetLatestToTrue(InitialParsedVersion),
                     },
                     Enumerable.ToArray(output.Hijack));
-                Assert.Equal(InitialFullVersion, _list.LatestOrNull);
+                Assert.Equal(InitialFullVersion, _list.GetLatestVersionInfo().FullVersion);
                 Assert.Equal(InitialParsedVersion, _list._latestOrNull);
-                Assert.Equal(new[] { PreviousFullVersion, InitialFullVersion }, _list.FullVersions.ToArray());
+                Assert.Equal(new[] { PreviousFullVersion, InitialFullVersion }, _list.GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(new[] { PreviousParsedVersion, InitialParsedVersion }, _list._versions.Keys.ToArray());
             }
         }
@@ -860,7 +847,7 @@ namespace NuGet.Services.AzureSearch
 
                 var list = new FilteredVersionList(versions);
 
-                Assert.Equal("1.0.0", list.LatestOrNull);
+                Assert.Equal("1.0.0", list.GetLatestVersionInfo().FullVersion);
             }
 
             [Fact]
@@ -870,7 +857,7 @@ namespace NuGet.Services.AzureSearch
 
                 var list = new FilteredVersionList(versions);
 
-                Assert.Null(list.LatestOrNull);
+                Assert.Null(list._latestOrNull);
             }
 
             [Fact]
@@ -884,7 +871,7 @@ namespace NuGet.Services.AzureSearch
 
                 var list = new FilteredVersionList(versions);
 
-                Assert.Null(list.LatestOrNull);
+                Assert.Null(list._latestOrNull);
             }
         }
 
@@ -901,7 +888,7 @@ namespace NuGet.Services.AzureSearch
 
                 var list = new FilteredVersionList(versions);
 
-                Assert.Equal(new[] { "1.0.0" }, list.FullVersions.ToArray());
+                Assert.Equal(new[] { "1.0.0" }, list.GetLatestVersionInfo().ListedFullVersions);
             }
 
             [Fact]
@@ -921,7 +908,7 @@ namespace NuGet.Services.AzureSearch
 
                 Assert.Equal(
                     new[] { "2.0.0", "10.0.0-alpha", "10.0.0-beta.2", "10.0.0-beta.10", "10.0.0", "10.0.1" },
-                    list.FullVersions.ToArray());
+                    list.GetLatestVersionInfo().ListedFullVersions);
             }
         }
 

--- a/tests/NuGet.Services.AzureSearch.Tests/VersionList/MutableIndexChangesFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/VersionList/MutableIndexChangesFacts.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using NuGet.Versioning;
 using Xunit;
 
-namespace NuGet.Services.AzureSearch.VersionList
+namespace NuGet.Services.AzureSearch
 {
     public class MutableIndexChangesFacts
     {

--- a/tests/NuGet.Services.AzureSearch.Tests/VersionList/VersionListsFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/VersionList/VersionListsFacts.cs
@@ -36,16 +36,16 @@ namespace NuGet.Services.AzureSearch
                     list._versionLists.Keys);
                 Assert.Equal(
                     new[] { StableSemVer1 },
-                    list._versionLists[SearchFilters.Default].FullVersions.ToArray());
+                    list._versionLists[SearchFilters.Default].GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(
                     new[] { StableSemVer1, PrereleaseSemVer1 },
-                    list._versionLists[SearchFilters.IncludePrerelease].FullVersions.ToArray());
+                    list._versionLists[SearchFilters.IncludePrerelease].GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(
                     new[] { StableSemVer1, StableSemVer2 },
-                    list._versionLists[SearchFilters.IncludeSemVer2].FullVersions.ToArray());
+                    list._versionLists[SearchFilters.IncludeSemVer2].GetLatestVersionInfo().ListedFullVersions);
                 Assert.Equal(
                     new[] { StableSemVer1, PrereleaseSemVer1, StableSemVer2, PrereleaseSemVer2 },
-                    list._versionLists[SearchFilters.IncludePrereleaseAndSemVer2].FullVersions.ToArray());
+                    list._versionLists[SearchFilters.IncludePrereleaseAndSemVer2].GetLatestVersionInfo().ListedFullVersions);
             }
 
             [Fact]
@@ -87,7 +87,7 @@ namespace NuGet.Services.AzureSearch
                 Assert.Empty(list._versionLists[SearchFilters.IncludeSemVer2]._versions);
                 Assert.Equal(
                     new[] { PrereleaseSemVer2 },
-                    list._versionLists[SearchFilters.IncludePrereleaseAndSemVer2].FullVersions.ToArray());
+                    list._versionLists[SearchFilters.IncludePrereleaseAndSemVer2].GetLatestVersionInfo().ListedFullVersions);
             }
         }
 
@@ -257,8 +257,8 @@ namespace NuGet.Services.AzureSearch
                             .Where(x => x.Value)
                             .OrderBy(x => x.Key)
                             .Select(x => x.Key.ToFullString())
-                            .ToList(),
-                        filteredList.FullVersions);
+                            .ToArray(),
+                        filteredList.GetLatestVersionInfo()?.ListedFullVersions ?? new string[0]);
                     Assert.Equal(
                         expectedVersions
                             .Where(x => x.Value)
@@ -266,7 +266,7 @@ namespace NuGet.Services.AzureSearch
                             .OrderBy(x => x)
                             .LastOrDefault()?
                             .ToFullString(),
-                        filteredList.LatestOrNull);
+                        filteredList.GetLatestVersionInfo()?.FullVersion);
 
                     return new TestResult(testCase, exception: null);
                 }


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/6439.
Progress on https://github.com/NuGet/NuGetGallery/issues/6440.

This PR does two things.

**Add initial Azure Search document models.** There are multiple subsets of the fields, to support the different update patterns. For example, when updating the search index, you only want to update the `Versions` property (e.g. a non-latest version was added).

**Improve the API on `VersionLists` to get latest version information.** Previously you had to call multiple properties/methods to determine the latest version and the version list. Now all the data you need is returned as `LatestVersionInfo`. This will be used in the search index updater code reacting to change types like `AddFirst`. This also made some test assertions cleaner.