### PR TITLE
Add CatalogLeafFetcher for getting catalog leaves via registration

### DIFF
--- a/src/NuGet.Jobs.Catalog2AzureSearch/NuGet.Jobs.Catalog2AzureSearch.csproj
+++ b/src/NuGet.Jobs.Catalog2AzureSearch/NuGet.Jobs.Catalog2AzureSearch.csproj
@@ -53,6 +53,10 @@
       <Project>{E97F23B8-ECB0-4AFA-B00C-015C39395FEF}</Project>
       <Name>NuGet.Services.Metadata.Catalog</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NuGet.Protocol.Catalog\NuGet.Protocol.Catalog.csproj">
+      <Project>{D44C2E89-2D98-44BD-8712-8CCBE4E67C9C}</Project>
+      <Name>NuGet.Protocol.Catalog</Name>
+    </ProjectReference>
     <ProjectReference Include="..\NuGet.Services.AzureSearch\NuGet.Services.AzureSearch.csproj">
       <Project>{1a53fe3d-8041-4773-942f-d73aef5b82b2}</Project>
       <Name>NuGet.Services.AzureSearch</Name>

--- a/src/NuGet.Jobs.Catalog2AzureSearch/Settings/dev.json
+++ b/src/NuGet.Jobs.Catalog2AzureSearch/Settings/dev.json
@@ -1,7 +1,7 @@
 {
   "Catalog2AzureSearch": {
     "AzureSearchBatchSize": 1000,
-    "WorkerCount": 32,
+    "MaxConcurrentBatches": 32,
     "SearchServiceName": "",
     "SearchServiceApiKey": "",
     "SearchIndexName": "",
@@ -13,7 +13,8 @@
     "HttpClientTimeout": "00:15:00",
     "DependencyCursorUrls": [
       ""
-    ]
+    ],
+    "RegistrationsBaseUrl": ""
   },
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",

--- a/src/NuGet.Jobs.Db2AzureSearch/Settings/dev.json
+++ b/src/NuGet.Jobs.Db2AzureSearch/Settings/dev.json
@@ -5,7 +5,7 @@
 
   "Db2AzureSearch": {
     "AzureSearchBatchSize": 1000,
-    "WorkerCount": 32,
+    "MaxConcurrentBatches": 32,
     "SearchServiceName": "",
     "SearchServiceApiKey": "",
     "SearchIndexName": "",

--- a/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/Catalog2AzureSearchConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/Catalog2AzureSearchConfiguration.cs
@@ -12,5 +12,6 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
         public string Source { get; set; }
         public TimeSpan HttpClientTimeout { get; set; }
         public List<string> DependencyCursorUrls { get; set; }
+        public string RegistrationsBaseUrl { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/CatalogLeafFetcher.cs
+++ b/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/CatalogLeafFetcher.cs
@@ -1,0 +1,255 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NuGet.Protocol.Catalog;
+using NuGet.Protocol.Registration;
+using NuGet.Versioning;
+
+namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
+{
+    public class CatalogLeafFetcher : ICatalogLeafFetcher
+    {
+        private readonly IRegistrationClient _registrationClient;
+        private readonly ICatalogClient _catalogClient;
+        private readonly IOptionsSnapshot<Catalog2AzureSearchConfiguration> _options;
+        private readonly ILogger<CatalogLeafFetcher> _logger;
+
+        public CatalogLeafFetcher(
+            IRegistrationClient registrationClient,
+            ICatalogClient catalogClient,
+            IOptionsSnapshot<Catalog2AzureSearchConfiguration> options,
+            ILogger<CatalogLeafFetcher> logger)
+        {
+            _registrationClient = registrationClient ?? throw new ArgumentNullException(nameof(registrationClient));
+            _catalogClient = catalogClient ?? throw new ArgumentNullException(nameof(catalogClient));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<LatestCatalogLeaves> GetLatestLeavesAsync(
+            string packageId,
+            IReadOnlyList<IReadOnlyList<NuGetVersion>> versions)
+        {
+            if (packageId == null)
+            {
+                throw new ArgumentNullException(nameof(packageId));
+            }
+
+            if (versions == null)
+            {
+                throw new ArgumentNullException(nameof(versions));
+            }
+
+            if (!versions.Any())
+            {
+                throw new ArgumentException("At least one version list must be provided.", nameof(versions));
+            }
+
+            var unavailable = new HashSet<NuGetVersion>();
+            var available = new Dictionary<NuGetVersion, PackageDetailsCatalogLeaf>();
+
+            var registrationIndexUrl = GetRegistrationIndexUrl(packageId);
+            var registrationIndex = await _registrationClient.GetIndexOrNullAsync(registrationIndexUrl);
+            if (registrationIndex == null)
+            {
+                _logger.LogWarning(
+                    "No registation index was found. ID: {PackageId}, registration index URL: {RegistrationIndexUrl}",
+                    packageId,
+                    registrationIndexUrl);
+
+                foreach (var version in versions.SelectMany(x => x))
+                {
+                    unavailable.Add(version);
+                }
+
+                return new LatestCatalogLeaves(unavailable, available);
+            }
+
+            var pageUrlToInfo = registrationIndex
+                .Items
+                .ToDictionary(x => x.Url, x => new RegistrationPageInfo(x));
+
+            // Make a list of ranges for logging purposes.
+            var ranges = pageUrlToInfo
+                .OrderBy(x => x.Value.Range.MinVersion)
+                .Select(x => x.Value.RangeString)
+                .ToList();
+
+            foreach (var versionList in versions)
+            {
+                await AddLatestLeafAsync(
+                    packageId,
+                    versionList,
+                    pageUrlToInfo,
+                    ranges,
+                    unavailable,
+                    available);
+            }
+
+            return new LatestCatalogLeaves(unavailable, available);
+        }
+
+        private async Task AddLatestLeafAsync(
+            string packageId,
+            IReadOnlyList<NuGetVersion> versionList,
+            Dictionary<string, RegistrationPageInfo> pageUrlToInfo,
+            List<string> ranges,
+            HashSet<NuGetVersion> unavailable,
+            Dictionary<NuGetVersion, PackageDetailsCatalogLeaf> available)
+        {
+            var descendingVersions = versionList
+                .OrderByDescending(x => x)
+                .ToList();
+
+            foreach (var version in descendingVersions)
+            {
+                if (unavailable.Contains(version))
+                {
+                    _logger.LogDebug(
+                        "For {PackageId}, version {Version} was already discovered to be unavailable.",
+                        packageId,
+                        version);
+                    continue;
+                }
+
+                if (available.ContainsKey(version))
+                {
+                    _logger.LogDebug(
+                        "For {PackageId}, version {Version} was already discovered to be available.",
+                        packageId,
+                        version);
+                    continue;
+                }
+
+                _logger.LogInformation(
+                    "Looking for the catalog leaf for {PackageId} {Version}.",
+                    packageId,
+                    version);
+
+                var info = GetPageInfo(pageUrlToInfo, version);
+                if (info == null)
+                {
+                    _logger.LogWarning(
+                        "No page was found for {PackageId} {Version}. Page ranges were: {Ranges}",
+                        packageId,
+                        version,
+                        ranges);
+                    unavailable.Add(version);
+                    continue;
+                }
+
+                // When the items are not inlined, we need to make a network request to get the metadata.
+                if (info.VersionToItem == null)
+                {
+                    _logger.LogInformation(
+                        "Fetching the items for page {PageUrl}. Range: {Range}",
+                        info.Page.Url,
+                        info.RangeString);
+
+                    var page = await _registrationClient.GetPageAsync(info.Page.Url);
+                    info.SetVersionToItem(page.Items);
+                }
+
+                if (!info.VersionToItem.TryGetValue(version, out var item))
+                {
+                    _logger.LogWarning(
+                        "No registration leaf item found for {PackageId} {Version} on {PageUrl}",
+                        packageId,
+                        version,
+                        info.Page.Url);
+                    unavailable.Add(version);
+                    continue;
+                }
+
+                _logger.LogInformation(
+                    "Fetching the catalog leaf for {PackageId} {Version} from {LeafUrl}",
+                    packageId,
+                    version,
+                    item.CatalogEntry.Url);
+
+                var leaf = await _catalogClient.GetPackageDetailsLeafAsync(item.CatalogEntry.Url);
+                available[version] = leaf;
+
+                if (leaf.IsListed())
+                {
+                    _logger.LogInformation(
+                        "{PackageId} {Version} was found to be listed. Metadata from {Url} will be used.",
+                        packageId,
+                        version,
+                        leaf.Url);
+                    return;
+                }
+                else
+                {
+                    _logger.LogInformation(
+                        "{PackageId} {Version} was found to be unlisted from {Url}. This will not be used as a latest version.",
+                        packageId,
+                        version,
+                        leaf.Url);
+                }
+            }
+
+            _logger.LogWarning(
+                "No catalog leaves matchings leaves found for {PackageId}. Versions tried: {Versions}",
+                packageId,
+                descendingVersions);
+        }
+
+        private string GetRegistrationIndexUrl(string id)
+        {
+            var baseUrl = _options.Value.RegistrationsBaseUrl.TrimEnd('/');
+            return $"{baseUrl}/{id.ToLowerInvariant()}/index.json";
+        }
+
+        private RegistrationPageInfo GetPageInfo(
+            IReadOnlyDictionary<string, RegistrationPageInfo> pageUrlToInfo,
+            NuGetVersion version)
+        {
+            foreach (var info in pageUrlToInfo.Values)
+            {
+                if (info.Range.Satisfies(version))
+                {
+                    return info;
+                }
+            }
+
+            return null;
+        }
+
+        private class RegistrationPageInfo
+        {
+            public RegistrationPageInfo(RegistrationPage page)
+            {
+                Page = page;
+                Range = new VersionRange(
+                    minVersion: NuGetVersion.Parse(page.Lower),
+                    includeMinVersion: true,
+                    maxVersion: NuGetVersion.Parse(page.Upper),
+                    includeMaxVersion: true);
+                RangeString = Range.ToNormalizedString();
+
+                // When the items are inlined, we don't need to make a network request to get the metadata.
+                if (page.Items != null)
+                {
+                    SetVersionToItem(page.Items);
+                }
+            }
+
+            public void SetVersionToItem(IEnumerable<RegistrationLeafItem> items)
+            {
+                VersionToItem = items.ToDictionary(x => NuGetVersion.Parse(x.CatalogEntry.Version));
+            }
+
+            public RegistrationPage Page { get; }
+            public VersionRange Range { get; }
+            public string RangeString { get; }
+            public Dictionary<NuGetVersion, RegistrationLeafItem> VersionToItem { get; private set; }
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/ICatalogLeafFetcher.cs
+++ b/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/ICatalogLeafFetcher.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NuGet.Versioning;
+
+namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
+{
+    public interface ICatalogLeafFetcher
+    {
+        /// <summary>
+        /// Fetch information about the latest versions available in the catalog, via the package metadata
+        /// (registration) resource. At least one version in each provided version list is returned in the
+        /// <see cref="LatestCatalogLeaves.Available"/> property of the result, assuming there is are
+        /// any available versions. Versions referenced in the input version lists that could have been the new latest
+        /// version but are deleted will appear in <see cref="LatestCatalogLeaves.Unavailable"/>. Versions not
+        /// referenced in the version lists but available in the registration index will be ignored.
+        /// 
+        /// The whole purpose of this class is to handle the <see cref="SearchIndexChangeType.DowngradeLatest"/> case
+        /// where we need to put a lower version's metadata in the search index document but we don't have that metadata
+        /// available. For example, this happens when a single catalog leaf comes in unlisting the currently latest
+        /// version.
+        /// 
+        /// The input is a list of lists because multiple downgrades can happen for a single package ID. For example,
+        /// consider the latest version was 3.0.0 and the other versions are 1.0.0 and 2.0.0-beta. If 3.0.0 is unlisted
+        /// then 1.0.0 is the latest version for <see cref="SearchFilters.Default"/> but 2.0.0-beta is the latest
+        /// version for <see cref="SearchFilters.IncludePrerelease"/>. There can be as many input version lists as there
+        /// are different <see cref="SearchFilters"/> values.
+        /// </summary>
+        /// <param name="packageId">The package ID to fetch catalog leaves for.</param>
+        /// <param name="versions">The list of candidate latest versions.</param>
+        /// <returns>The latest catalog leaves.</returns>
+        Task<LatestCatalogLeaves> GetLatestLeavesAsync(string packageId, IReadOnlyList<IReadOnlyList<NuGetVersion>> versions);
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/LatestCatalogLeaves.cs
+++ b/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/LatestCatalogLeaves.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Protocol.Catalog;
+using NuGet.Versioning;
+
+namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
+{
+    public class LatestCatalogLeaves
+    {
+        public LatestCatalogLeaves(
+            ISet<NuGetVersion> unavailable,
+            IReadOnlyDictionary<NuGetVersion, PackageDetailsCatalogLeaf> available)
+        {
+            Unavailable = unavailable ?? throw new ArgumentNullException(nameof(unavailable));
+            Available = available ?? throw new ArgumentNullException(nameof(available));
+        }
+
+        public ISet<NuGetVersion> Unavailable { get; }
+        public IReadOnlyDictionary<NuGetVersion, PackageDetailsCatalogLeaf> Available { get; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -38,6 +38,9 @@
     <Compile Include="AzureSearchConfiguration.cs" />
     <Compile Include="Catalog2AzureSearch\Catalog2AzureSearchConfiguration.cs" />
     <Compile Include="BatchPusher.cs" />
+    <Compile Include="Catalog2AzureSearch\CatalogLeafFetcher.cs" />
+    <Compile Include="Catalog2AzureSearch\ICatalogLeafFetcher.cs" />
+    <Compile Include="Catalog2AzureSearch\LatestCatalogLeaves.cs" />
     <Compile Include="IBatchPusher.cs" />
     <Compile Include="Db2AzureSearch\Db2AzureSearchCommand.cs" />
     <Compile Include="Db2AzureSearch\Db2AzureSearchConfiguration.cs" />

--- a/src/NuGet.Services.AzureSearch/Registration/Models/RegistrationPage.cs
+++ b/src/NuGet.Services.AzureSearch/Registration/Models/RegistrationPage.cs
@@ -7,7 +7,10 @@ using Newtonsoft.Json;
 namespace NuGet.Protocol.Registration
 {
     /// <summary>
+    /// This model is used for both the registration page item (found in a registration index) and for a registration
+    /// page fetched on its own.
     /// Source: https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#registration-page
+    /// Source: https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#registration-page-object
     /// </summary>
     public class RegistrationPage
     {
@@ -17,6 +20,11 @@ namespace NuGet.Protocol.Registration
         [JsonProperty("count")]
         public int Count { get; set; }
 
+        /// <summary>
+        /// This property can be null when this model is used as an item in <see cref="RegistrationIndex.Items"/> when
+        /// the server decided not to inline the leaf items. In this case, the <see cref="Url"/> property can be used 
+        /// fetch another <see cref="RegistrationPage"/> instance with the <see cref="Items"/> property filled in.
+        /// </summary>
         [JsonProperty("items")]
         public List<RegistrationLeafItem> Items { get; set; }
 

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/CatalogLeafFetcherFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/CatalogLeafFetcherFacts.cs
@@ -1,0 +1,568 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Moq;
+using NuGet.Protocol.Catalog;
+using NuGet.Protocol.Registration;
+using NuGet.Services.AzureSearch.Support;
+using NuGet.Versioning;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
+{
+    public class CatalogLeafFetcherFacts
+    {
+        public class GetLatestLeavesAsync : BaseFacts
+        {
+            public GetLatestLeavesAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task ConsidersAllVersionsUnavailableIfIndexIsMissing()
+            {
+                _registrationClient
+                    .Setup(x => x.GetIndexOrNullAsync(It.IsAny<string>()))
+                    .ReturnsAsync((RegistrationIndex)null);
+
+                var latest = await _target.GetLatestLeavesAsync(PackageId, _versions);
+
+                Assert.Equal(_eachVersion, latest.Unavailable.OrderBy(x => x).ToArray());
+                Assert.Empty(latest.Available);
+                _registrationClient.Verify(
+                    x => x.GetIndexOrNullAsync(It.IsAny<string>()), Times.Once);
+                _registrationClient.Verify(
+                    x => x.GetIndexOrNullAsync("https://example/v3-registration/nuget.versioning/index.json"), Times.Once);
+                _registrationClient.Verify(
+                    x => x.GetPageAsync(It.IsAny<string>()), Times.Never);
+            }
+
+            [Fact]
+            public async Task ConsidersVersionOutsideOfRangeAsMissing()
+            {
+                var index = new RegistrationIndex
+                {
+                    Items = new List<RegistrationPage>
+                    {
+                        new RegistrationPage
+                        {
+                            Lower = "10.0.0",
+                            Upper = "10.0.0",
+                            Url = "http://example/page",
+                            Items = new List<RegistrationLeafItem>
+                            {
+                                new RegistrationLeafItem
+                                {
+                                    CatalogEntry = new RegistrationCatalogEntry
+                                    {
+                                        Version = "10.0.0",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                };
+                _registrationClient
+                    .Setup(x => x.GetIndexOrNullAsync(It.IsAny<string>()))
+                    .ReturnsAsync(index);
+
+                var latest = await _target.GetLatestLeavesAsync(PackageId, _versions);
+
+                Assert.Equal(_eachVersion, latest.Unavailable.OrderBy(x => x).ToArray());
+                Assert.Empty(latest.Available);
+                _registrationClient.Verify(
+                    x => x.GetIndexOrNullAsync(It.IsAny<string>()), Times.Once);
+                _registrationClient.Verify(
+                    x => x.GetIndexOrNullAsync("https://example/v3-registration/nuget.versioning/index.json"), Times.Once);
+                _registrationClient.Verify(
+                    x => x.GetPageAsync(It.IsAny<string>()), Times.Never);
+            }
+
+            [Fact]
+            public async Task ConsidersMissingVersionAsUnavailable()
+            {
+                var index = new RegistrationIndex
+                {
+                    Items = new List<RegistrationPage>
+                    {
+                        new RegistrationPage
+                        {
+                            Lower = "0.0.0",
+                            Upper = "10.0.0",
+                            Url = "http://example/page",
+                            Items = new List<RegistrationLeafItem>
+                            {
+                                new RegistrationLeafItem
+                                {
+                                    CatalogEntry = new RegistrationCatalogEntry
+                                    {
+                                        Version = "10.0.0",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                };
+                _registrationClient
+                    .Setup(x => x.GetIndexOrNullAsync(It.IsAny<string>()))
+                    .ReturnsAsync(index);
+
+                var latest = await _target.GetLatestLeavesAsync(PackageId, _versions);
+
+                Assert.Equal(_eachVersion, latest.Unavailable.OrderBy(x => x).ToArray());
+                Assert.Empty(latest.Available);
+                _registrationClient.Verify(
+                    x => x.GetIndexOrNullAsync(It.IsAny<string>()), Times.Once);
+                _registrationClient.Verify(
+                    x => x.GetIndexOrNullAsync("https://example/v3-registration/nuget.versioning/index.json"), Times.Once);
+                _registrationClient.Verify(
+                    x => x.GetPageAsync(It.IsAny<string>()), Times.Never);
+            }
+
+            [Fact]
+            public async Task ContinuesWhenVersionIsFoundToBeUnlisted()
+            {
+                var versions = new List<IReadOnlyList<NuGetVersion>>
+                {
+                    new List<NuGetVersion>
+                    {
+                        Parse("1.0.0"),
+                        Parse("2.0.0"),
+                        Parse("3.0.0"),
+                    },
+                };
+                var details1 = new PackageDetailsCatalogLeaf { Listed = true };
+                var details2 = new PackageDetailsCatalogLeaf { Listed = true };
+                var details3 = new PackageDetailsCatalogLeaf { Listed = false };
+                var index = new RegistrationIndex
+                {
+                    Items = new List<RegistrationPage>
+                    {
+                        new RegistrationPage
+                        {
+                            Lower = "1.0.0",
+                            Upper = "3.0.0",
+                            Url = "https://example/page",
+                            Items = new List<RegistrationLeafItem>
+                            {
+                                new RegistrationLeafItem
+                                {
+                                    CatalogEntry = new RegistrationCatalogEntry
+                                    {
+                                        Url = "https://example/1.0.0",
+                                        Version = "1.0.0",
+                                    },
+                                },
+                                new RegistrationLeafItem
+                                {
+                                    CatalogEntry = new RegistrationCatalogEntry
+                                    {
+                                        Url = "https://example/2.0.0",
+                                        Version = "2.0.0",
+                                    },
+                                },
+                                new RegistrationLeafItem
+                                {
+                                    CatalogEntry = new RegistrationCatalogEntry
+                                    {
+                                        Url = "https://example/3.0.0",
+                                        Version = "3.0.0",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                };
+                _catalogClient
+                    .Setup(x => x.GetPackageDetailsLeafAsync("https://example/1.0.0"))
+                    .ReturnsAsync(details1);
+                _catalogClient
+                    .Setup(x => x.GetPackageDetailsLeafAsync("https://example/2.0.0"))
+                    .ReturnsAsync(details2);
+                _catalogClient
+                    .Setup(x => x.GetPackageDetailsLeafAsync("https://example/3.0.0"))
+                    .ReturnsAsync(details3);
+                _registrationClient
+                    .Setup(x => x.GetIndexOrNullAsync(It.IsAny<string>()))
+                    .ReturnsAsync(index);
+
+                var latest = await _target.GetLatestLeavesAsync(PackageId, versions);
+
+                Assert.Empty(latest.Unavailable);
+                Assert.Equal(
+                    new[] { Parse("2.0.0"), Parse("3.0.0") },
+                    latest.Available.Keys.OrderBy(x => x).ToArray());
+                Assert.Same(details2, latest.Available[Parse("2.0.0")]);
+                Assert.Same(details3, latest.Available[Parse("3.0.0")]);
+                _registrationClient.Verify(
+                    x => x.GetIndexOrNullAsync(It.IsAny<string>()), Times.Once);
+                _registrationClient.Verify(
+                    x => x.GetIndexOrNullAsync("https://example/v3-registration/nuget.versioning/index.json"), Times.Once);
+                _registrationClient.Verify(
+                    x => x.GetPageAsync(It.IsAny<string>()), Times.Never);
+                _catalogClient.Verify(
+                    x => x.GetPackageDetailsLeafAsync(It.IsAny<string>()),
+                    Times.Exactly(2));
+                _catalogClient.Verify(
+                    x => x.GetPackageDetailsLeafAsync("https://example/1.0.0"),
+                    Times.Never);
+            }
+
+            [Fact]
+            public async Task ReturnsAllProvidedVersionsIfUnlisted()
+            {
+                var versions = new List<IReadOnlyList<NuGetVersion>>
+                {
+                    new List<NuGetVersion>
+                    {
+                        Parse("1.0.0"),
+                        Parse("2.0.0"),
+                        Parse("3.0.0"),
+                    },
+                };
+                var details1 = new PackageDetailsCatalogLeaf { Listed = false };
+                var details2 = new PackageDetailsCatalogLeaf { Listed = false };
+                var details3 = new PackageDetailsCatalogLeaf { Listed = false };
+                var index = new RegistrationIndex
+                {
+                    Items = new List<RegistrationPage>
+                    {
+                        new RegistrationPage
+                        {
+                            Lower = "0.0.0",
+                            Upper = "4.0.0",
+                            Url = "https://example/page",
+                            Items = new List<RegistrationLeafItem>
+                            {
+                                new RegistrationLeafItem
+                                {
+                                    CatalogEntry = new RegistrationCatalogEntry
+                                    {
+                                        Url = "https://example/0.0.0",
+                                        Version = "0.0.0",
+                                    },
+                                },
+                                new RegistrationLeafItem
+                                {
+                                    CatalogEntry = new RegistrationCatalogEntry
+                                    {
+                                        Url = "https://example/1.0.0",
+                                        Version = "1.0.0",
+                                    },
+                                },
+                                new RegistrationLeafItem
+                                {
+                                    CatalogEntry = new RegistrationCatalogEntry
+                                    {
+                                        Url = "https://example/2.0.0",
+                                        Version = "2.0.0",
+                                    },
+                                },
+                                new RegistrationLeafItem
+                                {
+                                    CatalogEntry = new RegistrationCatalogEntry
+                                    {
+                                        Url = "https://example/3.0.0",
+                                        Version = "3.0.0",
+                                    },
+                                },
+                                new RegistrationLeafItem
+                                {
+                                    CatalogEntry = new RegistrationCatalogEntry
+                                    {
+                                        Url = "https://example/4.0.0",
+                                        Version = "4.0.0",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                };
+                _catalogClient
+                    .Setup(x => x.GetPackageDetailsLeafAsync("https://example/1.0.0"))
+                    .ReturnsAsync(details1);
+                _catalogClient
+                    .Setup(x => x.GetPackageDetailsLeafAsync("https://example/2.0.0"))
+                    .ReturnsAsync(details2);
+                _catalogClient
+                    .Setup(x => x.GetPackageDetailsLeafAsync("https://example/3.0.0"))
+                    .ReturnsAsync(details3);
+                _registrationClient
+                    .Setup(x => x.GetIndexOrNullAsync(It.IsAny<string>()))
+                    .ReturnsAsync(index);
+
+                var latest = await _target.GetLatestLeavesAsync(PackageId, versions);
+
+                Assert.Empty(latest.Unavailable);
+                Assert.Equal(
+                    new[] { Parse("1.0.0"), Parse("2.0.0"), Parse("3.0.0") },
+                    latest.Available.Keys.OrderBy(x => x).ToArray());
+                Assert.Same(details1, latest.Available[Parse("1.0.0")]);
+                Assert.Same(details2, latest.Available[Parse("2.0.0")]);
+                Assert.Same(details3, latest.Available[Parse("3.0.0")]);
+                _registrationClient.Verify(
+                    x => x.GetIndexOrNullAsync(It.IsAny<string>()), Times.Once);
+                _registrationClient.Verify(
+                    x => x.GetIndexOrNullAsync("https://example/v3-registration/nuget.versioning/index.json"), Times.Once);
+                _registrationClient.Verify(
+                    x => x.GetPageAsync(It.IsAny<string>()), Times.Never);
+                _catalogClient.Verify(
+                    x => x.GetPackageDetailsLeafAsync(It.IsAny<string>()),
+                    Times.Exactly(3));
+                _catalogClient.Verify(
+                    x => x.GetPackageDetailsLeafAsync("https://example/0.0.0"),
+                    Times.Never);
+                _catalogClient.Verify(
+                    x => x.GetPackageDetailsLeafAsync("https://example/4.0.0"),
+                    Times.Never);
+            }
+
+            [Fact]
+            public async Task FetchesPageIfItemsAreNotInlined()
+            {
+                var versions = new List<IReadOnlyList<NuGetVersion>>
+                {
+                    new List<NuGetVersion>
+                    {
+                        Parse("1.0.0"),
+                    },
+                };
+                var details1 = new PackageDetailsCatalogLeaf { Listed = true };
+                var page = new RegistrationPage
+                {
+                    Items = new List<RegistrationLeafItem>
+                    {
+                        new RegistrationLeafItem
+                        {
+                            CatalogEntry = new RegistrationCatalogEntry
+                            {
+                                Url = "https://example/1.0.0",
+                                Version = "1.0.0",
+                            },
+                        },
+                    },
+                };
+                var index = new RegistrationIndex
+                {
+                    Items = new List<RegistrationPage>
+                    {
+                        new RegistrationPage
+                        {
+                            Lower = "1.0.0",
+                            Upper = "1.0.0",
+                            Url = "https://example/page",
+                        },
+                    },
+                };
+                _catalogClient
+                    .Setup(x => x.GetPackageDetailsLeafAsync("https://example/1.0.0"))
+                    .ReturnsAsync(details1);
+                _registrationClient
+                    .Setup(x => x.GetPageAsync("https://example/page"))
+                    .ReturnsAsync(page);
+                _registrationClient
+                    .Setup(x => x.GetIndexOrNullAsync(It.IsAny<string>()))
+                    .ReturnsAsync(index);
+
+                var latest = await _target.GetLatestLeavesAsync(PackageId, versions);
+
+                Assert.Empty(latest.Unavailable);
+                Assert.Equal(
+                    new[] { Parse("1.0.0") },
+                    latest.Available.Keys.OrderBy(x => x).ToArray());
+                Assert.Same(details1, latest.Available[Parse("1.0.0")]);
+                _registrationClient.Verify(
+                    x => x.GetIndexOrNullAsync(It.IsAny<string>()), Times.Once);
+                _registrationClient.Verify(
+                    x => x.GetIndexOrNullAsync("https://example/v3-registration/nuget.versioning/index.json"), Times.Once);
+                _registrationClient.Verify(
+                    x => x.GetPageAsync(It.IsAny<string>()), Times.Once);
+                _registrationClient.Verify(
+                    x => x.GetPageAsync("https://example/page"), Times.Once);
+                _catalogClient.Verify(
+                    x => x.GetPackageDetailsLeafAsync(It.IsAny<string>()),
+                    Times.Once);
+                _catalogClient.Verify(
+                    x => x.GetPackageDetailsLeafAsync("https://example/1.0.0"),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task FetchesLeavesOnlyOnce()
+            {
+                var details1 = new PackageDetailsCatalogLeaf { Listed = true };
+                var details2 = new PackageDetailsCatalogLeaf { Listed = true };
+                var details3 = new PackageDetailsCatalogLeaf { Listed = true };
+                var details4 = new PackageDetailsCatalogLeaf { Listed = true };
+                var index = new RegistrationIndex
+                {
+                    Items = new List<RegistrationPage>
+                    {
+                        new RegistrationPage
+                        {
+                            Lower = "0.0.0",
+                            Upper = "10.0.0",
+                            Url = "https://example/page",
+                            Items = new List<RegistrationLeafItem>
+                            {
+                                new RegistrationLeafItem
+                                {
+                                    CatalogEntry = new RegistrationCatalogEntry
+                                    {
+                                        Url = "https://example/1",
+                                        Version = "1.0.0",
+                                    },
+                                },
+                                new RegistrationLeafItem
+                                {
+                                    CatalogEntry = new RegistrationCatalogEntry
+                                    {
+                                        Url = "https://example/2",
+                                        Version = "2.0.0-alpha",
+                                    },
+                                },
+                                new RegistrationLeafItem
+                                {
+                                    CatalogEntry = new RegistrationCatalogEntry
+                                    {
+                                        Url = "https://example/3",
+                                        Version = "3.0.0+git",
+                                    },
+                                },
+                                new RegistrationLeafItem
+                                {
+                                    CatalogEntry = new RegistrationCatalogEntry
+                                    {
+                                        Url = "https://example/4",
+                                        Version = "4.0.0-beta.1",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                };
+                _catalogClient
+                    .Setup(x => x.GetPackageDetailsLeafAsync("https://example/1"))
+                    .ReturnsAsync(details1);
+                _catalogClient
+                    .Setup(x => x.GetPackageDetailsLeafAsync("https://example/2"))
+                    .ReturnsAsync(details2);
+                _catalogClient
+                    .Setup(x => x.GetPackageDetailsLeafAsync("https://example/3"))
+                    .ReturnsAsync(details3);
+                _catalogClient
+                    .Setup(x => x.GetPackageDetailsLeafAsync("https://example/4"))
+                    .ReturnsAsync(details4);
+                _registrationClient
+                    .Setup(x => x.GetIndexOrNullAsync(It.IsAny<string>()))
+                    .ReturnsAsync(index);
+
+                var latest = await _target.GetLatestLeavesAsync(PackageId, _versions);
+
+                Assert.Empty(latest.Unavailable);
+                Assert.Equal(
+                    _eachVersion,
+                    latest.Available.Keys.OrderBy(x => x).ToArray());
+                Assert.Same(details1, latest.Available[Parse("1.0.0")]);
+                Assert.Same(details2, latest.Available[Parse("2.0.0-alpha")]);
+                Assert.Same(details3, latest.Available[Parse("3.0.0")]);
+                Assert.Same(details4, latest.Available[Parse("4.0.0-beta.1")]);
+                _registrationClient.Verify(
+                    x => x.GetIndexOrNullAsync(It.IsAny<string>()), Times.Once);
+                _registrationClient.Verify(
+                    x => x.GetIndexOrNullAsync("https://example/v3-registration/nuget.versioning/index.json"), Times.Once);
+                _registrationClient.Verify(
+                    x => x.GetPageAsync(It.IsAny<string>()), Times.Never);
+                _catalogClient.Verify(
+                    x => x.GetPackageDetailsLeafAsync(It.IsAny<string>()),
+                    Times.Exactly(4));
+                _catalogClient.Verify(
+                    x => x.GetPackageDetailsLeafAsync("https://example/1"),
+                    Times.Once);
+                _catalogClient.Verify(
+                    x => x.GetPackageDetailsLeafAsync("https://example/2"),
+                    Times.Once);
+                _catalogClient.Verify(
+                    x => x.GetPackageDetailsLeafAsync("https://example/3"),
+                    Times.Once);
+                _catalogClient.Verify(
+                    x => x.GetPackageDetailsLeafAsync("https://example/4"),
+                    Times.Once);
+            }
+        }
+
+        public abstract class BaseFacts
+        {
+            protected const string PackageId = "NuGet.Versioning";
+
+            protected readonly Mock<IRegistrationClient> _registrationClient;
+            protected readonly Mock<ICatalogClient> _catalogClient;
+            protected readonly Mock<IOptionsSnapshot<Catalog2AzureSearchConfiguration>> _options;
+            protected readonly Catalog2AzureSearchConfiguration _config;
+            protected readonly RecordingLogger<CatalogLeafFetcher> _logger;
+            protected readonly List<IReadOnlyList<NuGetVersion>> _versions;
+            protected readonly NuGetVersion[] _eachVersion;
+            protected readonly CatalogLeafFetcher _target;
+
+            public BaseFacts(ITestOutputHelper output)
+            {
+                _registrationClient = new Mock<IRegistrationClient>();
+                _catalogClient = new Mock<ICatalogClient>();
+                _options = new Mock<IOptionsSnapshot<Catalog2AzureSearchConfiguration>>();
+                _config = new Catalog2AzureSearchConfiguration();
+                _logger = output.GetLogger<CatalogLeafFetcher>();
+
+                _options.Setup(x => x.Value).Returns(() => _config);
+
+                _config.RegistrationsBaseUrl = "https://example/v3-registration/";
+                _versions = new List<IReadOnlyList<NuGetVersion>>
+                {
+                    new List<NuGetVersion>
+                    {
+                        Parse("1.0.0"),
+                    },
+                    new List<NuGetVersion>
+                    {
+                        Parse("1.0.0"),
+                        Parse("2.0.0-alpha"),
+                    },
+                    new List<NuGetVersion>
+                    {
+                        Parse("1.0.0"),
+                        Parse("3.0.0+git"),
+                    },
+                    new List<NuGetVersion>
+                    {
+                        Parse("1.0.0"),
+                        Parse("2.0.0-alpha"),
+                        Parse("3.0.0+git"),
+                        Parse("4.0.0-beta.1"),
+                    },
+                };
+                _eachVersion = new[]
+                {
+                    Parse("1.0.0"),
+                    Parse("2.0.0-alpha"),
+                    Parse("3.0.0+git"),
+                    Parse("4.0.0-beta.1"),
+                };
+
+                _target = new CatalogLeafFetcher(
+                    _registrationClient.Object,
+                    _catalogClient.Object,
+                    _options.Object,
+                    _logger);
+            }
+
+            protected NuGetVersion Parse(string input)
+            {
+                return NuGetVersion.Parse(input);
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -38,6 +38,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BatchPusherFacts.cs" />
+    <Compile Include="Catalog2AzureSearch\CatalogLeafFetcherFacts.cs" />
     <Compile Include="Db2AzureSearch\Db2AzureSearchCommandFacts.cs" />
     <Compile Include="Db2AzureSearch\EnumerableExtensionsFacts.cs" />
     <Compile Include="Db2AzureSearch\NewPackageRegistrationProducerFacts.cs" />


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/6446

We keep track of available/unavailable discoveries so that the caller can react to any information now available in the registration. The list of lists provided to the `GetLatestLeavesAsync` are created from the listed versions per `SearchFilters`. Basically we want to find a new latest version for each of the downgrades. This might be more than one version depending on the search filters.

Also fix up some broken config.