### PR TITLE
Add Db2AzureSearchCommand and DI wire-up to push changes to Azure Search

### DIFF
--- a/src/NuGet.Jobs.Db2AzureSearch/Job.cs
+++ b/src/NuGet.Jobs.Db2AzureSearch/Job.cs
@@ -1,26 +1,80 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Autofac;
+using Microsoft.Azure.Search;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NuGet.Services.AzureSearch;
+using NuGet.Services.AzureSearch.Db2AzureSearch;
+using NuGet.Services.AzureSearch.Wrappers;
 
 namespace NuGet.Jobs
 {
     public class Job : JsonConfigurationJob
     {
-        public override Task Run()
+        private const string Db2AzureSearchSectionName = "Db2AzureSearch";
+        private const string SearchIndexKey = "SearchIndex";
+        private const string HijackIndexKey = "HijackIndex";
+
+        public override async Task Run()
         {
-            return Task.CompletedTask;
+            var db2AzureSearch = _serviceProvider.GetRequiredService<IDb2AzureSearchCommand>();
+            await db2AzureSearch.ExecuteAsync();
         }
 
         protected override void ConfigureAutofacServices(ContainerBuilder containerBuilder)
         {
+            containerBuilder
+                .Register(c =>
+                {
+                    var serviceClient = c.Resolve<ISearchServiceClientWrapper>();
+                    var options = c.Resolve<IOptionsSnapshot<Db2AzureSearchConfiguration>>();
+                    return serviceClient.Indexes.GetClient(options.Value.SearchIndexName);
+                })
+                .SingleInstance()
+                .Keyed<ISearchIndexClientWrapper>(SearchIndexKey);
+
+            containerBuilder
+                .Register(c =>
+                {
+                    var serviceClient = c.Resolve<ISearchServiceClientWrapper>();
+                    var options = c.Resolve<IOptionsSnapshot<Db2AzureSearchConfiguration>>();
+                    return serviceClient.Indexes.GetClient(options.Value.HijackIndexName);
+                })
+                .SingleInstance()
+                .Keyed<ISearchIndexClientWrapper>(HijackIndexKey);
+
+            containerBuilder
+                .Register<IDb2AzureSearchCommand>(c => new Db2AzureSearchCommand(
+                    c.Resolve<INewPackageRegistrationProducer>(),
+                    c.Resolve<IIndexActionBuilder>(),
+                    c.Resolve<ISearchServiceClientWrapper>(),
+                    c.ResolveKeyed<ISearchIndexClientWrapper>(SearchIndexKey),
+                    c.ResolveKeyed<ISearchIndexClientWrapper>(HijackIndexKey),
+                    c.Resolve<IOptionsSnapshot<Db2AzureSearchConfiguration>>(),
+                    c.Resolve<ILogger<Db2AzureSearchCommand>>()));
         }
 
         protected override void ConfigureJobServices(IServiceCollection services, IConfigurationRoot configurationRoot)
         {
+            services.Configure<Db2AzureSearchConfiguration>(configurationRoot.GetSection(Db2AzureSearchSectionName));
+
+            services.AddSingleton<ISearchServiceClient>(p =>
+            {
+                var options = p.GetRequiredService<IOptionsSnapshot<Db2AzureSearchConfiguration>>();
+                return new SearchServiceClient(
+                    options.Value.SearchServiceName,
+                    new SearchCredentials(options.Value.SearchServiceApiKey));
+            });
+
+            services.AddSingleton<ISearchServiceClientWrapper, SearchServiceClientWrapper>();
+            services.AddTransient<IEntitiesContextFactory, EntitiesContextFactory>();
+            services.AddTransient<INewPackageRegistrationProducer, NewPackageRegistrationProducer>();
+            services.AddTransient<IIndexActionBuilder, IndexActionBuilder>();
         }
     }
 }

--- a/src/NuGet.Jobs.Db2AzureSearch/Settings/dev.json
+++ b/src/NuGet.Jobs.Db2AzureSearch/Settings/dev.json
@@ -3,6 +3,17 @@
     "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=Search.GenerateAuxData;AadTenant=#{Deployment.Azure.ActiveDirectory.Tenant};AadClientId=#{Deployment.Azure.ActiveDirectory.GalleryDbReader.ClientId};AadCertificate=$$dev-gallerydb-reader$$"
   },
 
+  "Db2AzureSearch": {
+    "DatabaseBatchSize": 10000,
+    "AzureSearchBatchSize": 1000,
+    "WorkerCount": 16,
+    "SearchServiceName": "",
+    "SearchServiceApiKey": "",
+    "SearchIndexName": "",
+    "HijackIndexName": "",
+    "ReplaceIndexes": false
+  },
+
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
   "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",
   "KeyVault_CertificateThumbprint": "#{Deployment.Azure.KeyVault.CertificateThumbprint}",

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchCommand.cs
@@ -1,0 +1,230 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Search;
+using Microsoft.Azure.Search.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NuGet.Services.AzureSearch.Wrappers;
+
+namespace NuGet.Services.AzureSearch.Db2AzureSearch
+{
+    public class Db2AzureSearchCommand : IDb2AzureSearchCommand
+    {
+        private readonly INewPackageRegistrationProducer _producer;
+        private readonly IIndexActionBuilder _indexActionBuilder;
+        private readonly ISearchServiceClientWrapper _serviceClient;
+        private readonly ISearchIndexClientWrapper _searchIndexClient;
+        private readonly ISearchIndexClientWrapper _hijackIndexClient;
+        private readonly IOptionsSnapshot<Db2AzureSearchConfiguration> _options;
+        private readonly ILogger<Db2AzureSearchCommand> _logger;
+
+        public Db2AzureSearchCommand(
+            INewPackageRegistrationProducer producer,
+            IIndexActionBuilder indexActionBuilder,
+            ISearchServiceClientWrapper serviceClient,
+            ISearchIndexClientWrapper searchIndexClient,
+            ISearchIndexClientWrapper hijackIndexClient,
+            IOptionsSnapshot<Db2AzureSearchConfiguration> options,
+            ILogger<Db2AzureSearchCommand> logger)
+        {
+            _producer = producer ?? throw new ArgumentNullException(nameof(producer));
+            _indexActionBuilder = indexActionBuilder ?? throw new ArgumentNullException(nameof(indexActionBuilder));
+            _serviceClient = serviceClient ?? throw new ArgumentNullException(nameof(serviceClient));
+            _searchIndexClient = searchIndexClient ?? throw new ArgumentNullException(nameof(searchIndexClient));
+            _hijackIndexClient = hijackIndexClient ?? throw new ArgumentNullException(nameof(hijackIndexClient));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task ExecuteAsync()
+        {
+            var allWork = new ConcurrentBag<NewPackageRegistration>();
+            using (var cancelledCts = new CancellationTokenSource())
+            using (var produceWorkCts = new CancellationTokenSource())
+            {
+                // Initialize the indexes
+                await InitializeAsync();
+
+                // Set up the producer and the consumers.
+                var producerTask = ProduceWorkAsync(allWork, produceWorkCts, cancelledCts.Token);
+                var consumerTasks = Enumerable
+                    .Range(0, _options.Value.WorkerCount)
+                    .Select(i => ConsumeWorkAsync(allWork, produceWorkCts.Token, cancelledCts.Token))
+                    .ToList();
+                var allTasks = new[] { producerTask }.Concat(consumerTasks).ToList();
+
+                // If one of the tasks throws an exception before the work is completed, cancel the work.
+                var firstTask = await Task.WhenAny(allTasks);
+                if (firstTask.IsFaulted)
+                {
+                    cancelledCts.Cancel();
+                }
+
+                await firstTask;
+                await Task.WhenAll(allTasks);
+            }
+        }
+
+        private async Task InitializeAsync()
+        {
+            if (_options.Value.ReplaceIndexes)
+            {
+                await DeleteIndexIfExistsAsync(_options.Value.SearchIndexName);
+                await DeleteIndexIfExistsAsync(_options.Value.HijackIndexName);
+            }
+
+            await CreateIndexAsync<SearchDocument.Full>(_options.Value.SearchIndexName);
+            await CreateIndexAsync<HijackDocument.Full>(_options.Value.HijackIndexName);
+        }
+
+        private async Task DeleteIndexIfExistsAsync(string indexName)
+        {
+            if (await _serviceClient.Indexes.ExistsAsync(indexName))
+            {
+                _logger.LogWarning("Deleting index {IndexName}.", indexName);
+                await _serviceClient.Indexes.DeleteAsync(indexName);
+                _logger.LogWarning("Done deleting index {IndexName}.", indexName);
+            }
+        }
+
+        private async Task CreateIndexAsync<T>(string indexName)
+        {
+            _logger.LogInformation("Creating index {IndexName}.", indexName);
+            await _serviceClient.Indexes.CreateAsync(new Index
+            {
+                Name = indexName,
+                Fields = FieldBuilder.BuildForType<T>(),
+            });
+            _logger.LogInformation("Done creating index {IndexName}.", indexName);
+        }
+
+        private async Task ProduceWorkAsync(
+            ConcurrentBag<NewPackageRegistration> allWork,
+            CancellationTokenSource produceWorkCts,
+            CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+            await _producer.ProduceWorkAsync(allWork, cancellationToken);
+            produceWorkCts.Cancel();
+        }
+
+        private async Task ConsumeWorkAsync(
+            ConcurrentBag<NewPackageRegistration> allWork,
+            CancellationToken produceWorkToken,
+            CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+
+            var searchActions = new Queue<IndexAction<KeyedDocument>>();
+            var hijackActions = new Queue<IndexAction<KeyedDocument>>();
+
+            NewPackageRegistration work = null;
+            try
+            {
+                while ((allWork.TryTake(out work) || !produceWorkToken.IsCancellationRequested)
+                    && !cancellationToken.IsCancellationRequested)
+                {
+                    // If there's no work to do, wait a bit before checking again.
+                    if (work == null)
+                    {
+                        await Task.Delay(TimeSpan.FromMilliseconds(100));
+                        continue;
+                    }
+
+                    var indexActions = _indexActionBuilder.AddNewPackageRegistration(work);
+
+                    foreach (var action in indexActions.Search)
+                    {
+                        searchActions.Enqueue(action);
+                    }
+
+                    foreach (var action in indexActions.Hijack)
+                    {
+                        hijackActions.Enqueue(action);
+                    }
+
+                    var searchBatchesTask = PushFullBatchesAsync(_searchIndexClient, searchActions);
+                    var hijackBatchesTask = PushFullBatchesAsync(_hijackIndexClient, hijackActions);
+                    await Task.WhenAll(searchBatchesTask, hijackBatchesTask);
+                }
+
+                var searchFinishTask = IndexAsync(_searchIndexClient, searchActions);
+                var hijackFinishTask = IndexAsync(_hijackIndexClient, hijackActions);
+                await Task.WhenAll(searchFinishTask, hijackFinishTask);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    0,
+                    ex,
+                    "An exception was thrown while processing package ID {PackageId}.",
+                    work?.PackageId ?? "(last batch...)");
+                throw;
+            }
+        }
+
+        private async Task PushFullBatchesAsync(
+            ISearchIndexClientWrapper indexClient,
+            Queue<IndexAction<KeyedDocument>> actions)
+        {
+            while (actions.Count > _options.Value.AzureSearchBatchSize)
+            {
+                var batch = new List<IndexAction<KeyedDocument>>();
+                while (batch.Count < _options.Value.AzureSearchBatchSize)
+                {
+                    batch.Add(actions.Dequeue());
+                }
+
+                await IndexAsync(indexClient, batch);
+            }
+        }
+
+        private async Task IndexAsync(
+            ISearchIndexClientWrapper indexClient,
+            IReadOnlyCollection<IndexAction<KeyedDocument>> batch)
+        {
+            if (batch.Count == 0)
+            {
+                return;
+            }
+
+            await Task.Yield();
+
+            _logger.LogInformation(
+                "Pushing batch of {BatchSize} to index {IndexName}.",
+                batch.Count,
+                indexClient.IndexName);
+            var batchResults = await indexClient.Documents.IndexAsync(new IndexBatch<KeyedDocument>(batch));
+            const int errorsToLog = 5;
+            var errorCount = 0;
+            foreach (var result in batchResults.Results)
+            {
+                if (!result.Succeeded)
+                {
+                    if (errorCount < errorsToLog)
+                    {
+                        _logger.LogError(
+                            "Indexing document with key {Key} failed. {StatusCode}: {ErrorMessage}",
+                            result.Key,
+                            result.StatusCode,
+                            result.ErrorMessage);
+                    }
+
+                    errorCount++;
+                }
+            }
+
+            if (errorCount > 0)
+            {
+                throw new InvalidOperationException($"{errorCount} errors were found when indexing a batch. Only {errorsToLog} were logged.");
+            }
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/IDb2AzureSearchCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/IDb2AzureSearchCommand.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace NuGet.Services.AzureSearch.Db2AzureSearch
+{
+    public interface IDb2AzureSearchCommand
+    {
+        Task ExecuteAsync();
+    }
+}

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -35,9 +35,11 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Db2AzureSearch\Db2AzureSearchCommand.cs" />
     <Compile Include="Db2AzureSearch\Db2AzureSearchConfiguration.cs" />
     <Compile Include="Db2AzureSearch\EntitiesContextFactory.cs" />
     <Compile Include="Db2AzureSearch\EnumerableExtensions.cs" />
+    <Compile Include="Db2AzureSearch\IDb2AzureSearchCommand.cs" />
     <Compile Include="Db2AzureSearch\IEntitiesContextFactory.cs" />
     <Compile Include="IIndexActionBuilder.cs" />
     <Compile Include="Db2AzureSearch\INewPackageRegistrationProducer.cs" />

--- a/src/NuGet.Services.AzureSearch/Wrappers/IIndexesOperationsWrapper.cs
+++ b/src/NuGet.Services.AzureSearch/Wrappers/IIndexesOperationsWrapper.cs
@@ -8,6 +8,7 @@ namespace NuGet.Services.AzureSearch.Wrappers
 {
     public interface IIndexesOperationsWrapper
     {
+        ISearchIndexClientWrapper GetClient(string indexName);
         Task<Index> CreateAsync(Index index);
         Task DeleteAsync(string indexName);
         Task<bool> ExistsAsync(string indexName);

--- a/src/NuGet.Services.AzureSearch/Wrappers/IndexesOperationsWrapper.cs
+++ b/src/NuGet.Services.AzureSearch/Wrappers/IndexesOperationsWrapper.cs
@@ -17,6 +17,11 @@ namespace NuGet.Services.AzureSearch.Wrappers
             _inner = inner ?? throw new ArgumentNullException(nameof(inner));
         }
 
+        public ISearchIndexClientWrapper GetClient(string indexName)
+        {
+            return new SearchIndexClientWrapper(_inner.GetClient(indexName));
+        }
+
         public async Task<bool> ExistsAsync(string indexName)
         {
             return await _inner.ExistsAsync(indexName);

--- a/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/Db2AzureSearchCommandFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/Db2AzureSearchCommandFacts.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Search.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using NuGet.Services.AzureSearch.Support;
+using NuGet.Services.AzureSearch.Wrappers;
+using NuGetGallery;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.AzureSearch.Db2AzureSearch
+{
+    public class Db2AzureSearchCommandFacts
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly Mock<INewPackageRegistrationProducer> _producer;
+        private readonly Mock<IIndexActionBuilder> _builder;
+        private readonly Mock<ISearchServiceClientWrapper> _serviceClient;
+        private readonly Mock<IIndexesOperationsWrapper> _serviceClientIndexes;
+        private readonly Mock<ISearchIndexClientWrapper> _searchIndexClient;
+        private readonly Mock<IDocumentsOperationsWrapper> _searchIndexClientDocuments;
+        private readonly Mock<ISearchIndexClientWrapper> _hijackIndexClient;
+        private readonly Mock<IDocumentsOperationsWrapper> _hijackIndexClientDocuments;
+        private readonly Mock<IOptionsSnapshot<Db2AzureSearchConfiguration>> _options;
+        private readonly Db2AzureSearchConfiguration _config;
+        private readonly RecordingLogger<Db2AzureSearchCommand> _logger;
+        private readonly Db2AzureSearchCommand _target;
+
+        public Db2AzureSearchCommandFacts(ITestOutputHelper output)
+        {
+            _output = output;
+            _producer = new Mock<INewPackageRegistrationProducer>();
+            _builder = new Mock<IIndexActionBuilder>();
+            _serviceClient = new Mock<ISearchServiceClientWrapper>();
+            _serviceClientIndexes = new Mock<IIndexesOperationsWrapper>();
+            _searchIndexClient = new Mock<ISearchIndexClientWrapper>();
+            _searchIndexClientDocuments = new Mock<IDocumentsOperationsWrapper>();
+            _hijackIndexClient = new Mock<ISearchIndexClientWrapper>();
+            _hijackIndexClientDocuments = new Mock<IDocumentsOperationsWrapper>();
+            _options = new Mock<IOptionsSnapshot<Db2AzureSearchConfiguration>>();
+            _logger = new RecordingLogger<Db2AzureSearchCommand>(
+                new LoggerFactory().AddXunit(_output).CreateLogger<Db2AzureSearchCommand>());
+
+            _config = new Db2AzureSearchConfiguration
+            {
+                SearchIndexName = "search",
+                HijackIndexName = "hijack",
+                WorkerCount = 1,
+            };
+
+            _options
+                .Setup(x => x.Value)
+                .Returns(() => _config);
+            _serviceClient
+                .Setup(x => x.Indexes)
+                .Returns(() => _serviceClientIndexes.Object);
+            _searchIndexClient
+                .Setup(x => x.Documents)
+                .Returns(() => _searchIndexClientDocuments.Object);
+            _hijackIndexClient
+                .Setup(x => x.Documents)
+                .Returns(() => _hijackIndexClientDocuments.Object);
+            _builder
+                .Setup(x => x.AddNewPackageRegistration(It.IsAny<NewPackageRegistration>()))
+                .Returns(() => new SearchAndHijackIndexActions(
+                    new IndexAction<KeyedDocument>[0],
+                    new IndexAction<KeyedDocument>[0]));
+
+            _target = new Db2AzureSearchCommand(
+                _producer.Object,
+                _builder.Object,
+                _serviceClient.Object,
+                _searchIndexClient.Object,
+                _hijackIndexClient.Object,
+                _options.Object,
+                _logger);
+        }
+
+        [Fact]
+        public async Task ReplacesIndexes()
+        {
+            _config.ReplaceIndexes = true;
+            _serviceClientIndexes
+                .Setup(x => x.ExistsAsync(It.IsAny<string>()))
+                .ReturnsAsync(true);
+
+            await _target.ExecuteAsync();
+
+            _serviceClientIndexes.Verify(
+                x => x.ExistsAsync(_config.SearchIndexName),
+                Times.Once);
+            _serviceClientIndexes.Verify(
+                x => x.ExistsAsync(_config.HijackIndexName),
+                Times.Once);
+            _serviceClientIndexes.Verify(
+                x => x.DeleteAsync(_config.SearchIndexName),
+                Times.Once);
+            _serviceClientIndexes.Verify(
+                x => x.DeleteAsync(_config.HijackIndexName),
+                Times.Once);
+            _serviceClientIndexes.Verify(
+                x => x.CreateAsync(It.Is<Index>(i => i.Name == _config.SearchIndexName)),
+                Times.Once);
+            _serviceClientIndexes.Verify(
+                x => x.CreateAsync(It.Is<Index>(i => i.Name == _config.HijackIndexName)),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task PushesToIndexesUsingMaximumBatchSize()
+        {
+            _config.AzureSearchBatchSize = 2;
+            _producer
+                .Setup(x => x.ProduceWorkAsync(It.IsAny<ConcurrentBag<NewPackageRegistration>>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask)
+                .Callback<ConcurrentBag<NewPackageRegistration>, CancellationToken>((w, _) =>
+                {
+                    w.Add(new NewPackageRegistration("A", 0, new string[0], new Package[0]));
+                    w.Add(new NewPackageRegistration("B", 0, new string[0], new Package[0]));
+                    w.Add(new NewPackageRegistration("C", 0, new string[0], new Package[0]));
+                    w.Add(new NewPackageRegistration("D", 0, new string[0], new Package[0]));
+                    w.Add(new NewPackageRegistration("E", 0, new string[0], new Package[0]));
+                });
+            _builder
+                .Setup(x => x.AddNewPackageRegistration(It.IsAny<NewPackageRegistration>()))
+                .Returns<NewPackageRegistration>(x => new SearchAndHijackIndexActions(
+                    new List<IndexAction<KeyedDocument>> { IndexAction.Upload(new KeyedDocument { Key = x.PackageId }) },
+                    new List<IndexAction<KeyedDocument>>()));
+
+            var batches = new List<List<IndexAction<KeyedDocument>>>();
+            _searchIndexClientDocuments
+                .Setup(x => x.IndexAsync(It.IsAny<IndexBatch<KeyedDocument>>()))
+                .ReturnsAsync(() => new DocumentIndexResult(new List<IndexingResult>()))
+                .Callback<IndexBatch<KeyedDocument>>(b =>
+                {
+                    batches.Add(b.Actions.ToList());
+                });
+
+            await _target.ExecuteAsync();
+
+            Assert.Equal(3, batches.Count);
+
+            var orderedBatches = batches.OrderBy(x => x.Count).ToList();
+            Assert.Single(orderedBatches[0]);
+            Assert.Equal(2, orderedBatches[1].Count);
+            Assert.Equal(2, orderedBatches[2].Count);
+
+            var keys = batches
+                .SelectMany(x => x)
+                .Select(x => x.Document.Key)
+                .OrderBy(x => x)
+                .ToArray();
+            Assert.Equal(
+                new[] { "A", "B", "C", "D", "E" },
+                keys);
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -37,6 +37,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Db2AzureSearch\Db2AzureSearchCommandFacts.cs" />
     <Compile Include="Db2AzureSearch\EnumerableExtensionsFacts.cs" />
     <Compile Include="Db2AzureSearch\NewPackageRegistrationProducerFacts.cs" />
     <Compile Include="IndexActionBuilderFacts.cs" />


### PR DESCRIPTION
Complete https://github.com/NuGet/NuGetGallery/issues/6440.

This can build a search and hijack index for DEV environment in about 6 minutes on my box. I'm running it right now so I can give you exact package counts, document counts, and index sizes.

This uses an in-memory pub-sub model so that we can start pushing packages to Azure Search before we have fully enumerated the database.