### PR TITLE
Hotfix: Fix CatalogIndexEntry.IsDelete and improve tests

### DIFF
--- a/src/Catalog/CatalogIndexEntry.cs
+++ b/src/Catalog/CatalogIndexEntry.cs
@@ -31,7 +31,6 @@ namespace NuGet.Services.Metadata.Catalog
             }
 
             Types = new[] { type };
-            IsDelete = type == "nuget:PackageDelete";
 
             if (string.IsNullOrWhiteSpace(commitId))
             {
@@ -76,7 +75,7 @@ namespace NuGet.Services.Metadata.Catalog
         public NuGetVersion Version { get; private set; }
 
         [JsonIgnore]
-        public bool IsDelete { get; }
+        public bool IsDelete => Types.SingleOrDefault() == "nuget:PackageDelete";
 
         public int CompareTo(CatalogIndexEntry other)
         {

--- a/tests/CatalogTests/CatalogIndexEntryTests.cs
+++ b/tests/CatalogTests/CatalogIndexEntryTests.cs
@@ -305,6 +305,24 @@ namespace CatalogTests
             Assert.StartsWith($"Required property '{propertyToRemove}' not found in JSON.", exception.Message);
         }
 
+        [Fact]
+        public void JsonDeserialization_ChoosesLastTypeInList()
+        {
+            var jObject = CreateCatalogIndexJObjectForPackage();
+            
+            jObject.Remove(CatalogConstants.TypeKeyword);
+            jObject.Add(
+                CatalogConstants.TypeKeyword, 
+                new JArray(
+                    "invalidType",
+                    CatalogConstants.NuGetPackageDetails));
+
+            var json = jObject.ToString(Formatting.None, _settings.Converters.ToArray());
+            var entry = JsonConvert.DeserializeObject<CatalogIndexEntry>(json, _settings);
+
+            Assert.Equal(CatalogConstants.NuGetPackageDetails, entry.Types.Single());
+        }
+
         [Theory]
         [InlineData(CatalogConstants.NuGetPackageDetails, false)]
         [InlineData(CatalogConstants.NuGetPackageDelete, true)]


### PR DESCRIPTION
When deserialized through JSON, `CatalogIndexEntry.IsDelete` was not being set properly.

This change properly sets `CatalogIndexEntry.IsDelete` and improves the testing around it.