### PR TITLE
 Add Service Bus wrapper interfaces and implementations

### DIFF
--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -65,6 +65,14 @@
     <Compile Include="VersionList\VersionPropertiesData.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />
+    <Compile Include="Wrappers\DocumentsOperationsWrapper.cs" />
+    <Compile Include="Wrappers\IDocumentsOperationsWrapper.cs" />
+    <Compile Include="Wrappers\IIndexesOperationsWrapper.cs" />
+    <Compile Include="Wrappers\IndexesOperationsWrapper.cs" />
+    <Compile Include="Wrappers\ISearchIndexClientWrapper.cs" />
+    <Compile Include="Wrappers\ISearchServiceClientWrapper.cs" />
+    <Compile Include="Wrappers\SearchIndexClientWrapper.cs" />
+    <Compile Include="Wrappers\SearchServiceClientWrapper.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core">

--- a/src/NuGet.Services.AzureSearch/Wrappers/DocumentsOperationsWrapper.cs
+++ b/src/NuGet.Services.AzureSearch/Wrappers/DocumentsOperationsWrapper.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.Search;
+using Microsoft.Azure.Search.Models;
+
+namespace NuGet.Services.AzureSearch.Wrappers
+{
+    public class DocumentsOperationsWrapper : IDocumentsOperationsWrapper
+    {
+        private readonly IDocumentsOperations _inner;
+
+        public DocumentsOperationsWrapper(IDocumentsOperations inner)
+        {
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        }
+
+        public async Task<DocumentIndexResult> IndexAsync<T>(IndexBatch<T> batch) where T : class
+        {
+            return await _inner.IndexAsync(batch);
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Wrappers/IDocumentsOperationsWrapper.cs
+++ b/src/NuGet.Services.AzureSearch/Wrappers/IDocumentsOperationsWrapper.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Azure.Search.Models;
+
+namespace NuGet.Services.AzureSearch.Wrappers
+{
+    public interface IDocumentsOperationsWrapper
+    {
+        Task<DocumentIndexResult> IndexAsync<T>(IndexBatch<T> batch) where T : class;
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Wrappers/IIndexesOperationsWrapper.cs
+++ b/src/NuGet.Services.AzureSearch/Wrappers/IIndexesOperationsWrapper.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Azure.Search.Models;
+
+namespace NuGet.Services.AzureSearch.Wrappers
+{
+    public interface IIndexesOperationsWrapper
+    {
+        Task<Index> CreateAsync(Index index);
+        Task DeleteAsync(string indexName);
+        Task<bool> ExistsAsync(string indexName);
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Wrappers/ISearchIndexClientWrapper.cs
+++ b/src/NuGet.Services.AzureSearch/Wrappers/ISearchIndexClientWrapper.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.AzureSearch.Wrappers
+{
+    public interface ISearchIndexClientWrapper
+    {
+        string IndexName { get; }
+        IDocumentsOperationsWrapper Documents { get; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Wrappers/ISearchServiceClientWrapper.cs
+++ b/src/NuGet.Services.AzureSearch/Wrappers/ISearchServiceClientWrapper.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.AzureSearch.Wrappers
+{
+    public interface ISearchServiceClientWrapper
+    {
+        IIndexesOperationsWrapper Indexes { get; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Wrappers/IndexesOperationsWrapper.cs
+++ b/src/NuGet.Services.AzureSearch/Wrappers/IndexesOperationsWrapper.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.Search;
+using Microsoft.Azure.Search.Models;
+
+namespace NuGet.Services.AzureSearch.Wrappers
+{
+    public class IndexesOperationsWrapper : IIndexesOperationsWrapper
+    {
+        private readonly IIndexesOperations _inner;
+
+        public IndexesOperationsWrapper(IIndexesOperations inner)
+        {
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        }
+
+        public async Task<bool> ExistsAsync(string indexName)
+        {
+            return await _inner.ExistsAsync(indexName);
+        }
+
+        public async Task DeleteAsync(string indexName)
+        {
+            await _inner.DeleteAsync(indexName);
+        }
+
+        public async Task<Index> CreateAsync(Index index)
+        {
+            return await _inner.CreateAsync(index);
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Wrappers/SearchIndexClientWrapper.cs
+++ b/src/NuGet.Services.AzureSearch/Wrappers/SearchIndexClientWrapper.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.Search;
+
+namespace NuGet.Services.AzureSearch.Wrappers
+{
+    public class SearchIndexClientWrapper : ISearchIndexClientWrapper
+    {
+        private readonly ISearchIndexClient _inner;
+
+        public SearchIndexClientWrapper(ISearchIndexClient inner)
+        {
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+            Documents = new DocumentsOperationsWrapper(_inner.Documents);
+        }
+
+        public string IndexName => _inner.IndexName;
+        public IDocumentsOperationsWrapper Documents { get; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Wrappers/SearchServiceClientWrapper.cs
+++ b/src/NuGet.Services.AzureSearch/Wrappers/SearchServiceClientWrapper.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.Search;
+
+namespace NuGet.Services.AzureSearch.Wrappers
+{
+    public class SearchServiceClientWrapper : ISearchServiceClientWrapper
+    {
+        private readonly ISearchServiceClient _inner;
+
+        public SearchServiceClientWrapper(ISearchServiceClient inner)
+        {
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+            Indexes = new IndexesOperationsWrapper(_inner.Indexes);
+        }
+
+        public IIndexesOperationsWrapper Indexes { get; }
+    }
+}


### PR DESCRIPTION
Per recommendations by Azure Search discussion group, this is the right way to unit test Azure Search.

I chose not to put this in ServerCommon (where other wrappers are) because we only have one planned used for Azure Search, which is in Services.Metadata.

Progress on https://github.com/NuGet/NuGetGallery/issues/6440