### PR TITLE
Extract batch pushing to its own class to share with catalog2azuresearch

### DIFF
--- a/src/NuGet.Jobs.Db2AzureSearch/Job.cs
+++ b/src/NuGet.Jobs.Db2AzureSearch/Job.cs
@@ -57,15 +57,12 @@ namespace NuGet.Jobs
                 .Keyed<ISearchIndexClientWrapper>(HijackIndexKey);
 
             containerBuilder
-                .Register(c => new Db2AzureSearchCommand(
-                    c.Resolve<INewPackageRegistrationProducer>(),
-                    c.Resolve<IIndexActionBuilder>(),
-                    c.Resolve<ISearchServiceClientWrapper>(),
+                .Register<IBatchPusher>(c => new BatchPusher(
                     c.ResolveKeyed<ISearchIndexClientWrapper>(SearchIndexKey),
                     c.ResolveKeyed<ISearchIndexClientWrapper>(HijackIndexKey),
                     c.Resolve<IVersionListDataClient>(),
                     c.Resolve<IOptionsSnapshot<Db2AzureSearchConfiguration>>(),
-                    c.Resolve<ILogger<Db2AzureSearchCommand>>()));
+                    c.Resolve<ILogger<BatchPusher>>()));
         }
 
         protected override void ConfigureJobServices(IServiceCollection services, IConfigurationRoot configurationRoot)

--- a/src/NuGet.Services.AzureSearch/BatchPusher.cs
+++ b/src/NuGet.Services.AzureSearch/BatchPusher.cs
@@ -1,0 +1,257 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.Search.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NuGet.Services.AzureSearch.Wrappers;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class BatchPusher : IBatchPusher
+    {
+        private readonly ISearchIndexClientWrapper _searchIndexClient;
+        private readonly ISearchIndexClientWrapper _hijackIndexClient;
+        private readonly IVersionListDataClient _versionListDataClient;
+        private readonly IOptionsSnapshot<AzureSearchConfiguration> _options;
+        private readonly ILogger<BatchPusher> _logger;
+        internal readonly Dictionary<string, int> _idReferenceCount;
+        internal readonly Queue<IdAndValue<IndexAction<KeyedDocument>>> _searchActions;
+        internal readonly Queue<IdAndValue<IndexAction<KeyedDocument>>> _hijackActions;
+        internal readonly Dictionary<string, ResultAndAccessCondition<VersionListData>> _versionListDataResults;
+
+        public BatchPusher(
+            ISearchIndexClientWrapper searchIndexClient,
+            ISearchIndexClientWrapper hijackIndexClient,
+            IVersionListDataClient versionListDataClient,
+            IOptionsSnapshot<AzureSearchConfiguration> options,
+            ILogger<BatchPusher> logger)
+        {
+            _searchIndexClient = searchIndexClient ?? throw new ArgumentNullException(nameof(searchIndexClient));
+            _hijackIndexClient = hijackIndexClient ?? throw new ArgumentNullException(nameof(hijackIndexClient));
+            _versionListDataClient = versionListDataClient ?? throw new ArgumentNullException(nameof(versionListDataClient));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _idReferenceCount = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            _searchActions = new Queue<IdAndValue<IndexAction<KeyedDocument>>>();
+            _hijackActions = new Queue<IdAndValue<IndexAction<KeyedDocument>>>();
+            _versionListDataResults = new Dictionary<string, ResultAndAccessCondition<VersionListData>>();
+        }
+
+        public void EnqueueIndexActions(string packageId, IndexActions indexActions)
+        {
+            if (_versionListDataResults.ContainsKey(packageId))
+            {
+                throw new ArgumentException("This package ID has already been enqueued.", nameof(packageId));
+            }
+
+            if (!indexActions.Hijack.Any() && !indexActions.Search.Any())
+            {
+                throw new ArgumentException("There must be at least one index action.", nameof(indexActions));
+            }
+
+            foreach (var action in indexActions.Hijack)
+            {
+                EnqueueAndIncrement(_hijackActions, packageId, action);
+            }
+
+            foreach (var action in indexActions.Search)
+            {
+                EnqueueAndIncrement(_searchActions, packageId, action);
+            }
+
+            _versionListDataResults.Add(packageId, indexActions.VersionListDataResult);
+        }
+
+        public async Task PushFullBatchesAsync()
+        {
+            await PushBatchesAsync(onlyFull: true);
+        }
+
+        public async Task FinishAsync()
+        {
+            await PushBatchesAsync(onlyFull: false);
+        }
+
+        private async Task PushBatchesAsync(bool onlyFull)
+        {
+            await PushBatchesAsync(_hijackIndexClient, _hijackActions, onlyFull);
+            await PushBatchesAsync(_searchIndexClient, _searchActions, onlyFull);
+        }
+
+        private async Task PushBatchesAsync(
+            ISearchIndexClientWrapper indexClient,
+            Queue<IdAndValue<IndexAction<KeyedDocument>>> actions,
+            bool onlyFull)
+        {
+            while ((onlyFull && actions.Count >= _options.Value.AzureSearchBatchSize)
+                || (!onlyFull && actions.Count > 0))
+            {
+                var allFinished = new List<IdAndValue<ResultAndAccessCondition<VersionListData>>>();
+                var batch = new List<IndexAction<KeyedDocument>>();
+
+                while (batch.Count < _options.Value.AzureSearchBatchSize && actions.Count > 0)
+                {
+                    var idAndValue = DequeueAndDecrement(actions, out int newCount);
+                    batch.Add(idAndValue.Value);
+
+                    if (newCount == 0)
+                    {
+                        allFinished.Add(NewIdAndValue(idAndValue.Id, _versionListDataResults[idAndValue.Id]));
+                        Guard.Assert(_versionListDataResults.Remove(idAndValue.Id), "The version list data result should have existed.");
+                    }
+                }
+
+                await IndexAsync(indexClient, batch);
+
+                if (allFinished.Any())
+                {
+                    var versionListIdSample = allFinished
+                       .OrderByDescending(x => x.Value.Result.VersionProperties.Count(v => v.Value.Listed))
+                       .Select(x => x.Id)
+                       .Take(5)
+                       .ToArray();
+                    _logger.LogInformation(
+                        "Updating {VersionListCount} version lists, including {IdSample}.",
+                        allFinished.Count,
+                        versionListIdSample);
+                    var stopwatch = Stopwatch.StartNew();
+
+                    foreach (var finished in allFinished)
+                    {
+                        _logger.LogDebug("Updating version list for package ID {PackageId}.", finished.Id);
+                        await _versionListDataClient.ReplaceAsync(
+                            finished.Id,
+                            finished.Value.Result,
+                            finished.Value.AccessCondition);
+                    }
+
+                    stopwatch.Stop();
+                    _logger.LogInformation(
+                        "Done updating {VersionListCount} version lists (took {Duration}).",
+                        allFinished.Count,
+                        stopwatch.Elapsed);
+                }
+            }
+
+            Guard.Assert(
+                !_versionListDataResults
+                    .Keys
+                    .Except(_idReferenceCount.Keys)
+                    .Any(),
+                "There are some version list data results without reference counts.");
+            Guard.Assert(
+                !_idReferenceCount
+                    .Keys
+                    .Except(_versionListDataResults.Keys)
+                    .Any(),
+                "There are some reference counts without version list data results.");
+        }
+
+        private async Task IndexAsync(
+            ISearchIndexClientWrapper indexClient,
+            IReadOnlyCollection<IndexAction<KeyedDocument>> batch)
+        {
+            if (batch.Count == 0)
+            {
+                return;
+            }
+
+            if (batch.Count > _options.Value.AzureSearchBatchSize)
+            {
+                throw new ArgumentException("The provided batch is too large.");
+            }
+
+            _logger.LogInformation(
+                "Pushing batch of {BatchSize} to index {IndexName}.",
+                batch.Count,
+                indexClient.IndexName);
+            var batchResults = await indexClient.Documents.IndexAsync(new IndexBatch<KeyedDocument>(batch));
+            const int errorsToLog = 5;
+            var errorCount = 0;
+            foreach (var result in batchResults.Results)
+            {
+                if (!result.Succeeded)
+                {
+                    if (errorCount < errorsToLog)
+                    {
+                        _logger.LogError(
+                            "Indexing document with key {Key} failed. {StatusCode}: {ErrorMessage}",
+                            result.Key,
+                            result.StatusCode,
+                            result.ErrorMessage);
+                    }
+
+                    errorCount++;
+                }
+            }
+
+            if (errorCount > 0)
+            {
+                _logger.LogError(
+                    "{ErrorCount} errors were found when indexing a batch. {LoggedErrors} were logged.",
+                    errorCount,
+                    Math.Min(errorCount, errorsToLog));
+                throw new InvalidOperationException($"Errors were found when indexing a batch. Up to {errorsToLog} errors get logged.");
+            }
+        }
+
+        private void EnqueueAndIncrement<T>(Queue<IdAndValue<T>> queue, string id, T value)
+        {
+            if (_idReferenceCount.TryGetValue(id, out var count))
+            {
+                Guard.Assert(count >= 1, "The existing reference count should always be greater than zero.");
+                _idReferenceCount[id] = count + 1;
+            }
+            else
+            {
+                _idReferenceCount[id] = 1;
+            }
+
+            queue.Enqueue(NewIdAndValue(id, value));
+        }
+
+        private IdAndValue<T> DequeueAndDecrement<T>(Queue<IdAndValue<T>> queue, out int newCount)
+        {
+            var idAndValue = queue.Dequeue();
+
+            var oldCount = _idReferenceCount[idAndValue.Id];
+            newCount = oldCount - 1;
+            Guard.Assert(newCount >= 0, "The reference count should never be negative.");
+
+            if (newCount == 0)
+            {
+                _idReferenceCount.Remove(idAndValue.Id);
+            }
+            else
+            {
+                _idReferenceCount[idAndValue.Id] = newCount;
+            }
+
+            return idAndValue;
+        }
+
+        private IdAndValue<T> NewIdAndValue<T>(string id, T value)
+        {
+            return new IdAndValue<T>(id, value);
+        }
+
+        internal class IdAndValue<T>
+        {
+            public IdAndValue(string id, T value)
+            {
+                Id = id ?? throw new ArgumentNullException(nameof(id));
+                Value = value;
+            }
+
+            public string Id { get; }
+            public T Value { get; }
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/IBatchPusher.cs
+++ b/src/NuGet.Services.AzureSearch/IBatchPusher.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace NuGet.Services.AzureSearch
+{
+    /// <summary>
+    /// This is a stateful interface that handles pushing index actions to Azure Search and updating the version list
+    /// resource based on the enqueued <see cref="IndexActions"/> in a batch-wise fashion. This interface is not
+    /// designed to be thread-safe.
+    /// </summary>
+    public interface IBatchPusher
+    {
+        /// <summary>
+        /// This method does not work with Azure Search or the version lists. It simply enqueues the actions in memory
+        /// and associates the work with the provided package ID.
+        /// </summary>
+        /// <param name="packageId">The package ID related to the index actions.</param>
+        /// <param name="indexActions">The index actions and version list.</param>
+        void EnqueueIndexActions(string packageId, IndexActions indexActions);
+
+        /// <summary>
+        /// Pushes full batches to Azure Search based on the based provided to
+        /// <see cref="EnqueueIndexActions(string, IndexActions)"/>. If there is not enough data to create a full batch,
+        /// it is not pushed by this method (until enough additional data is enqueued to make a full batch). When all of
+        /// the index actions for a specific package ID completed (pushed to Azure Search), the corresponding version
+        /// list is also updated. Hijack index changes are applied before search index changes.
+        /// </summary>
+        Task PushFullBatchesAsync();
+
+        /// <summary>
+        /// Same as <see cref="PushFullBatchesAsync"/> but if there is a partial batch remaining, it is also pushed.
+        /// </summary>
+        Task FinishAsync();
+    }
+}

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -36,6 +36,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AzureSearchConfiguration.cs" />
+    <Compile Include="BatchPusher.cs" />
+    <Compile Include="IBatchPusher.cs" />
     <Compile Include="Db2AzureSearch\Db2AzureSearchCommand.cs" />
     <Compile Include="Db2AzureSearch\Db2AzureSearchConfiguration.cs" />
     <Compile Include="Db2AzureSearch\EntitiesContextFactory.cs" />

--- a/tests/NuGet.Services.AzureSearch.Tests/BatchPusherFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/BatchPusherFacts.cs
@@ -1,0 +1,511 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.Search.Models;
+using Microsoft.Extensions.Options;
+using Moq;
+using NuGet.Services.AzureSearch.Support;
+using NuGet.Services.AzureSearch.Wrappers;
+using NuGetGallery;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class BatchPusherFacts
+    {
+        public class FinishAsync : BaseFacts
+        {
+            public FinishAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task UpdatesOnlyAllVersionLists()
+            {
+                _config.AzureSearchBatchSize = 7;
+                _target.EnqueueIndexActions(IdA, _indexActions);
+                _target.EnqueueIndexActions(IdB, _indexActions);
+                _target.EnqueueIndexActions(IdC, _indexActions);
+
+                await _target.FinishAsync();
+
+                Assert.Equal(3, _hijackBatches.Count);
+                Assert.Equal(2, _searchBatches.Count);
+
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        IdA,
+                        It.IsAny<VersionListData>(),
+                        It.IsAny<IAccessCondition>()),
+                    Times.Once);
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        IdB,
+                        It.IsAny<VersionListData>(),
+                        It.IsAny<IAccessCondition>()),
+                    Times.Once);
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        IdC,
+                        It.IsAny<VersionListData>(),
+                        It.IsAny<IAccessCondition>()),
+                    Times.Once);
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<VersionListData>(),
+                        It.IsAny<IAccessCondition>()),
+                    Times.Exactly(3));
+            }
+
+            [Fact]
+            public async Task UpdatesVersionListIfAllActionsAreDone()
+            {
+                _config.AzureSearchBatchSize = 1;
+                _target.EnqueueIndexActions(IdA, _indexActions);
+
+                await _target.FinishAsync();
+
+                Assert.Equal(5, _hijackBatches.Count);
+                Assert.Equal(3, _searchBatches.Count);
+
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<VersionListData>(),
+                        It.IsAny<IAccessCondition>()),
+                    Times.Once);
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        IdA,
+                        _indexActions.VersionListDataResult.Result,
+                        _indexActions.VersionListDataResult.AccessCondition),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task PushesPartialBatch()
+            {
+                _config.AzureSearchBatchSize = 1000;
+                _target.EnqueueIndexActions(IdA, _indexActions);
+
+                await _target.FinishAsync();
+
+                Assert.Single(_hijackBatches);
+                Assert.Equal(_hijackDocuments, _hijackBatches[0].Actions.ToArray());
+                Assert.Single(_searchBatches);
+                Assert.Equal(_searchDocuments, _searchBatches[0].Actions.ToArray());
+
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<VersionListData>(),
+                        It.IsAny<IAccessCondition>()),
+                    Times.Once);
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        IdA,
+                        _indexActions.VersionListDataResult.Result,
+                        _indexActions.VersionListDataResult.AccessCondition),
+                    Times.Once);
+
+                Assert.Empty(_target._versionListDataResults);
+                Assert.Empty(_target._hijackActions);
+                Assert.Empty(_target._searchActions);
+                Assert.Empty(_target._idReferenceCount);
+            }
+
+            [Fact]
+            public async Task PushesFullBatchesThenPartialBatch()
+            {
+                _config.AzureSearchBatchSize = 2;
+                _target.EnqueueIndexActions(IdA, _indexActions);
+
+                await _target.FinishAsync();
+
+                Assert.Equal(3, _hijackBatches.Count);
+                Assert.Equal(new[] { _hijackDocumentA, _hijackDocumentB }, _hijackBatches[0].Actions.ToArray());
+                Assert.Equal(new[] { _hijackDocumentC, _hijackDocumentD }, _hijackBatches[1].Actions.ToArray());
+                Assert.Equal(new[] { _hijackDocumentE }, _hijackBatches[2].Actions.ToArray());
+                Assert.Equal(2, _searchBatches.Count);
+                Assert.Equal(new[] { _searchDocumentA, _searchDocumentB }, _searchBatches[0].Actions.ToArray());
+                Assert.Equal(new[] { _searchDocumentC }, _searchBatches[1].Actions.ToArray());
+
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<VersionListData>(),
+                        It.IsAny<IAccessCondition>()),
+                    Times.Once);
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        IdA,
+                        _indexActions.VersionListDataResult.Result,
+                        _indexActions.VersionListDataResult.AccessCondition),
+                    Times.Once);
+
+                Assert.Empty(_target._versionListDataResults);
+                Assert.Empty(_target._hijackActions);
+                Assert.Empty(_target._searchActions);
+                Assert.Empty(_target._idReferenceCount);
+            }
+        }
+
+        public class PushFullBatchesAsync : BaseFacts
+        {
+            public PushFullBatchesAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task LogsUpALimitedNumberOfFailedResults()
+            {
+                _config.MaxConcurrentBatches = 1;
+                _target.EnqueueIndexActions(IdA, _indexActions);
+                _searchDocumentsWrapper
+                    .Setup(x => x.IndexAsync(It.IsAny<IndexBatch<KeyedDocument>>()))
+                    .ReturnsAsync(() => new DocumentIndexResult(new List<IndexingResult>
+                    {
+                        new IndexingResult(key: "A-0", errorMessage: "A-0 message", succeeded: false, statusCode: 0),
+                        new IndexingResult(key: "A-1", errorMessage: "A-1 message", succeeded: false, statusCode: 1),
+                        new IndexingResult(key: "A-2", errorMessage: "A-2 message", succeeded: true, statusCode: 2),
+                        new IndexingResult(key: "A-3", errorMessage: "A-3 message", succeeded: false, statusCode: 3),
+                        new IndexingResult(key: "A-4", errorMessage: "A-4 message", succeeded: false, statusCode: 4),
+                        new IndexingResult(key: "A-5", errorMessage: "A-5 message", succeeded: false, statusCode: 5),
+                        new IndexingResult(key: "A-6", errorMessage: "A-6 message", succeeded: false, statusCode: 6),
+                    }));
+
+
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => _target.PushFullBatchesAsync());
+
+                Assert.Contains("Errors were found when indexing a batch. Up to 5 errors get logged.", ex.Message);
+                Assert.Contains("Indexing document with key A-0 failed. 0: A-0 message", _logger.Messages);
+                Assert.Contains("Indexing document with key A-1 failed. 1: A-1 message", _logger.Messages);
+                Assert.Contains("Indexing document with key A-3 failed. 3: A-3 message", _logger.Messages);
+                Assert.Contains("Indexing document with key A-4 failed. 4: A-4 message", _logger.Messages);
+                Assert.Contains("Indexing document with key A-5 failed. 5: A-5 message", _logger.Messages);
+
+                Assert.All(_logger.Messages, x => Assert.DoesNotContain("A-2", x));
+                Assert.All(_logger.Messages, x => Assert.DoesNotContain("A-6", x));
+            }
+
+            [Fact]
+            public async Task UpdatesOnlyFinishedVersionLists()
+            {
+                _config.AzureSearchBatchSize = 7;
+                _target.EnqueueIndexActions(IdA, _indexActions);
+                _target.EnqueueIndexActions(IdB, _indexActions);
+                _target.EnqueueIndexActions(IdC, _indexActions);
+
+                await _target.PushFullBatchesAsync();
+
+                Assert.Equal(2, _hijackBatches.Count);
+                Assert.Single(_searchBatches);
+
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        IdA,
+                        It.IsAny<VersionListData>(),
+                        It.IsAny<IAccessCondition>()),
+                    Times.Once);
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        IdB,
+                        It.IsAny<VersionListData>(),
+                        It.IsAny<IAccessCondition>()),
+                    Times.Once);
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        IdC,
+                        It.IsAny<VersionListData>(),
+                        It.IsAny<IAccessCondition>()),
+                    Times.Never);
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<VersionListData>(),
+                        It.IsAny<IAccessCondition>()),
+                    Times.Exactly(2));
+            }
+
+            [Fact]
+            public async Task OnlyPushesFullBatches()
+            {
+                _config.AzureSearchBatchSize = 2;
+                _target.EnqueueIndexActions(IdA, _indexActions);
+
+                await _target.PushFullBatchesAsync();
+
+                Assert.Equal(2, _hijackBatches.Count);
+                Assert.Equal(new[] { _hijackDocumentA, _hijackDocumentB }, _hijackBatches[0].Actions.ToArray());
+                Assert.Equal(new[] { _hijackDocumentC, _hijackDocumentD }, _hijackBatches[1].Actions.ToArray());
+                Assert.Single(_searchBatches);
+                Assert.Equal(new[] { _searchDocumentA, _searchDocumentB }, _searchBatches[0].Actions.ToArray());
+
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<VersionListData>(),
+                        It.IsAny<IAccessCondition>()),
+                    Times.Never);
+
+                Assert.Single(_target._versionListDataResults);
+                Assert.Equal(new[] { _hijackDocumentE }, _target._hijackActions.Select(x => x.Value).ToArray());
+                Assert.Equal(new[] { _searchDocumentC }, _target._searchActions.Select(x => x.Value).ToArray());
+                Assert.Equal(2, _target._idReferenceCount[IdA]);
+            }
+
+            [Fact]
+            public async Task AllowsPushingNoBatchesIfNoBatchesAreFull()
+            {
+                _config.AzureSearchBatchSize = 1000;
+                _target.EnqueueIndexActions(IdA, _indexActions);
+
+                await _target.PushFullBatchesAsync();
+
+                Assert.Empty(_hijackBatches);
+                Assert.Empty(_searchBatches);
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<VersionListData>(),
+                        It.IsAny<IAccessCondition>()),
+                    Times.Never);
+            }
+
+            [Fact]
+            public async Task DoesNotUpdateVersionListIfOnlyOneIndexsActionsAreComplete()
+            {
+                _config.AzureSearchBatchSize = 3;
+                _target.EnqueueIndexActions(IdA, _indexActions);
+
+                await _target.PushFullBatchesAsync();
+
+                Assert.Single(_hijackBatches);
+                Assert.Equal(new[] { _hijackDocumentA, _hijackDocumentB, _hijackDocumentC }, _hijackBatches[0].Actions.ToArray());
+                Assert.Single(_searchBatches);
+                Assert.Equal(new[] { _searchDocumentA, _searchDocumentB, _searchDocumentC }, _searchBatches[0].Actions.ToArray());
+
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<VersionListData>(),
+                        It.IsAny<IAccessCondition>()),
+                    Times.Never);
+            }
+
+            [Fact]
+            public async Task UpdatesVersionListIfAllActionsAreDone()
+            {
+                _config.AzureSearchBatchSize = 1;
+                _target.EnqueueIndexActions(IdA, _indexActions);
+
+                await _target.PushFullBatchesAsync();
+
+                Assert.Equal(5, _hijackBatches.Count);
+                Assert.Equal(3, _searchBatches.Count);
+
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<VersionListData>(),
+                        It.IsAny<IAccessCondition>()),
+                    Times.Once);
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        IdA,
+                        _indexActions.VersionListDataResult.Result,
+                        _indexActions.VersionListDataResult.AccessCondition),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task AllowsReprocessingCompletedActions()
+            {
+                _config.AzureSearchBatchSize = 1;
+                _target.EnqueueIndexActions(IdA, _indexActions);
+                await _target.PushFullBatchesAsync();
+                _target.EnqueueIndexActions(IdA, _indexActions);
+
+                await _target.PushFullBatchesAsync();
+
+                Assert.Equal(10, _hijackBatches.Count);
+                Assert.Equal(6, _searchBatches.Count);
+
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<VersionListData>(),
+                        It.IsAny<IAccessCondition>()),
+                    Times.Exactly(2));
+                _versionListDataClient.Verify(
+                    x => x.ReplaceAsync(
+                        IdA,
+                        _indexActions.VersionListDataResult.Result,
+                        _indexActions.VersionListDataResult.AccessCondition),
+                    Times.Exactly(2));
+            }
+        }
+
+        public class EnqueueIndexActions : BaseFacts
+        {
+            public EnqueueIndexActions(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public void RejectsDuplicateId()
+            {
+                _target.EnqueueIndexActions(IdA, _indexActions);
+
+                var ex = Assert.Throws<ArgumentException>(
+                    () => _target.EnqueueIndexActions(IdA, _indexActions));
+                Assert.Contains("This package ID has already been enqueued.", ex.Message);
+            }
+
+            [Fact]
+            public void EnqueuesAndIncrements()
+            {
+                _target.EnqueueIndexActions(IdA, _indexActions);
+
+                Assert.Equal(3, _target._searchActions.Count);
+                Assert.Equal(_searchDocuments, _target._searchActions.Select(x => x.Value).ToList());
+                Assert.All(_target._searchActions, x => Assert.Equal(IdA, x.Id));
+
+                Assert.Equal(5, _target._hijackActions.Count);
+                Assert.Equal(_hijackDocuments, _target._hijackActions.Select(x => x.Value).ToList());
+                Assert.All(_target._hijackActions, x => Assert.Equal(IdA, x.Id));
+
+                Assert.Equal(new[] { IdA }, _target._idReferenceCount.Keys.ToArray());
+                Assert.Equal(8, _target._idReferenceCount[IdA]);
+
+                Assert.Equal(new[] { IdA }, _target._versionListDataResults.Keys.ToArray());
+                Assert.Same(_indexActions.VersionListDataResult, _target._versionListDataResults[IdA]);
+            }
+
+            [Fact]
+            public void RejectsEmptyEnqueue()
+            {
+                var emptyIndexActions = new IndexActions(
+                    new List<IndexAction<KeyedDocument>>(),
+                    new List<IndexAction<KeyedDocument>>(),
+                    new ResultAndAccessCondition<VersionListData>(
+                        new VersionListData(new Dictionary<string, VersionPropertiesData>()),
+                        AccessConditionWrapper.GenerateEmptyCondition()));
+
+                var ex = Assert.Throws<ArgumentException>(
+                    () => _target.EnqueueIndexActions(IdA, emptyIndexActions));
+                Assert.Contains("There must be at least one index action.", ex.Message);
+                Assert.Empty(_target._searchActions);
+                Assert.Empty(_target._hijackActions);
+                Assert.Empty(_target._idReferenceCount);
+                Assert.Empty(_target._versionListDataResults);
+            }
+        }
+
+        public abstract class BaseFacts
+        {
+            protected const string IdA = "NuGet.Versioning";
+            protected const string IdB = "NuGet.Frameworks";
+            protected const string IdC = "NuGet.Packaging";
+
+            protected readonly RecordingLogger<BatchPusher> _logger;
+            protected readonly Mock<ISearchIndexClientWrapper> _searchIndexClientWrapper;
+            protected readonly Mock<IDocumentsOperationsWrapper> _searchDocumentsWrapper;
+            protected readonly Mock<ISearchIndexClientWrapper> _hijackIndexClientWrapper;
+            protected readonly Mock<IDocumentsOperationsWrapper> _hijackDocumentsWrapper;
+            protected readonly Mock<IVersionListDataClient> _versionListDataClient;
+            protected readonly AzureSearchConfiguration _config;
+            protected readonly Mock<IOptionsSnapshot<AzureSearchConfiguration>> _options;
+            protected readonly IndexActions _indexActions;
+            protected readonly BatchPusher _target;
+
+            protected readonly IndexAction<KeyedDocument> _searchDocumentA;
+            protected readonly IndexAction<KeyedDocument> _searchDocumentB;
+            protected readonly IndexAction<KeyedDocument> _searchDocumentC;
+            protected readonly List<IndexAction<KeyedDocument>> _searchDocuments;
+            protected readonly IndexAction<KeyedDocument> _hijackDocumentA;
+            protected readonly IndexAction<KeyedDocument> _hijackDocumentB;
+            protected readonly IndexAction<KeyedDocument> _hijackDocumentC;
+            protected readonly IndexAction<KeyedDocument> _hijackDocumentD;
+            protected readonly IndexAction<KeyedDocument> _hijackDocumentE;
+            protected readonly List<IndexAction<KeyedDocument>> _hijackDocuments;
+            protected readonly List<IndexBatch<KeyedDocument>> _searchBatches;
+            protected readonly List<IndexBatch<KeyedDocument>> _hijackBatches;
+
+            public BaseFacts(ITestOutputHelper output)
+            {
+                _logger = output.GetLogger<BatchPusher>();
+                _searchIndexClientWrapper = new Mock<ISearchIndexClientWrapper>();
+                _searchDocumentsWrapper = new Mock<IDocumentsOperationsWrapper>();
+                _hijackIndexClientWrapper = new Mock<ISearchIndexClientWrapper>();
+                _hijackDocumentsWrapper = new Mock<IDocumentsOperationsWrapper>();
+                _versionListDataClient = new Mock<IVersionListDataClient>();
+                _config = new AzureSearchConfiguration();
+                _options = new Mock<IOptionsSnapshot<AzureSearchConfiguration>>();
+
+                _searchIndexClientWrapper.Setup(x => x.Documents).Returns(() => _searchDocumentsWrapper.Object);
+                _hijackIndexClientWrapper.Setup(x => x.Documents).Returns(() => _hijackDocumentsWrapper.Object);
+                _options.Setup(x => x.Value).Returns(() => _config);
+
+                _searchBatches = new List<IndexBatch<KeyedDocument>>();
+                _hijackBatches = new List<IndexBatch<KeyedDocument>>();
+
+                _searchDocumentsWrapper
+                    .Setup(x => x.IndexAsync(It.IsAny<IndexBatch<KeyedDocument>>()))
+                    .ReturnsAsync(() => new DocumentIndexResult(new List<IndexingResult>()))
+                    .Callback<IndexBatch<KeyedDocument>>(b => _searchBatches.Add(b));
+                _hijackDocumentsWrapper
+                    .Setup(x => x.IndexAsync(It.IsAny<IndexBatch<KeyedDocument>>()))
+                    .ReturnsAsync(() => new DocumentIndexResult(new List<IndexingResult>()))
+                    .Callback<IndexBatch<KeyedDocument>>(b => _hijackBatches.Add(b));
+
+                _config.AzureSearchBatchSize = 2;
+
+                _searchDocumentA = IndexAction.Upload(new KeyedDocument());
+                _searchDocumentB = IndexAction.Upload(new KeyedDocument());
+                _searchDocumentC = IndexAction.Upload(new KeyedDocument());
+                _searchDocuments = new List<IndexAction<KeyedDocument>>
+                {
+                    _searchDocumentA,
+                    _searchDocumentB,
+                    _searchDocumentC,
+                };
+
+                _hijackDocumentA = IndexAction.Upload(new KeyedDocument());
+                _hijackDocumentB = IndexAction.Upload(new KeyedDocument());
+                _hijackDocumentC = IndexAction.Upload(new KeyedDocument());
+                _hijackDocumentD = IndexAction.Upload(new KeyedDocument());
+                _hijackDocumentE = IndexAction.Upload(new KeyedDocument());
+                _hijackDocuments = new List<IndexAction<KeyedDocument>>
+                {
+                    _hijackDocumentA,
+                    _hijackDocumentB,
+                    _hijackDocumentC,
+                    _hijackDocumentD,
+                    _hijackDocumentE,
+                };
+
+                _indexActions = new IndexActions(
+                    _searchDocuments,
+                    _hijackDocuments,
+                    new ResultAndAccessCondition<VersionListData>(
+                        new VersionListData(new Dictionary<string, VersionPropertiesData>()),
+                        AccessConditionWrapper.GenerateEmptyCondition()));
+
+                _target = new BatchPusher(
+                    _searchIndexClientWrapper.Object,
+                    _hijackIndexClientWrapper.Object,
+                    _versionListDataClient.Object,
+                    _options.Object,
+                    _logger);
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -37,6 +37,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BatchPusherFacts.cs" />
     <Compile Include="Db2AzureSearch\Db2AzureSearchCommandFacts.cs" />
     <Compile Include="Db2AzureSearch\EnumerableExtensionsFacts.cs" />
     <Compile Include="Db2AzureSearch\NewPackageRegistrationProducerFacts.cs" />


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/6444
Progress on https://github.com/NuGet/NuGetGallery/issues/6445

This PR introduces `BatchPusher`. This is a **stateful** class that handles pushing changes to the two Azure Search indexes and updating the version list for a package ID that is fully pushed to Azure Search.

This class has three methods:

1. `EnqueueIndexActions` - does no hard work, just puts the search and hijack index actions in their respective queues and keeps track of the version list to push.
1. `PushFullBatchesAsync` - pushes full batches to Azure search (1000 index actions). It updates hijack index first then updates the search index. If a package ID has all of its index changes pushed to Azure Search, then the version list should be updated too.
1. `FinishAsync` - same as `PushFullBatchesAsync` but at the end allows the last partial batch to be pushed.

The trick of the implementation is a reference count pattern on package ID. As index actions are enqueued for the package ID, the reference count goes up. As the index actions are pushed to Azure Search, the reference count goes down. When the reference count reaches zero, the version list for that package ID is updated.

