### PR TITLE
Add the initial project for the db2azuresearch job

### DIFF
--- a/NuGet.Services.Metadata.sln
+++ b/NuGet.Services.Metadata.sln
@@ -46,6 +46,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.AzureSearch"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.AzureSearch.Tests", "tests\NuGet.Services.AzureSearch.Tests\NuGet.Services.AzureSearch.Tests.csproj", "{6A9C3802-A2A2-49CF-87BD-C1303533B846}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Jobs.Db2AzureSearch", "src\NuGet.Jobs.Db2AzureSearch\NuGet.Jobs.Db2AzureSearch.csproj", "{209B1B7F-1C5C-41EC-B6A6-E01FD9C86E26}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -220,6 +222,18 @@ Global
 		{6A9C3802-A2A2-49CF-87BD-C1303533B846}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{6A9C3802-A2A2-49CF-87BD-C1303533B846}.Release|x64.ActiveCfg = Release|Any CPU
 		{6A9C3802-A2A2-49CF-87BD-C1303533B846}.Release|x64.Build.0 = Release|Any CPU
+		{209B1B7F-1C5C-41EC-B6A6-E01FD9C86E26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{209B1B7F-1C5C-41EC-B6A6-E01FD9C86E26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{209B1B7F-1C5C-41EC-B6A6-E01FD9C86E26}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{209B1B7F-1C5C-41EC-B6A6-E01FD9C86E26}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{209B1B7F-1C5C-41EC-B6A6-E01FD9C86E26}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{209B1B7F-1C5C-41EC-B6A6-E01FD9C86E26}.Debug|x64.Build.0 = Debug|Any CPU
+		{209B1B7F-1C5C-41EC-B6A6-E01FD9C86E26}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{209B1B7F-1C5C-41EC-B6A6-E01FD9C86E26}.Release|Any CPU.Build.0 = Release|Any CPU
+		{209B1B7F-1C5C-41EC-B6A6-E01FD9C86E26}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{209B1B7F-1C5C-41EC-B6A6-E01FD9C86E26}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{209B1B7F-1C5C-41EC-B6A6-E01FD9C86E26}.Release|x64.ActiveCfg = Release|Any CPU
+		{209B1B7F-1C5C-41EC-B6A6-E01FD9C86E26}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -239,6 +253,7 @@ Global
 		{E76E73FA-4462-4F07-94C0-8B9CC413F696} = {C86C6DEE-84E1-4E4E-8868-6755D7A8E0E4}
 		{1A53FE3D-8041-4773-942F-D73AEF5B82B2} = {62F629BA-0F25-4007-82B0-93165883AF5D}
 		{6A9C3802-A2A2-49CF-87BD-C1303533B846} = {F1C83FD9-A498-483E-ADFA-B55D82A14965}
+		{209B1B7F-1C5C-41EC-B6A6-E01FD9C86E26} = {C86C6DEE-84E1-4E4E-8868-6755D7A8E0E4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D3AB83E9-02B4-4FFA-A2D0-637F0B97E626}

--- a/build.ps1
+++ b/build.ps1
@@ -80,7 +80,8 @@ Invoke-BuildStep 'Set version metadata in AssemblyInfo.cs' {
             "src\NuGet.ApplicationInsights.Owin\Properties\AssemblyInfo.g.cs", `
             "src\Ng\Properties\AssemblyInfo.g.cs", `
             "src\NuGet.Services.Metadata.Catalog.Monitoring\Properties\AssemblyInfo.g.cs", `
-            "src\NuGet.Services.AzureSearch\Properties\AssemblyInfo.g.cs"
+            "src\NuGet.Services.AzureSearch\Properties\AssemblyInfo.g.cs", `
+            "src\NuGet.Jobs.Db2AzureSearch\Properties\AssemblyInfo.g.cs"
 
         Foreach ($assemblyInfo in $assemblyInfos) {
             Set-VersionInfo -Path (Join-Path $PSScriptRoot $assemblyInfo) -Version $SimpleVersion -Branch $Branch -Commit $CommitSHA
@@ -106,7 +107,8 @@ Invoke-BuildStep 'Creating artifacts' {
         }
 
         $nuspecPackages = `
-            "src\Ng\Ng.nuspec"
+            "src\Ng\Ng.nuspec", `
+            "src\NuGet.Jobs.Db2AzureSearch\NuGet.Jobs.Db2AzureSearch.nuspec"
 
         $nuspecPackages | ForEach-Object {
             New-Package (Join-Path $PSScriptRoot $_) -Configuration $Configuration -BuildNumber $BuildNumber -Version $SemanticVersion -Branch $Branch

--- a/src/NuGet.Jobs.Db2AzureSearch/App.config
+++ b/src/NuGet.Jobs.Db2AzureSearch/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+    </startup>
+</configuration>

--- a/src/NuGet.Jobs.Db2AzureSearch/Job.cs
+++ b/src/NuGet.Jobs.Db2AzureSearch/Job.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Autofac;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace NuGet.Jobs
+{
+    public class Job : JsonConfigurationJob
+    {
+        public override Task Run()
+        {
+            return Task.CompletedTask;
+        }
+
+        protected override void ConfigureAutofacServices(ContainerBuilder containerBuilder)
+        {
+        }
+
+        protected override void ConfigureJobServices(IServiceCollection services, IConfigurationRoot configurationRoot)
+        {
+        }
+    }
+}

--- a/src/NuGet.Jobs.Db2AzureSearch/NuGet.Jobs.Db2AzureSearch.csproj
+++ b/src/NuGet.Jobs.Db2AzureSearch/NuGet.Jobs.Db2AzureSearch.csproj
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{209B1B7F-1C5C-41EC-B6A6-E01FD9C86E26}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>NuGet.Jobs.Db2AzureSearch</RootNamespace>
+    <AssemblyName>NuGet.Jobs.Db2AzureSearch</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Job.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.*.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="NuGet.Jobs.Db2AzureSearch.nuspec" />
+    <None Include="Scripts\NuGet.Jobs.Db2AzureSearch.cmd" />
+    <None Include="Settings\dev.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NuGet.Services.AzureSearch\NuGet.Services.AzureSearch.csproj">
+      <Project>{1a53fe3d-8041-4773-942f-d73aef5b82b2}</Project>
+      <Name>NuGet.Services.AzureSearch</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <SignPath>..\..\build</SignPath>
+    <SignPath Condition="'$(BUILD_SOURCESDIRECTORY)' != ''">$(BUILD_SOURCESDIRECTORY)\build</SignPath>
+    <SignPath Condition="'$(NuGetBuildPath)' != ''">$(NuGetBuildPath)</SignPath>
+  </PropertyGroup>
+  <Import Project="$(SignPath)\sign.targets" Condition="Exists('$(SignPath)\sign.targets')" />
+  <Import Project="$(SignPath)\sign.microbuild.targets" Condition="Exists('$(SignPath)\sign.microbuild.targets')" />
+</Project>

--- a/src/NuGet.Jobs.Db2AzureSearch/NuGet.Jobs.Db2AzureSearch.nuspec
+++ b/src/NuGet.Jobs.Db2AzureSearch/NuGet.Jobs.Db2AzureSearch.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>NuGet.Jobs.Db2AzureSearch</id>
+    <version>$version$</version>
+    <authors>.NET Foundation</authors>
+    <owners>.NET Foundation</owners>
+    <description>NuGet.Jobs.Db2AzureSearch</description>
+    <copyright>Copyright .NET Foundation</copyright>
+  </metadata>
+  <files>
+    <file src="bin\$configuration$\*.*" target="bin" />
+    <file src="Scripts\*.cmd" />
+    <file src="Settings\*.json" target="bin" />
+  </files>
+</package>

--- a/src/NuGet.Jobs.Db2AzureSearch/Program.cs
+++ b/src/NuGet.Jobs.Db2AzureSearch/Program.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Jobs
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var job = new Job();
+            JobRunner.RunOnce(job, args).GetAwaiter().GetResult();
+        }
+    }
+}

--- a/src/NuGet.Jobs.Db2AzureSearch/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Jobs.Db2AzureSearch/Properties/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("NuGet.Jobs.Db2AzureSearch")]
+[assembly: ComVisible(false)]
+[assembly: Guid("209b1b7f-1c5c-41ec-b6a6-e01fd9c86e26")]

--- a/src/NuGet.Jobs.Db2AzureSearch/Scripts/NuGet.Jobs.Db2AzureSearch.cmd
+++ b/src/NuGet.Jobs.Db2AzureSearch/Scripts/NuGet.Jobs.Db2AzureSearch.cmd
@@ -1,0 +1,15 @@
+﻿@echo OFF
+	
+cd bin
+
+:Top
+echo "Starting job - NuGet.Jobs.Db2AzureSearch"
+
+title NuGet.Jobs.Db2AzureSearch
+
+start /w NuGet.Jobs.Db2AzureSearch.exe ^
+	-Configuration "#{Jobs.Db2AzureSearch.Configuration}" ^
+	-InstrumentationKey "#{Jobs.Db2AzureSearch.ApplicationInsightsInstrumentationKey}" ^
+	-Verbose true
+
+echo "Finished NuGet.Jobs.Db2AzureSearch"

--- a/src/NuGet.Jobs.Db2AzureSearch/Settings/dev.json
+++ b/src/NuGet.Jobs.Db2AzureSearch/Settings/dev.json
@@ -1,0 +1,12 @@
+{
+  "GalleryDb": {
+    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=Search.GenerateAuxData;AadTenant=#{Deployment.Azure.ActiveDirectory.Tenant};AadClientId=#{Deployment.Azure.ActiveDirectory.GalleryDbReader.ClientId};AadCertificate=$$dev-gallerydb-reader$$"
+  },
+
+  "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
+  "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",
+  "KeyVault_CertificateThumbprint": "#{Deployment.Azure.KeyVault.CertificateThumbprint}",
+  "KeyVault_ValidateCertificate": true,
+  "KeyVault_StoreName": "My",
+  "KeyVault_StoreLocation": "LocalMachine"
+}

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -75,6 +75,9 @@
     <PackageReference Include="Microsoft.Azure.Search">
       <Version>5.0.2</Version>
     </PackageReference>
+    <PackageReference Include="NuGet.Jobs.Common">
+      <Version>4.0.42887-dev</Version>
+    </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
       <Version>4.4.4-dev-41931</Version>
     </PackageReference>


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/6440.

By design, this is an independent entry point (as opposed to a shared entry point for many jobs, like ng.exe). This also used the job infrastructure used by NuGet.Jobs and our internal jobs repo (`NuGet.Jobs.Common`).

The job is packed as an Octopus nupkg, but does not necessarily need to be deployed since it's an ops tool.