### PR TITLE
[Search 1] Add document builder logic

### DIFF
--- a/src/NuGet.Indexing/Extraction/CatalogPackageMetadataExtraction.cs
+++ b/src/NuGet.Indexing/Extraction/CatalogPackageMetadataExtraction.cs
@@ -170,7 +170,7 @@ namespace NuGet.Indexing
                         // Add packages list
                         foreach (var packageDependency in dependencyGroup.Packages)
                         {
-                            AddFlattennedPackageDependency(dependencyGroup, packageDependency, builder);
+                            AddFlattenedPackageDependency(dependencyGroup, packageDependency, builder);
                         }
                     }
                     else
@@ -192,7 +192,7 @@ namespace NuGet.Indexing
                 }
             }
 
-            private void AddFlattennedPackageDependency(
+            private void AddFlattenedPackageDependency(
                 PackageDependencyGroup dependencyGroup,
                 Packaging.Core.PackageDependency packageDependency,
                 StringBuilder builder)

--- a/src/NuGet.Services.AzureSearch/DocumentUtilities.cs
+++ b/src/NuGet.Services.AzureSearch/DocumentUtilities.cs
@@ -1,0 +1,241 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using NuGet.Frameworks;
+using NuGet.Protocol.Catalog;
+using NuGet.Services.Entities;
+using NuGet.Services.Metadata.Catalog;
+using NuGet.Versioning;
+using PackageDependency = NuGet.Protocol.Catalog.PackageDependency;
+
+namespace NuGet.Services.AzureSearch
+{
+    internal static class DocumentUtilities
+    {
+        private static readonly VersionRangeFormatter VersionRangeFormatter = new VersionRangeFormatter();
+        private static readonly DateTimeOffset UnlistedPublished = new DateTimeOffset(Metadata.Catalog.Constants.UnpublishedDate);
+
+        private static readonly HashSet<NuGetFramework> SpecialFrameworks = new HashSet<NuGetFramework>
+        {
+            NuGetFramework.AnyFramework,
+            NuGetFramework.AgnosticFramework,
+            NuGetFramework.UnsupportedFramework
+        };
+
+        public static void PopulateMetadata(
+            IBaseMetadataDocument document,
+            string packageId,
+            Package package)
+        {
+            document.Authors = package.FlattenedAuthors;
+            document.Copyright = package.Copyright;
+            document.Created = AssumeUtc(package.Created);
+            document.Description = package.Description;
+            document.FileSize = package.PackageFileSize;
+            document.FlattenedDependencies = package.FlattenedDependencies;
+            document.Hash = package.Hash;
+            document.HashAlgorithm = package.HashAlgorithm;
+            document.IconUrl = package.IconUrl;
+            document.Language = package.Language;
+            document.LastEdited = AssumeUtc(package.LastEdited);
+            document.LicenseUrl = package.LicenseUrl;
+            document.MinClientVersion = package.MinClientVersion;
+            document.NormalizedVersion = package.NormalizedVersion;
+            document.OriginalVersion = package.Version;
+            document.PackageId = packageId;
+            document.Prerelease = package.IsPrerelease;
+            document.ProjectUrl = package.ProjectUrl;
+            document.Published = package.Listed ? AssumeUtc(package.Published) : UnlistedPublished;
+            document.ReleaseNotes = package.ReleaseNotes;
+            document.RequiresLicenseAcceptance = package.RequiresLicenseAcceptance;
+            document.SemVerLevel = package.SemVerLevelKey;
+            document.Summary = package.Summary;
+            document.Tags = Utils.SplitTags(package.Tags ?? string.Empty);
+            document.Title = package.Title;
+        }
+
+        public static void PopulateMetadata(
+            IBaseMetadataDocument document,
+            string normalizedVersion,
+            PackageDetailsCatalogLeaf leaf)
+        {
+            document.Authors = leaf.Authors;
+            document.Copyright = leaf.Copyright;
+            document.Created = leaf.Created;
+            document.Description = leaf.Description;
+            document.FileSize = leaf.PackageSize;
+            document.FlattenedDependencies = GetFlattenedDependencies(leaf);
+            document.Hash = leaf.PackageHash;
+            document.HashAlgorithm = leaf.PackageHashAlgorithm;
+            document.IconUrl = leaf.IconUrl;
+            document.Language = leaf.Language;
+            document.LastEdited = leaf.LastEdited;
+            document.LicenseUrl = leaf.LicenseUrl;
+            document.MinClientVersion = leaf.MinClientVersion;
+            document.NormalizedVersion = normalizedVersion;
+            document.OriginalVersion = leaf.VerbatimVersion ?? leaf.PackageVersion;
+            document.PackageId = leaf.PackageId;
+            document.Prerelease = leaf.IsPrerelease;
+            document.ProjectUrl = leaf.ProjectUrl;
+            document.Published = leaf.Published;
+            document.ReleaseNotes = leaf.ReleaseNotes;
+            document.RequiresLicenseAcceptance = leaf.RequireLicenseAgreement;
+            document.SemVerLevel = leaf.IsSemVer2() ? 2 : (int?)null;
+            document.Summary = leaf.Summary;
+            document.Tags = leaf.Tags == null ? null : leaf.Tags.ToArray();
+            document.Title = leaf.Title;
+        }
+
+        public static string GetSearchDocumentKey(string packageId, SearchFilters searchFilters)
+        {
+            var lowerId = packageId.ToLowerInvariant();
+            var encodedId = EncodeKey(lowerId);
+            return $"{encodedId}-{searchFilters}";
+        }
+
+        public static string GetHijackDocumentKey(string packageId, string normalizedVersion)
+        {
+            var lowerId = packageId.ToLowerInvariant();
+            var lowerVersion = normalizedVersion.ToLowerInvariant();
+            return EncodeKey($"{lowerId}/{lowerVersion}");
+        }
+
+        private static string EncodeKey(string rawKey)
+        {
+            // First, encode the raw value for uniqueness.
+            var bytes = Encoding.UTF8.GetBytes(rawKey);
+            var unique = HttpServerUtility.UrlTokenEncode(bytes);
+
+            // Then, prepend a string as close to the raw key as possible, for readability.
+            var readable = ReplaceUnsafeKeyCharacters(rawKey).TrimStart('_');
+
+            return readable.Length > 0 ? $"{readable}-{unique}" : unique;
+        }
+
+        private static string ReplaceUnsafeKeyCharacters(string input)
+        {
+            return Regex.Replace(
+                input,
+                "[^A-Za-z0-9-_]", // Remove equal sign as well, since it's ugly.
+                "_",
+                RegexOptions.None,
+                TimeSpan.FromSeconds(30));
+        }
+
+        private static DateTimeOffset? AssumeUtc(DateTime? dateTime)
+        {
+            if (!dateTime.HasValue)
+            {
+                return null;
+            }
+
+            return new DateTimeOffset(dateTime.Value.Ticks, TimeSpan.Zero);
+        }
+
+        /// <summary>
+        /// This method produces output for official client. The implementation on the client side, at one point of time
+        /// was:
+        /// https://github.com/NuGet/NuGet.Client/blob/b404acf6eb88c2b6086a9cbb5106104534de2428/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedPackageInfo.cs#L228-L308
+        /// 
+        /// The output is a string where each dependency is separated by a "|" character and information about each
+        /// dependency is separated by a ":" character. Per dependency, the colon-seperated data is a pair or triple.
+        /// The three fields in order are: dependency package ID, version range, and target framework. If third value
+        /// (the framework that the dependency targets) is an empty string or excluded, this means the dependency
+        /// applies to any framework. If the package ID and range and empty strings but the framework is included, this
+        /// means that the package supports the specified framework but has no dependencies specific to that framework.
+        /// 
+        /// Output:
+        ///     [DEPENDENCY[|DEPENDENCY][|...][|DEPENDENCY]]
+        /// Each dependency:
+        ///     [PACKAGE_ID]:[VERSION_RANGE][:TARGET_FRAMEWORK]
+        ///   
+        /// Example A (no target frameworks):
+        ///     Microsoft.Data.OData:5.0.2|Microsoft.WindowsAzure.ConfigurationManager:1.8.0
+        /// Example B (target frameworks):
+        ///     NETStandard.Library:1.6.1:netstandard1.0|Newtonsoft.Json:10.0.2:netstandard1.0
+        /// Example D (empty target framework):
+        ///     Microsoft.Data.OData:5.0.2:
+        /// Example D (just target framework):
+        ///     ::net20|::net35|::net40|::net45|NETStandard.Library:1.6.1:netstandard1.0
+        /// </summary>
+        private static string GetFlattenedDependencies(PackageDetailsCatalogLeaf leaf)
+        {
+            if (leaf.DependencyGroups == null)
+            {
+                return null;
+            }
+
+            var builder = new StringBuilder();
+            foreach (var dependencyGroup in leaf.DependencyGroups)
+            {
+                var targetFramework = dependencyGroup.ParseTargetFramework();
+
+                if (dependencyGroup.Dependencies != null && dependencyGroup.Dependencies.Any())
+                {
+                    foreach (var packageDependency in dependencyGroup.Dependencies)
+                    {
+                        AddFlattenedPackageDependency(targetFramework, packageDependency, builder);
+                    }
+                }
+                else
+                {
+                    if (builder.Length > 0)
+                    {
+                        builder.Append("|");
+                    }
+
+                    builder.Append(":");
+                    AddFlattenedFrameworkDependency(targetFramework, builder);
+                }
+            }
+
+            return builder.Length > 0 ? builder.ToString() : null;
+        }
+
+        private static void AddFlattenedPackageDependency(
+            NuGetFramework targetFramework,
+            PackageDependency packageDependency,
+            StringBuilder builder)
+        {
+            if (builder.Length > 0)
+            {
+                builder.Append("|");
+            }
+
+            builder.Append(packageDependency.Id);
+            builder.Append(":");
+
+            var versionRange = packageDependency.ParseRange();
+
+            if (!VersionRange.All.Equals(versionRange))
+            {
+                builder.Append(versionRange?.ToString("S", VersionRangeFormatter));
+            }
+
+            AddFlattenedFrameworkDependency(targetFramework, builder);
+        }
+
+        private static void AddFlattenedFrameworkDependency(NuGetFramework targetFramework, StringBuilder builder)
+        {
+            if (!SpecialFrameworks.Contains(targetFramework))
+            {
+                try
+                {
+                    builder.Append(":");
+                    builder.Append(targetFramework?.GetShortFolderName());
+                }
+                catch (FrameworkException)
+                {
+                    // ignoring FrameworkException on purpose - we don't want the job crashing
+                    // whenever someone uploads an unsupported framework
+                }
+            }
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/HijackDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/HijackDocumentBuilder.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Protocol.Catalog;
+using NuGet.Services.Entities;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class HijackDocumentBuilder : IHijackDocumentBuilder
+    {
+        public KeyedDocument Keyed(
+            string packageId,
+            string normalizedVersion)
+        {
+            var document = new KeyedDocument();
+
+            PopulateKey(document, packageId, normalizedVersion);
+
+            return document;
+        }
+
+        public HijackDocument.Latest Latest(
+            string packageId,
+            string normalizedVersion,
+            HijackDocumentChanges changes)
+        {
+            var document = new HijackDocument.Latest();
+
+            PopulateLatest(document, packageId, normalizedVersion, changes);
+
+            return document;
+        }
+
+        public HijackDocument.Full Full(
+            string normalizedVersion,
+            HijackDocumentChanges changes,
+            PackageDetailsCatalogLeaf leaf)
+        {
+            var document = new HijackDocument.Full();
+
+            PopulateFull(document, leaf.PackageId, normalizedVersion, changes, leaf.Title);
+            DocumentUtilities.PopulateMetadata(document, normalizedVersion, leaf);
+
+            return document;
+        }
+
+        public HijackDocument.Full Full(
+            string packageId,
+            HijackDocumentChanges changes,
+            Package package)
+        {
+            var document = new HijackDocument.Full();
+
+            PopulateFull(document, packageId, package.NormalizedVersion, changes, package.Title);
+            DocumentUtilities.PopulateMetadata(document, packageId, package);
+
+            return document;
+        }
+
+        private static void PopulateFull(
+            HijackDocument.Full document,
+            string packageId,
+            string normalizedVersion,
+            HijackDocumentChanges changes,
+            string title)
+        {
+            PopulateLatest(document, packageId, normalizedVersion, changes);
+            document.SortableTitle = title ?? packageId;
+        }
+
+        private static void PopulateLatest<T>(
+            T document,
+            string packageId,
+            string normalizedVersion,
+            HijackDocumentChanges changes) where T : KeyedDocument, HijackDocument.ILatest
+        {
+            PopulateKey(document, packageId, normalizedVersion);
+            document.IsLatestStableSemVer1 = changes.LatestStableSemVer1;
+            document.IsLatestSemVer1 = changes.LatestSemVer1;
+            document.IsLatestStableSemVer2 = changes.LatestStableSemVer2;
+            document.IsLatestSemVer2 = changes.LatestSemVer2;
+        }
+
+        private static void PopulateKey(KeyedDocument document, string packageId, string normalizedVersion)
+        {
+            document.Key = DocumentUtilities.GetHijackDocumentKey(packageId, normalizedVersion);
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/IHijackDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/IHijackDocumentBuilder.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Protocol.Catalog;
+using NuGet.Services.Entities;
+
+namespace NuGet.Services.AzureSearch
+{
+    public interface IHijackDocumentBuilder
+    {
+        KeyedDocument Keyed(
+            string packageId,
+            string normalizedVersion);
+
+        HijackDocument.Latest Latest(
+            string packageId,
+            string normalizedVersion,
+            HijackDocumentChanges changes);
+
+        HijackDocument.Full Full(
+            string packageId,
+            HijackDocumentChanges changes,
+            Package package);
+
+        HijackDocument.Full Full(
+            string normalizedVersion,
+            HijackDocumentChanges changes,
+            PackageDetailsCatalogLeaf leaf);
+    }
+}

--- a/src/NuGet.Services.AzureSearch/ISearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/ISearchDocumentBuilder.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Protocol.Catalog;
+using NuGet.Services.Entities;
+
+namespace NuGet.Services.AzureSearch
+{
+    public interface ISearchDocumentBuilder
+    {
+        KeyedDocument Keyed(
+            string packageId,
+            SearchFilters searchFilters);
+
+        SearchDocument.UpdateVersionList UpdateVersionList(
+            string packageId,
+            SearchFilters searchFilters,
+            string[] versions);
+
+        SearchDocument.Full Full(
+            string packageId, 
+            SearchFilters searchFilters,
+            string[] versions,
+            string fullVersion,
+            Package package,
+            string[] owners,
+            long totalDownloadCount);
+
+        SearchDocument.UpdateLatest UpdateLatest(
+            SearchFilters searchFilters,
+            string[] versions,
+            string normalizedVersion,
+            string fullVersion,
+            PackageDetailsCatalogLeaf leaf);
+    }
+}

--- a/src/NuGet.Services.AzureSearch/IndexActions.cs
+++ b/src/NuGet.Services.AzureSearch/IndexActions.cs
@@ -8,7 +8,7 @@ using Microsoft.Azure.Search.Models;
 namespace NuGet.Services.AzureSearch
 {
     /// <summary>
-    /// <see cref="IndexAction{T}"/> instances seperated by whether they apply to the search index or the hijack index
+    /// <see cref="IndexAction{T}"/> instances separated by whether they apply to the search index or the hijack index
     /// as well as the version list data to write to storage after the index actions have been applied.
     /// </summary>
     public class IndexActions

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -41,6 +41,8 @@
     <Compile Include="Catalog2AzureSearch\CatalogLeafFetcher.cs" />
     <Compile Include="Catalog2AzureSearch\ICatalogLeafFetcher.cs" />
     <Compile Include="Catalog2AzureSearch\LatestCatalogLeaves.cs" />
+    <Compile Include="DocumentUtilities.cs" />
+    <Compile Include="HijackDocumentBuilder.cs" />
     <Compile Include="IBatchPusher.cs" />
     <Compile Include="Db2AzureSearch\Db2AzureSearchCommand.cs" />
     <Compile Include="Db2AzureSearch\Db2AzureSearchConfiguration.cs" />
@@ -52,7 +54,9 @@
     <Compile Include="Db2AzureSearch\NewPackageRegistration.cs" />
     <Compile Include="IndexActionBuilder.cs" />
     <Compile Include="Db2AzureSearch\NewPackageRegistrationProducer.cs" />
+    <Compile Include="IHijackDocumentBuilder.cs" />
     <Compile Include="IndexActions.cs" />
+    <Compile Include="ISearchDocumentBuilder.cs" />
     <Compile Include="Models\IBaseMetadataDocument.cs" />
     <Compile Include="Models\KeyedDocument.cs" />
     <Compile Include="Models\BaseMetadataDocument.cs" />
@@ -66,6 +70,7 @@
     <Compile Include="Registration\Models\RegistrationPage.cs" />
     <Compile Include="Registration\RegistrationClient.cs" />
     <Compile Include="Registration\Models\RegistrationLeaf.cs" />
+    <Compile Include="SearchDocumentBuilder.cs" />
     <Compile Include="VersionList\Guard.cs" />
     <Compile Include="VersionList\HijackIndexChange.cs" />
     <Compile Include="VersionList\HijackIndexChangeType.cs" />

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Protocol.Catalog;
+using NuGet.Services.Entities;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class SearchDocumentBuilder : ISearchDocumentBuilder
+    {
+        public KeyedDocument Keyed(
+            string packageId,
+            SearchFilters searchFilters)
+        {
+            var document = new KeyedDocument();
+
+            PopulateKey(document, packageId, searchFilters);
+
+            return document;
+        }
+
+        public SearchDocument.UpdateVersionList UpdateVersionList(
+            string packageId,
+            SearchFilters searchFilters,
+            string[] versions)
+        {
+            var document = new SearchDocument.UpdateVersionList();
+
+            PopulateVersions(document, packageId, searchFilters, versions);
+
+            return document;
+        }
+
+        public SearchDocument.UpdateLatest UpdateLatest(
+            SearchFilters searchFilters,
+            string[] versions,
+            string normalizedVersion,
+            string fullVersion,
+            PackageDetailsCatalogLeaf leaf)
+        {
+            var document = new SearchDocument.UpdateLatest();
+
+            PopulateUpdateLatest(document, leaf.PackageId, searchFilters, versions, fullVersion);
+            DocumentUtilities.PopulateMetadata(document, normalizedVersion, leaf);
+
+            return document;
+        }
+
+        public SearchDocument.Full Full(
+            string packageId,
+            SearchFilters searchFilters,
+            string[] versions,
+            string fullVersion,
+            Package package,
+            string[] owners,
+            long totalDownloadCount)
+        {
+            var document = new SearchDocument.Full();
+
+            PopulateAddFirst(document, packageId, searchFilters, versions, fullVersion, owners);
+            DocumentUtilities.PopulateMetadata(document, packageId, package);
+            document.TotalDownloadCount = totalDownloadCount;
+
+            return document;
+        }
+
+        private static void PopulateVersions<T>(
+            T document,
+            string packageId,
+            SearchFilters searchFilters,
+            string[] versions) where T : KeyedDocument, SearchDocument.IVersions
+        {
+            PopulateKey(document, packageId, searchFilters);
+            document.Versions = versions;
+        }
+
+        private static void PopulateKey(KeyedDocument document, string packageId, SearchFilters searchFilters)
+        {
+            document.Key = DocumentUtilities.GetSearchDocumentKey(packageId, searchFilters);
+        }
+
+        private static void PopulateUpdateLatest(
+            SearchDocument.UpdateLatest document,
+            string packageId,
+            SearchFilters searchFilters,
+            string[] versions,
+            string fullVersion)
+        {
+            PopulateVersions(document, packageId, searchFilters, versions);
+            document.FullVersion = fullVersion;
+        }
+
+        private static void PopulateAddFirst(
+            SearchDocument.AddFirst document,
+            string packageId,
+            SearchFilters searchFilters,
+            string[] versions,
+            string fullVersion,
+            string[] owners)
+        {
+            PopulateUpdateLatest(document, packageId, searchFilters, versions, fullVersion);
+            document.Owners = owners;
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/DocumentUtilitiesFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/DocumentUtilitiesFacts.cs
@@ -1,0 +1,212 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Protocol.Catalog;
+using Xunit;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class DocumentUtilitiesFacts
+    {
+        public class GetHijackDocumentKey
+        {
+            [Theory]
+            [InlineData("NuGet.Versioning", "1.0.0", "nuget_versioning_1_0_0-bnVnZXQudmVyc2lvbmluZy8xLjAuMA2")]
+            [InlineData("nuget.versioning", "1.0.0", "nuget_versioning_1_0_0-bnVnZXQudmVyc2lvbmluZy8xLjAuMA2")]
+            [InlineData("NUGET.VERSIONING", "1.0.0", "nuget_versioning_1_0_0-bnVnZXQudmVyc2lvbmluZy8xLjAuMA2")]
+            [InlineData("_", "1.0.0", "1_0_0-Xy8xLjAuMA2")]
+            [InlineData("foo-bar", "1.0.0", "foo-bar_1_0_0-Zm9vLWJhci8xLjAuMA2")]
+            [InlineData("İzmir", "1.0.0", "zmir_1_0_0-xLB6bWlyLzEuMC4w0")]
+            [InlineData("İİzmir", "1.0.0", "zmir_1_0_0-xLDEsHptaXIvMS4wLjA1")]
+            [InlineData("zİİmir", "1.0.0", "z__mir_1_0_0-esSwxLBtaXIvMS4wLjA1")]
+            [InlineData("zmirİ", "1.0.0", "zmir__1_0_0-em1pcsSwLzEuMC4w0")]
+            [InlineData("zmirİİ", "1.0.0", "zmir___1_0_0-em1pcsSwxLAvMS4wLjA1")]
+            [InlineData("惡", "1.0.0", "1_0_0-5oOhLzEuMC4w0")]
+            [InlineData("jQuery", "1.0.0-alpha", "jquery_1_0_0-alpha-anF1ZXJ5LzEuMC4wLWFscGhh0")]
+            [InlineData("jQuery", "1.0.0-Alpha", "jquery_1_0_0-alpha-anF1ZXJ5LzEuMC4wLWFscGhh0")]
+            [InlineData("jQuery", "1.0.0-ALPHA", "jquery_1_0_0-alpha-anF1ZXJ5LzEuMC4wLWFscGhh0")]
+            [InlineData("jQuery", "1.0.0-ALPHA.1", "jquery_1_0_0-alpha_1-anF1ZXJ5LzEuMC4wLWFscGhhLjE1")]
+            public void EncodesHijackDocumentKey(string id, string version, string expected)
+            {
+                var actual = DocumentUtilities.GetHijackDocumentKey(id, version);
+
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        public class GetSearchDocumentKey
+        {
+            [Theory]
+            [InlineData("NuGet.Versioning", "nuget_versioning-bnVnZXQudmVyc2lvbmluZw2")]
+            [InlineData("nuget.versioning", "nuget_versioning-bnVnZXQudmVyc2lvbmluZw2")]
+            [InlineData("NUGET.VERSIONING", "nuget_versioning-bnVnZXQudmVyc2lvbmluZw2")]
+            [InlineData("_", "Xw2")]
+            [InlineData("foo-bar", "foo-bar-Zm9vLWJhcg2")]
+            [InlineData("İzmir", "zmir-xLB6bWly0")]
+            [InlineData("İİzmir", "zmir-xLDEsHptaXI1")]
+            [InlineData("zİİmir", "z__mir-esSwxLBtaXI1")]
+            [InlineData("zmirİ", "zmir_-em1pcsSw0")]
+            [InlineData("zmirİİ", "zmir__-em1pcsSwxLA1")]
+            [InlineData("惡", "5oOh0")]
+            public void EncodesSearchDocumentKey(string id, string expected)
+            {
+                foreach (var searchFilters in Enum.GetValues(typeof(SearchFilters)).Cast<SearchFilters>())
+                {
+                    var actual = DocumentUtilities.GetSearchDocumentKey(id, searchFilters);
+
+                    Assert.Equal(expected + "-" + searchFilters, actual);
+                }
+            }
+        }
+
+        public class PopulateMetadataWithCatalogLeaf
+        {
+            private const string NormalizedVersion = "1.0.0";
+
+            [Theory]
+            [InlineData("any")]
+            [InlineData("agnostic")]
+            [InlineData("unsupported")]
+            [InlineData("fakeframework1.0")]
+            public void DoesNotIncludeDependencyVersionSpecialFrameworks(string framework)
+            {
+                var leaf = new PackageDetailsCatalogLeaf
+                {
+                    PackageVersion = NormalizedVersion,
+                    DependencyGroups = new List<PackageDependencyGroup>
+                    {
+                        new PackageDependencyGroup
+                        {
+                            TargetFramework = framework,
+                            Dependencies = new List<PackageDependency>
+                            {
+                                new PackageDependency
+                                {
+                                    Id = "NuGet.Versioning",
+                                    Range = "2.0.0",
+                                },
+                                new PackageDependency
+                                {
+                                    Id = "NuGet.Frameworks",
+                                    Range = "3.0.0",
+                                },
+                            },
+                        },
+                    },
+                };
+                var full = new HijackDocument.Full();
+
+                DocumentUtilities.PopulateMetadata(full, NormalizedVersion, leaf);
+
+                Assert.Equal("NuGet.Versioning:2.0.0|NuGet.Frameworks:3.0.0", full.FlattenedDependencies);
+            }
+
+            [Theory]
+            [InlineData("any", ":")]
+            [InlineData("net40", "::net40")]
+            [InlineData("NET45", "::net45")]
+            [InlineData(".NETFramework,Version=4.0", "::net40")]
+            public void AddsEmptyDependencyGroup(string framework, string expected)
+            {
+                var leaf = new PackageDetailsCatalogLeaf
+                {
+                    PackageVersion = NormalizedVersion,
+                    DependencyGroups = new List<PackageDependencyGroup>
+                    {
+                        new PackageDependencyGroup
+                        {
+                            TargetFramework = framework,
+                        },
+                    },
+                };
+                var full = new HijackDocument.Full();
+
+                DocumentUtilities.PopulateMetadata(full, NormalizedVersion, leaf);
+
+                Assert.Equal(expected, full.FlattenedDependencies);
+            }
+
+            [Fact]
+            public void AddsEmptyStringForDependencyVersionAllRange()
+            {
+                var leaf = new PackageDetailsCatalogLeaf
+                {
+                    PackageVersion = NormalizedVersion,
+                    DependencyGroups = new List<PackageDependencyGroup>
+                    {
+                        new PackageDependencyGroup
+                        {
+                            TargetFramework = "net40",
+                            Dependencies = new List<PackageDependency>
+                            {
+                                new PackageDependency
+                                {
+                                    Id = "NuGet.Versioning",
+                                    Range = "(, )"
+                                }
+                            },
+                        },
+                    },
+                };
+                var full = new HijackDocument.Full();
+
+                DocumentUtilities.PopulateMetadata(full, NormalizedVersion, leaf);
+
+                Assert.Equal("NuGet.Versioning::net40", full.FlattenedDependencies);
+            }
+
+            [Theory]
+            [InlineData("1.0.0", "1.0.0")]
+            [InlineData("1.0.0-beta+git", "1.0.0-beta")]
+            [InlineData("[1.0.0-beta+git, )", "1.0.0-beta")]
+            [InlineData("[1.0.0, 1.0.0]", "[1.0.0]")]
+            [InlineData("[1.0.0, 2.0.0)", "[1.0.0, 2.0.0)")]
+            [InlineData("[1.0.0, )", "1.0.0")]
+            public void AddShortFormOfDependencyVersionRange(string input, string expected)
+            {
+                var leaf = new PackageDetailsCatalogLeaf
+                {
+                    PackageVersion = NormalizedVersion,
+                    DependencyGroups = new List<PackageDependencyGroup>
+                    {
+                        new PackageDependencyGroup
+                        {
+                            TargetFramework = "net40",
+                            Dependencies = new List<PackageDependency>
+                            {
+                                new PackageDependency
+                                {
+                                    Id = "NuGet.Versioning",
+                                    Range = input
+                                }
+                            },
+                        },
+                    },
+                };
+                var full = new HijackDocument.Full();
+
+                DocumentUtilities.PopulateMetadata(full, NormalizedVersion, leaf);
+
+                Assert.Equal("NuGet.Versioning:" + expected + ":net40", full.FlattenedDependencies);
+            }
+
+            [Fact]
+            public void AllowNullDependencyGroups()
+            {
+                var leaf = new PackageDetailsCatalogLeaf
+                {
+                    PackageVersion = NormalizedVersion,
+                    DependencyGroups = null
+                };
+                var full = new HijackDocument.Full();
+
+                DocumentUtilities.PopulateMetadata(full, NormalizedVersion, leaf);
+
+                Assert.Null(full.FlattenedDependencies);
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/HijackDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/HijackDocumentBuilderFacts.cs
@@ -1,0 +1,219 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using NuGet.Services.AzureSearch.Support;
+using Xunit;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class HijackDocumentBuilderFacts
+    {
+        public class Keyed : BaseFacts
+        {
+            [Fact]
+            public async Task SetsExpectedProperties()
+            {
+                var document = _target.Keyed(Data.PackageId, Data.NormalizedVersion);
+
+                var json = await SerializationUtilities.SerializeToJsonAsync(document);
+                Assert.Equal(@"{
+  ""value"": [
+    {
+      ""@search.action"": ""upload"",
+      ""key"": ""windowsazure_storage_7_1_2-alpha-d2luZG93c2F6dXJlLnN0b3JhZ2UvNy4xLjItYWxwaGE1""
+    }
+  ]
+}", json);
+            }
+        }
+
+        public class Latest : BaseFacts
+        {
+            [Fact]
+            public async Task SetsExpectedProperties()
+            {
+                var document = _target.Latest(Data.PackageId, Data.NormalizedVersion, _changes);
+
+                var json = await SerializationUtilities.SerializeToJsonAsync(document);
+                Assert.Equal(@"{
+  ""value"": [
+    {
+      ""@search.action"": ""upload"",
+      ""isLatestStableSemVer1"": false,
+      ""isLatestSemVer1"": true,
+      ""isLatestStableSemVer2"": false,
+      ""isLatestSemVer2"": true,
+      ""key"": ""windowsazure_storage_7_1_2-alpha-d2luZG93c2F6dXJlLnN0b3JhZ2UvNy4xLjItYWxwaGE1""
+    }
+  ]
+}", json);
+            }
+        }
+
+        public class FullFromPackageEntity : BaseFacts
+        {
+            [Fact]
+            public async Task SetsExpectedProperties()
+            {
+                var document = _target.Full(Data.PackageId, _changes, Data.PackageEntity);
+
+                var json = await SerializationUtilities.SerializeToJsonAsync(document);
+                Assert.Equal(_fullJson, json);
+            }
+
+            [Fact]
+            public void UsesIdForNullTitleInHijackIndex()
+            {
+                var package = Data.PackageEntity;
+                package.Title = null;
+
+                var document = _target.Full(Data.PackageId, _changes, package);
+
+                Assert.Equal(Data.PackageId, document.SortableTitle);
+            }
+
+            [Fact]
+            public void Uses1900ForPublishedWhenUnlisted()
+            {
+                var package = Data.PackageEntity;
+                package.Listed = false;
+
+                var document = _target.Full(Data.PackageId, _changes, package);
+
+                Assert.Equal(DateTimeOffset.Parse("1900-01-01Z"), document.Published);
+            }
+
+            [Fact]
+            public void SplitsTags()
+            {
+                var package = Data.PackageEntity;
+                package.Tags = "foo; BAR |     Baz";
+
+                var document = _target.Full(Data.PackageId, _changes, package);
+
+                Assert.Equal(new[] { "foo", "BAR", "Baz" }, document.Tags);
+            }
+
+            [Theory]
+            [InlineData(null)]
+            [InlineData(2)]
+            public void UsesSemVerLevelToIndicateSemVer2(int? semVerLevelKey)
+            {
+                var package = Data.PackageEntity;
+                package.SemVerLevelKey = semVerLevelKey;
+
+                var document = _target.Full(Data.PackageId, _changes, package);
+
+                Assert.Equal(semVerLevelKey, document.SemVerLevel);
+            }
+
+            /// <summary>
+            /// The caller is expected to verify consistency.
+            /// </summary>
+            [Fact]
+            public void DoesNotUseVersionToIndicateIsPrerelease()
+            {
+                var package = Data.PackageEntity;
+                package.IsPrerelease = false;
+                package.Version = "2.0.0-alpha";
+                package.NormalizedVersion = "2.0.0-alpha";
+
+                var document = _target.Full(Data.PackageId, _changes, package);
+
+                Assert.False(document.Prerelease);
+            }
+        }
+
+        public class FullFromPackageDetailsCatalogLeaf : BaseFacts
+        {
+            [Fact]
+            public async Task SetsExpectedProperties()
+            {
+                var document = _target.Full(Data.NormalizedVersion, _changes, Data.Leaf);
+
+                var json = await SerializationUtilities.SerializeToJsonAsync(document);
+                Assert.Equal(_fullJson, json);
+            }
+
+            [Fact]
+            public void UsesIdForNullTitleInHijackIndex()
+            {
+                var leaf = Data.Leaf;
+                leaf.Title = null;
+                var document = _target.Full(Data.NormalizedVersion, _changes, leaf);
+
+                Assert.Equal(Data.PackageId, document.SortableTitle);
+            }
+        }
+
+        public abstract class BaseFacts
+        {
+            protected readonly HijackDocumentChanges _changes;
+            protected readonly string _fullJson;
+            protected readonly HijackDocumentBuilder _target;
+
+            public BaseFacts()
+            {
+                _changes = new HijackDocumentChanges(
+                    delete: false,
+                    updateMetadata: true,
+                    latestStableSemVer1: false,
+                    latestSemVer1: true,
+                    latestStableSemVer2: false,
+                    latestSemVer2: true);
+                _fullJson = @"{
+  ""value"": [
+    {
+      ""@search.action"": ""upload"",
+      ""lastEdited"": ""2017-01-02T00:00:00+00:00"",
+      ""published"": ""2017-01-03T00:00:00+00:00"",
+      ""sortableTitle"": ""Windows Azure Storage"",
+      ""isLatestStableSemVer1"": false,
+      ""isLatestSemVer1"": true,
+      ""isLatestStableSemVer2"": false,
+      ""isLatestSemVer2"": true,
+      ""semVerLevel"": 2,
+      ""authors"": ""Microsoft"",
+      ""copyright"": ""© Microsoft Corporation. All rights reserved."",
+      ""created"": ""2017-01-01T00:00:00+00:00"",
+      ""description"": ""Description."",
+      ""fileSize"": 3039254,
+      ""flattenedDependencies"": ""Microsoft.Data.OData:5.6.4:net40-client|Newtonsoft.Json:6.0.8:net40-client"",
+      ""hash"": ""oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33+Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ=="",
+      ""hashAlgorithm"": ""SHA512"",
+      ""iconUrl"": ""http://go.microsoft.com/fwlink/?LinkID=288890"",
+      ""language"": ""en-US"",
+      ""licenseUrl"": ""http://go.microsoft.com/fwlink/?LinkId=331471"",
+      ""minClientVersion"": ""2.12"",
+      ""normalizedVersion"": ""7.1.2-alpha"",
+      ""originalVersion"": ""7.1.2.0-alpha+git"",
+      ""packageId"": ""WindowsAzure.Storage"",
+      ""prerelease"": true,
+      ""projectUrl"": ""https://github.com/Azure/azure-storage-net"",
+      ""releaseNotes"": ""Release notes."",
+      ""requiresLicenseAcceptance"": true,
+      ""summary"": ""Summary."",
+      ""tags"": [
+        ""Microsoft"",
+        ""Azure"",
+        ""Storage"",
+        ""Table"",
+        ""Blob"",
+        ""File"",
+        ""Queue"",
+        ""Scalable"",
+        ""windowsazureofficial""
+      ],
+      ""title"": ""Windows Azure Storage"",
+      ""key"": ""windowsazure_storage_7_1_2-alpha-d2luZG93c2F6dXJlLnN0b3JhZ2UvNy4xLjItYWxwaGE1""
+    }
+  ]
+}";
+
+                _target = new HijackDocumentBuilder();
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -43,7 +43,11 @@
     <Compile Include="Db2AzureSearch\EnumerableExtensionsFacts.cs" />
     <Compile Include="Db2AzureSearch\NewPackageRegistrationProducerFacts.cs" />
     <Compile Include="IndexActionBuilderFacts.cs" />
+    <Compile Include="DocumentUtilitiesFacts.cs" />
+    <Compile Include="HijackDocumentBuilderFacts.cs" />
+    <Compile Include="SearchDocumentBuilderFacts.cs" />
     <Compile Include="Registration\RegistrationClientFacts.cs" />
+    <Compile Include="Support\SerializationUtilities.cs" />
     <Compile Include="Support\DbSetMockFactory.cs" />
     <Compile Include="Support\RecordingLogger.cs" />
     <Compile Include="Support\TestDbAsyncEnumerable.cs" />

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
@@ -1,0 +1,231 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using NuGet.Services.AzureSearch.Support;
+using Xunit;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class SearchDocumentBuilderFacts
+    {
+        public class Keyed : BaseFacts
+        {
+            [Fact]
+            public async Task SetsExpectedProperties()
+            {
+                var document = _target.Keyed(Data.PackageId, _searchFilters);
+
+                var json = await SerializationUtilities.SerializeToJsonAsync(document);
+                Assert.Equal(@"{
+  ""value"": [
+    {
+      ""@search.action"": ""upload"",
+      ""key"": ""windowsazure_storage-d2luZG93c2F6dXJlLnN0b3JhZ2U1-IncludePrereleaseAndSemVer2""
+    }
+  ]
+}", json);
+            }
+        }
+
+        public class UpdateVersionList : BaseFacts
+        {
+            [Fact]
+            public async Task SetsExpectedProperties()
+            {
+                var document = _target.UpdateVersionList(Data.PackageId, _searchFilters, _versions);
+
+                var json = await SerializationUtilities.SerializeToJsonAsync(document);
+                Assert.Equal(@"{
+  ""value"": [
+    {
+      ""@search.action"": ""upload"",
+      ""versions"": [
+        ""1.0.0"",
+        ""2.0.0+git"",
+        ""3.0.0-alpha.1"",
+        ""7.1.2-alpha+git""
+      ],
+      ""key"": ""windowsazure_storage-d2luZG93c2F6dXJlLnN0b3JhZ2U1-IncludePrereleaseAndSemVer2""
+    }
+  ]
+}", json);
+            }
+        }
+
+        public class UpdateLatest : BaseFacts
+        {
+            [Fact]
+            public async Task SetsExpectedProperties()
+            {
+                var document = _target.UpdateLatest(
+                    _searchFilters,
+                    _versions,
+                    Data.NormalizedVersion,
+                    Data.FullVersion,
+                    Data.Leaf);
+
+                var json = await SerializationUtilities.SerializeToJsonAsync(document);
+                Assert.Equal(@"{
+  ""value"": [
+    {
+      ""@search.action"": ""upload"",
+      ""fullVersion"": ""7.1.2-alpha+git"",
+      ""lastEdited"": ""2017-01-02T00:00:00+00:00"",
+      ""published"": ""2017-01-03T00:00:00+00:00"",
+      ""versions"": [
+        ""1.0.0"",
+        ""2.0.0+git"",
+        ""3.0.0-alpha.1"",
+        ""7.1.2-alpha+git""
+      ],
+      ""semVerLevel"": 2,
+      ""authors"": ""Microsoft"",
+      ""copyright"": ""© Microsoft Corporation. All rights reserved."",
+      ""created"": ""2017-01-01T00:00:00+00:00"",
+      ""description"": ""Description."",
+      ""fileSize"": 3039254,
+      ""flattenedDependencies"": ""Microsoft.Data.OData:5.6.4:net40-client|Newtonsoft.Json:6.0.8:net40-client"",
+      ""hash"": ""oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33+Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ=="",
+      ""hashAlgorithm"": ""SHA512"",
+      ""iconUrl"": ""http://go.microsoft.com/fwlink/?LinkID=288890"",
+      ""language"": ""en-US"",
+      ""licenseUrl"": ""http://go.microsoft.com/fwlink/?LinkId=331471"",
+      ""minClientVersion"": ""2.12"",
+      ""normalizedVersion"": ""7.1.2-alpha"",
+      ""originalVersion"": ""7.1.2.0-alpha+git"",
+      ""packageId"": ""WindowsAzure.Storage"",
+      ""prerelease"": true,
+      ""projectUrl"": ""https://github.com/Azure/azure-storage-net"",
+      ""releaseNotes"": ""Release notes."",
+      ""requiresLicenseAcceptance"": true,
+      ""summary"": ""Summary."",
+      ""tags"": [
+        ""Microsoft"",
+        ""Azure"",
+        ""Storage"",
+        ""Table"",
+        ""Blob"",
+        ""File"",
+        ""Queue"",
+        ""Scalable"",
+        ""windowsazureofficial""
+      ],
+      ""title"": ""Windows Azure Storage"",
+      ""key"": ""windowsazure_storage-d2luZG93c2F6dXJlLnN0b3JhZ2U1-IncludePrereleaseAndSemVer2""
+    }
+  ]
+}", json);
+            }
+        }
+
+        public class Full : BaseFacts
+        {
+            [Fact]
+            public async Task SetsExpectedProperties()
+            {
+                var document = _target.Full(
+                    Data.PackageId,
+                    _searchFilters,
+                    _versions,
+                    Data.FullVersion,
+                    Data.PackageEntity,
+                    _owners,
+                    _totalDownloadCount);
+
+                var json = await SerializationUtilities.SerializeToJsonAsync(document);
+                Assert.Equal(@"{
+  ""value"": [
+    {
+      ""@search.action"": ""upload"",
+      ""totalDownloadCount"": 1001,
+      ""owners"": [
+        ""Microsoft"",
+        ""azure-sdk""
+      ],
+      ""fullVersion"": ""7.1.2-alpha+git"",
+      ""lastEdited"": ""2017-01-02T00:00:00+00:00"",
+      ""published"": ""2017-01-03T00:00:00+00:00"",
+      ""versions"": [
+        ""1.0.0"",
+        ""2.0.0+git"",
+        ""3.0.0-alpha.1"",
+        ""7.1.2-alpha+git""
+      ],
+      ""semVerLevel"": 2,
+      ""authors"": ""Microsoft"",
+      ""copyright"": ""© Microsoft Corporation. All rights reserved."",
+      ""created"": ""2017-01-01T00:00:00+00:00"",
+      ""description"": ""Description."",
+      ""fileSize"": 3039254,
+      ""flattenedDependencies"": ""Microsoft.Data.OData:5.6.4:net40-client|Newtonsoft.Json:6.0.8:net40-client"",
+      ""hash"": ""oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33+Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ=="",
+      ""hashAlgorithm"": ""SHA512"",
+      ""iconUrl"": ""http://go.microsoft.com/fwlink/?LinkID=288890"",
+      ""language"": ""en-US"",
+      ""licenseUrl"": ""http://go.microsoft.com/fwlink/?LinkId=331471"",
+      ""minClientVersion"": ""2.12"",
+      ""normalizedVersion"": ""7.1.2-alpha"",
+      ""originalVersion"": ""7.1.2.0-alpha+git"",
+      ""packageId"": ""WindowsAzure.Storage"",
+      ""prerelease"": true,
+      ""projectUrl"": ""https://github.com/Azure/azure-storage-net"",
+      ""releaseNotes"": ""Release notes."",
+      ""requiresLicenseAcceptance"": true,
+      ""summary"": ""Summary."",
+      ""tags"": [
+        ""Microsoft"",
+        ""Azure"",
+        ""Storage"",
+        ""Table"",
+        ""Blob"",
+        ""File"",
+        ""Queue"",
+        ""Scalable"",
+        ""windowsazureofficial""
+      ],
+      ""title"": ""Windows Azure Storage"",
+      ""key"": ""windowsazure_storage-d2luZG93c2F6dXJlLnN0b3JhZ2U1-IncludePrereleaseAndSemVer2""
+    }
+  ]
+}", json);
+            }
+
+            [Fact]
+            public void SplitsTags()
+            {
+                var package = Data.PackageEntity;
+                package.Tags = "foo; BAR |     Baz";
+                var document = _target.Full(
+                    Data.PackageId,
+                    _searchFilters,
+                    _versions,
+                    Data.FullVersion,
+                    package,
+                    _owners,
+                    _totalDownloadCount);
+
+                Assert.Equal(new[] { "foo", "BAR", "Baz" }, document.Tags);
+            }
+        }
+
+        public abstract class BaseFacts
+        {
+            protected readonly SearchFilters _searchFilters;
+            protected readonly string[] _versions;
+            protected readonly string[] _owners;
+            protected readonly int _totalDownloadCount;
+            protected readonly SearchDocumentBuilder _target;
+
+            public BaseFacts()
+            {
+                _searchFilters = SearchFilters.IncludePrereleaseAndSemVer2;
+                _versions = new[] { "1.0.0", "2.0.0+git", "3.0.0-alpha.1", Data.FullVersion };
+                _owners = new[] { "Microsoft", "azure-sdk" };
+                _totalDownloadCount = 1001;
+
+                _target = new SearchDocumentBuilder();
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/Support/SerializationUtilities.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Support/SerializationUtilities.cs
@@ -1,0 +1,138 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Search;
+using Microsoft.Azure.Search.Models;
+using NuGet.Protocol.Catalog;
+using NuGet.Services.Entities;
+using PackageDependency = NuGet.Protocol.Catalog.PackageDependency;
+
+namespace NuGet.Services.AzureSearch.Support
+{
+    public static class Data
+    {
+        public const string PackageId = "WindowsAzure.Storage";
+        public const string NormalizedVersion = "7.1.2-alpha";
+        public const string FullVersion = "7.1.2-alpha+git";
+
+        public static Package PackageEntity => new Package
+        {
+            FlattenedAuthors = "Microsoft",
+            Copyright = "© Microsoft Corporation. All rights reserved.",
+            Created = new DateTime(2017, 1, 1),
+            Description = "Description.",
+            FlattenedDependencies = "Microsoft.Data.OData:5.6.4:net40-client|Newtonsoft.Json:6.0.8:net40-client",
+            Hash = "oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33+Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ==",
+            HashAlgorithm = "SHA512",
+            IconUrl = "http://go.microsoft.com/fwlink/?LinkID=288890",
+            IsPrerelease = true,
+            Language = "en-US",
+            LastEdited = new DateTime(2017, 1, 2),
+            LicenseUrl = "http://go.microsoft.com/fwlink/?LinkId=331471",
+            Listed = true,
+            MinClientVersion = "2.12",
+            NormalizedVersion = "7.1.2-alpha",
+            PackageFileSize = 3039254,
+            ProjectUrl = "https://github.com/Azure/azure-storage-net",
+            Published = new DateTime(2017, 1, 3),
+            ReleaseNotes = "Release notes.",
+            RequiresLicenseAcceptance = true,
+            SemVerLevelKey = 2,
+            Summary = "Summary.",
+            Tags = "Microsoft Azure Storage Table Blob File Queue Scalable windowsazureofficial",
+            Title = "Windows Azure Storage",
+            Version = "7.1.2.0-alpha+git",
+        };
+
+        public static PackageDetailsCatalogLeaf Leaf => new PackageDetailsCatalogLeaf
+        {
+            Authors = "Microsoft",
+            Copyright = "© Microsoft Corporation. All rights reserved.",
+            Created = new DateTimeOffset(new DateTime(2017, 1, 1), TimeSpan.Zero),
+            Description = "Description.",
+            DependencyGroups = new List<PackageDependencyGroup>
+            {
+                new PackageDependencyGroup
+                {
+                    TargetFramework = ".NETFramework4.0-Client",
+                    Dependencies = new List<PackageDependency>
+                    {
+                        new PackageDependency
+                        {
+                            Id = "Microsoft.Data.OData",
+                            Range = "[5.6.4, )",
+                        },
+                        new PackageDependency
+                        {
+                            Id = "Newtonsoft.Json",
+                            Range = "[6.0.8, )",
+                        },
+                    },
+                },
+            },
+            IconUrl = "http://go.microsoft.com/fwlink/?LinkID=288890",
+            IsPrerelease = true,
+            Language = "en-US",
+            LastEdited = new DateTimeOffset(new DateTime(2017, 1, 2), TimeSpan.Zero),
+            LicenseUrl = "http://go.microsoft.com/fwlink/?LinkId=331471",
+            Listed = true,
+            MinClientVersion = "2.12",
+            PackageHash = "oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33+Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ==",
+            PackageHashAlgorithm = "SHA512",
+            PackageId = PackageId,
+            PackageSize = 3039254,
+            PackageVersion = FullVersion,
+            ProjectUrl = "https://github.com/Azure/azure-storage-net",
+            Published = new DateTimeOffset(new DateTime(2017, 1, 3), TimeSpan.Zero),
+            ReleaseNotes = "Release notes.",
+            RequireLicenseAgreement = true,
+            Summary = "Summary.",
+            Tags = new List<string> { "Microsoft", "Azure", "Storage", "Table", "Blob", "File", "Queue", "Scalable", "windowsazureofficial" },
+            Title = "Windows Azure Storage",
+            VerbatimVersion = "7.1.2.0-alpha+git",
+        };
+    }
+
+
+
+    public class SerializationUtilities
+    {
+        public static async Task<string> SerializeToJsonAsync<T>(T obj) where T : class
+        {
+            using (var testHandler = new TestHttpClientHandler())
+            using (var serviceClient = new SearchServiceClient(
+                "unit-test-service",
+                new SearchCredentials("unit-test-api-key"),
+                testHandler))
+            {
+                var indexClient = serviceClient.Indexes.GetClient("unit-test-index");
+                await indexClient.Documents.IndexAsync(IndexBatch.Upload(new[] { obj }));
+                return testHandler.LastRequestBody;
+            }
+        }
+
+        private class TestHttpClientHandler : HttpClientHandler
+        {
+            public string LastRequestBody { get; private set; }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                if (request.Content != null)
+                {
+                    LastRequestBody = await request.Content.ReadAsStringAsync();
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(LastRequestBody ?? string.Empty),
+                };
+            }
+        }
+    }
+}


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/6444
Progress on https://github.com/NuGet/NuGetGallery/issues/6445

This is just a bunch of mapping logic. I used JSON serialization to assert the mapping because this is exactly what is sent to Azure Search. It also covers when new fields are added.