### PR TITLE
 Enhance NuGet.Protocol.Catalog to support other client implementations

### DIFF
--- a/src/NuGet.Protocol.Catalog/FileCursor.cs
+++ b/src/NuGet.Protocol.Catalog/FileCursor.cs
@@ -15,7 +15,7 @@ namespace NuGet.Protocol.Catalog
     /// </summary>
     public class FileCursor : ICursor
     {
-        private static readonly JsonSerializerSettings Settings = CatalogJsonSerialization.Settings;
+        private static readonly JsonSerializerSettings Settings = NuGetJsonSerialization.Settings;
         private readonly string _path;
         private readonly ILogger<FileCursor> _logger;
 

--- a/src/NuGet.Protocol.Catalog/ISimpleHttpClient.cs
+++ b/src/NuGet.Protocol.Catalog/ISimpleHttpClient.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace NuGet.Protocol.Catalog
+{
+    public interface ISimpleHttpClient
+    {
+        Task<byte[]> GetByteArrayAsync(string requestUri);
+        T DeserializeBytes<T>(byte[] jsonBytes);
+        Task<ResponseAndResult<T>> DeserializeUrlAsync<T>(string documentUrl);
+    }
+}

--- a/src/NuGet.Protocol.Catalog/Models/CatalogLeaf.cs
+++ b/src/NuGet.Protocol.Catalog/Models/CatalogLeaf.cs
@@ -8,9 +8,15 @@ namespace NuGet.Protocol.Catalog
 {
     public class CatalogLeaf : ICatalogLeafItem
     {
+        [JsonProperty("@id")]
+        public string Url { get; set; }
+
         [JsonProperty("@type")]
         [JsonConverter(typeof(CatalogLeafTypeConverter))]
         public CatalogLeafType Type { get; set; }
+
+        [JsonProperty("catalog:commitId")]
+        public string CommitId { get; set; }
 
         [JsonProperty("catalog:commitTimeStamp")]
         public DateTimeOffset CommitTimestamp { get; set; }

--- a/src/NuGet.Protocol.Catalog/Models/PackageDetailsCatalogLeaf.cs
+++ b/src/NuGet.Protocol.Catalog/Models/PackageDetailsCatalogLeaf.cs
@@ -12,6 +12,9 @@ namespace NuGet.Protocol.Catalog
         [JsonProperty("authors")]
         public string Authors { get; set; }
 
+        [JsonProperty("copyright")]
+        public string Copyright { get; set; }
+
         [JsonProperty("created")]
         public DateTimeOffset Created { get; set; }
 

--- a/src/NuGet.Protocol.Catalog/NuGet.Protocol.Catalog.csproj
+++ b/src/NuGet.Protocol.Catalog/NuGet.Protocol.Catalog.csproj
@@ -71,6 +71,7 @@
     <Compile Include="ICatalogClient.cs" />
     <Compile Include="ICatalogLeafProcessor.cs" />
     <Compile Include="ICursor.cs" />
+    <Compile Include="ISimpleHttpClient.cs" />
     <Compile Include="Models\CatalogIndex.cs" />
     <Compile Include="Models\CatalogLeaf.cs" />
     <Compile Include="Models\CatalogLeafItem.cs" />
@@ -85,10 +86,13 @@
     <Compile Include="Models\PackageDetailsCatalogLeaf.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />
+    <Compile Include="ResponseAndResult.cs" />
     <Compile Include="Serialization\BaseCatalogLeafConverter.cs" />
-    <Compile Include="Serialization\CatalogJsonSerialization.cs" />
     <Compile Include="Serialization\CatalogLeafItemTypeConverter.cs" />
     <Compile Include="Serialization\CatalogLeafTypeConverter.cs" />
+    <Compile Include="Serialization\NuGetJsonSerialization.cs" />
+    <Compile Include="SimpleHttpClient.cs" />
+    <Compile Include="SimpleHttpClientException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/src/NuGet.Protocol.Catalog/ResponseAndResult.cs
+++ b/src/NuGet.Protocol.Catalog/ResponseAndResult.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+
+namespace NuGet.Protocol.Catalog
+{
+    public class ResponseAndResult<T>
+    {
+        public ResponseAndResult(
+            HttpMethod method,
+            string requestUri,
+            HttpStatusCode statusCode,
+            string reasonPhrase,
+            bool hasResult,
+            T result)
+        {
+            Method = method ?? throw new ArgumentNullException(nameof(method));
+            RequestUri = requestUri ?? throw new ArgumentNullException(nameof(requestUri));
+            StatusCode = statusCode;
+            ReasonPhrase = reasonPhrase ?? throw new ArgumentNullException(nameof(reasonPhrase));
+            HasResult = hasResult;
+            Result = result;
+        }
+
+        public HttpMethod Method { get; }
+        public string RequestUri { get; }
+        public HttpStatusCode StatusCode { get; }
+        public string ReasonPhrase { get; }
+        public bool HasResult { get; }
+        public T Result { get; }
+
+        public T GetResultOrThrow()
+        {
+            if (!HasResult)
+            {
+                throw new SimpleHttpClientException(
+                    "The HTTP request failed.",
+                    Method,
+                    RequestUri,
+                    StatusCode,
+                    ReasonPhrase);
+            }
+
+            return Result;
+        }
+    }
+}

--- a/src/NuGet.Protocol.Catalog/Serialization/NuGetJsonSerialization.cs
+++ b/src/NuGet.Protocol.Catalog/Serialization/NuGetJsonSerialization.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 
 namespace NuGet.Protocol.Catalog
 {
-    internal static class CatalogJsonSerialization
+    internal static class NuGetJsonSerialization
     {
         public static JsonSerializer Serializer => JsonSerializer.Create(Settings);
 

--- a/src/NuGet.Protocol.Catalog/SimpleHttpClient.cs
+++ b/src/NuGet.Protocol.Catalog/SimpleHttpClient.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace NuGet.Protocol.Catalog
+{
+    public class SimpleHttpClient : ISimpleHttpClient
+    {
+        private static readonly JsonSerializer JsonSerializer = NuGetJsonSerialization.Serializer;
+        private readonly HttpClient _httpClient;
+        private readonly ILogger<SimpleHttpClient> _logger;
+
+        public SimpleHttpClient(HttpClient httpClient, ILogger<SimpleHttpClient> logger)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<byte[]> GetByteArrayAsync(string requestUri)
+        {
+            return await _httpClient.GetByteArrayAsync(requestUri);
+        }
+
+        public T DeserializeBytes<T>(byte[] jsonBytes)
+        {
+            using (var stream = new MemoryStream(jsonBytes))
+            using (var textReader = new StreamReader(stream))
+            using (var jsonReader = new JsonTextReader(textReader))
+            {
+                return JsonSerializer.Deserialize<T>(jsonReader);
+            }
+        }
+
+        public async Task<ResponseAndResult<T>> DeserializeUrlAsync<T>(string documentUrl)
+        {
+            _logger.LogDebug("Downloading {documentUrl} as a stream.", documentUrl);
+
+            using (var response = await _httpClient.GetAsync(
+                documentUrl,
+                HttpCompletionOption.ResponseHeadersRead))
+            {
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    return new ResponseAndResult<T>(
+                        HttpMethod.Get,
+                        documentUrl,
+                        response.StatusCode,
+                        response.ReasonPhrase,
+                        hasResult: false,
+                        result: default(T));
+                }
+
+                using (var stream = await response.Content.ReadAsStreamAsync())
+                using (var textReader = new StreamReader(stream))
+                using (var jsonReader = new JsonTextReader(textReader))
+                {
+                    return new ResponseAndResult<T>(
+                        HttpMethod.Get,
+                        documentUrl,
+                        response.StatusCode,
+                        response.ReasonPhrase,
+                        hasResult: true,
+                        result: JsonSerializer.Deserialize<T>(jsonReader));
+                }
+            }
+        }
+    }
+}

--- a/src/NuGet.Protocol.Catalog/SimpleHttpClientException.cs
+++ b/src/NuGet.Protocol.Catalog/SimpleHttpClientException.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+
+namespace NuGet.Protocol.Catalog
+{
+    public class SimpleHttpClientException : Exception
+    {
+        public SimpleHttpClientException(
+            string message,
+            HttpMethod method,
+            string requestUri,
+            HttpStatusCode statusCode,
+            string reasonPhrase) : base(message)
+        {
+            Method = method ?? throw new ArgumentNullException(nameof(method));
+            RequestUri = requestUri ?? throw new ArgumentNullException(nameof(requestUri));
+            StatusCode = statusCode;
+            ReasonPhrase = reasonPhrase ?? throw new ArgumentNullException(nameof(reasonPhrase));
+        }
+
+        public HttpMethod Method { get; }
+        public string RequestUri { get; }
+        public HttpStatusCode StatusCode { get; }
+        public string ReasonPhrase { get; }
+    }
+}

--- a/tests/NuGet.Protocol.Catalog.Tests/CatalogClientFacts.cs
+++ b/tests/NuGet.Protocol.Catalog.Tests/CatalogClientFacts.cs
@@ -19,7 +19,7 @@ namespace NuGet.Protocol.Catalog
                 // Arrange
                 using (var httpClient = new HttpClient(new TestDataHttpMessageHandler()))
                 {
-                    var client = new CatalogClient(httpClient, new NullLogger<CatalogClient>());
+                    var client = GetCatalogClient(httpClient);
 
                     // Act
                     var actual = await client.GetIndexAsync(TestData.CatalogIndexUrl);
@@ -41,7 +41,7 @@ namespace NuGet.Protocol.Catalog
                 // Arrange
                 using (var httpClient = new HttpClient(new TestDataHttpMessageHandler()))
                 {
-                    var client = new CatalogClient(httpClient, new NullLogger<CatalogClient>());
+                    var client = GetCatalogClient(httpClient);
 
                     // Act
                     var actual = await client.GetPageAsync(TestData.CatalogPageUrl);
@@ -63,7 +63,7 @@ namespace NuGet.Protocol.Catalog
                 // Arrange
                 using (var httpClient = new HttpClient(new TestDataHttpMessageHandler()))
                 {
-                    var client = new CatalogClient(httpClient, new NullLogger<CatalogClient>());
+                    var client = GetCatalogClient(httpClient);
 
                     // Act
                     var actual = await client.GetPackageDeleteLeafAsync(TestData.PackageDeleteCatalogLeafUrl);
@@ -82,7 +82,7 @@ namespace NuGet.Protocol.Catalog
                 // Arrange
                 using (var httpClient = new HttpClient(new TestDataHttpMessageHandler()))
                 {
-                    var client = new CatalogClient(httpClient, new NullLogger<CatalogClient>());
+                    var client = GetCatalogClient(httpClient);
 
                     // Act
                     var actual = await client.GetPackageDetailsLeafAsync(TestData.PackageDetailsCatalogLeafUrl);
@@ -101,7 +101,7 @@ namespace NuGet.Protocol.Catalog
                 // Arrange
                 using (var httpClient = new HttpClient(new TestDataHttpMessageHandler()))
                 {
-                    var client = new CatalogClient(httpClient, new NullLogger<CatalogClient>());
+                    var client = GetCatalogClient(httpClient);
 
                     // Act
                     var actual = await client.GetLeafAsync(TestData.PackageDeleteCatalogLeafUrl);
@@ -117,7 +117,7 @@ namespace NuGet.Protocol.Catalog
                 // Arrange
                 using (var httpClient = new HttpClient(new TestDataHttpMessageHandler()))
                 {
-                    var client = new CatalogClient(httpClient, new NullLogger<CatalogClient>());
+                    var client = GetCatalogClient(httpClient);
 
                     // Act
                     var actual = await client.GetLeafAsync(TestData.PackageDetailsCatalogLeafUrl);
@@ -126,6 +126,11 @@ namespace NuGet.Protocol.Catalog
                     Assert.NotNull(actual);
                 }
             }
+        }
+
+        private static CatalogClient GetCatalogClient(HttpClient httpClient)
+        {
+            return new CatalogClient(new SimpleHttpClient(httpClient, new NullLogger<SimpleHttpClient>()), new NullLogger<CatalogClient>());
         }
     }
 }

--- a/tests/NuGet.Protocol.Catalog.Tests/Models/ModelExtensionsFacts.cs
+++ b/tests/NuGet.Protocol.Catalog.Tests/Models/ModelExtensionsFacts.cs
@@ -1,0 +1,184 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace NuGet.Protocol.Catalog
+{
+    public class ModelExtensionsFacts
+    {
+        public class IsListed
+        {
+            [Theory]
+            [InlineData("1900-01-01Z", false)]
+            [InlineData("1900-01-01Z", true)]
+            [InlineData("2018-01-01Z", false)]
+            [InlineData("2018-01-01Z", true)]
+            public void PrefersListedPropertyOverPublished(string published, bool listed)
+            {
+                var leaf = new PackageDetailsCatalogLeaf
+                {
+                    Listed = listed,
+                    Published = DateTimeOffset.Parse(published),
+                };
+
+                var actual = leaf.IsListed();
+
+                Assert.Equal(listed, actual);
+            }
+
+            [Theory]
+            [InlineData("1899-01-01Z", true)]
+            [InlineData("1900-01-01Z", false)]
+            [InlineData("1900-01-01T00:00:01Z", false)]
+            [InlineData("1900-01-02Z", false)]
+            [InlineData("1900-02-01Z", false)]
+            [InlineData("1901-01-01Z", true)]
+            [InlineData("2018-01-01Z", true)]
+            public void PrefersListedProperty(string published, bool listed)
+            {
+                var leaf = new PackageDetailsCatalogLeaf
+                {
+                    Published = DateTimeOffset.Parse(published),
+                };
+
+                var actual = leaf.IsListed();
+
+                Assert.Equal(listed, actual);
+            }
+        }
+
+        public class IsSemVer2
+        {
+            [Theory]
+            [InlineData("1.0.0+git", true)]
+            [InlineData("1.0.0-alpha.1", true)]
+            [InlineData("1.0.0-alpha.1+git", true)]
+            [InlineData("1.0.0", false)]
+            public void SemVer2PackageVersionMeansSemVer2(string packageVersion, bool isSemVer2)
+            {
+                var leaf = new PackageDetailsCatalogLeaf
+                {
+                    PackageVersion = packageVersion,
+                    VerbatimVersion = "1.0.0",
+                };
+
+                var actual = leaf.IsSemVer2();
+
+                Assert.Equal(isSemVer2, actual);
+            }
+
+            [Fact]
+            public void AllowsNullVerbatimVersion()
+            {
+                var leaf = new PackageDetailsCatalogLeaf
+                {
+                    PackageVersion = "1.0.0",
+                    DependencyGroups = new List<PackageDependencyGroup>
+                    {
+                        new PackageDependencyGroup
+                        {
+                            Dependencies = new List<PackageDependency>
+                            {
+                                new PackageDependency
+                                {
+                                    Range = "[1.0.0, )",
+                                },
+                            },
+                        },
+                    },
+                };
+
+                var actual = leaf.IsSemVer2();
+
+                Assert.False(actual);
+            }
+
+            [Fact]
+            public void AllowsNullDependencyGroups()
+            {
+                var leaf = new PackageDetailsCatalogLeaf
+                {
+                    PackageVersion = "1.0.0",
+                    VerbatimVersion = "1.0.0",
+                };
+
+                var actual = leaf.IsSemVer2();
+
+                Assert.False(actual);
+            }
+
+            [Theory]
+            [InlineData("1.0.0+git", true)]
+            [InlineData("1.0.0-alpha.1", true)]
+            [InlineData("1.0.0-alpha.1+git", true)]
+            [InlineData("1.0.0", false)]
+            public void SemVer2VerbatimVersionMeansSemVer2(string verbatimVersion, bool isSemVer2)
+            {
+                var leaf = new PackageDetailsCatalogLeaf
+                {
+                    PackageVersion = "1.0.0",
+                    VerbatimVersion = verbatimVersion,
+                };
+
+                var actual = leaf.IsSemVer2();
+
+                Assert.Equal(isSemVer2, actual);
+            }
+
+
+            [Theory]
+            [InlineData("1.0.0+git", true)]
+            [InlineData("1.0.0-alpha.1", true)]
+            [InlineData("1.0.0-alpha.1+git", true)]
+            [InlineData("[1.0.0-alpha.1+git, )", true)]
+            [InlineData("(, 1.0.0-alpha.1+git)", true)]
+            [InlineData("(0.0.0+git, 1.0.0-alpha.1+git)", true)]
+            [InlineData("[1.0.0-alpha.1+git]", true)]
+            [InlineData("1.0.0", false)]
+            [InlineData("[1.0.0, )", false)]
+            [InlineData("(, 1.0.0]", false)]
+            public void SemVer2DependencyVersionRangeMeansSemVer2(string range, bool isSemVer2)
+            {
+                var leaf = new PackageDetailsCatalogLeaf
+                {
+                    PackageVersion = "1.0.0",
+                    VerbatimVersion = "1.0.0",
+                    DependencyGroups = new List<PackageDependencyGroup>
+                    {
+                        new PackageDependencyGroup
+                        {
+                            Dependencies = new List<PackageDependency>
+                            {
+                                new PackageDependency
+                                {
+                                    Range = "0.0.0",
+                                },
+                            },
+                        },
+                        new PackageDependencyGroup
+                        {
+                            Dependencies = new List<PackageDependency>
+                            {
+                                new PackageDependency
+                                {
+                                    Range = "0.0.1",
+                                },
+                                new PackageDependency
+                                {
+                                    Range = range,
+                                },
+                            },
+                        },
+                    },
+                };
+
+                var actual = leaf.IsSemVer2();
+
+                Assert.Equal(isSemVer2, actual);
+            }
+        }
+    }
+}

--- a/tests/NuGet.Protocol.Catalog.Tests/NuGet.Protocol.Catalog.Tests.csproj
+++ b/tests/NuGet.Protocol.Catalog.Tests/NuGet.Protocol.Catalog.Tests.csproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <Compile Include="CatalogClientFacts.cs" />
     <Compile Include="CatalogProcessorSettingsFacts.cs" />
+    <Compile Include="Models\ModelExtensionsFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestData.Designer.cs">
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/6444
Progress on https://github.com/NuGet/NuGetGallery/issues/6445

`ISimpleHttpClient` will be used by a future `RegistrationClient` to read registration blobs.

Also, add `IsSemVer2` extension method to package details catalog leaves.