### PR TITLE
Cat2Registration pipeline to support the license expression/file

### DIFF
--- a/src/Catalog/Registration/RegistrationCollector.cs
+++ b/src/Catalog/Registration/RegistrationCollector.cs
@@ -33,6 +33,7 @@ namespace NuGet.Services.Metadata.Catalog.Registration
             StorageFactory legacyStorageFactory,
             StorageFactory semVer2StorageFactory,
             Uri contentBaseAddress,
+            Uri galleryBaseAddress,
             ITelemetryService telemetryService,
             ILogger logger,
             Func<HttpMessageHandler> handlerFunc = null,
@@ -50,6 +51,7 @@ namespace NuGet.Services.Metadata.Catalog.Registration
             _semVer2StorageFactory = semVer2StorageFactory;
             _shouldIncludeSemVer2 = GetShouldIncludeRegistrationPackage(_semVer2StorageFactory);
             ContentBaseAddress = contentBaseAddress;
+            GalleryBaseAddress = galleryBaseAddress;
 
             if (maxConcurrentBatches < 1)
             {
@@ -63,6 +65,7 @@ namespace NuGet.Services.Metadata.Catalog.Registration
         }
 
         public Uri ContentBaseAddress { get; }
+        public Uri GalleryBaseAddress { get; }
 
         protected override Task<IEnumerable<CatalogCommitItemBatch>> CreateBatchesAsync(
             IEnumerable<CatalogCommitItem> catalogItems)
@@ -145,6 +148,7 @@ namespace NuGet.Services.Metadata.Catalog.Registration
                     shouldInclude: _shouldIncludeSemVer2,
                     storageFactory: _legacyStorageFactory,
                     contentBaseAddress: ContentBaseAddress,
+                    galleryBaseAddress: GalleryBaseAddress,
                     partitionSize: PartitionSize,
                     packageCountThreshold: PackageCountThreshold,
                     telemetryService: _telemetryService,
@@ -158,6 +162,7 @@ namespace NuGet.Services.Metadata.Catalog.Registration
                        newItems: sortedGraphs.Value,
                        storageFactory: _semVer2StorageFactory,
                        contentBaseAddress: ContentBaseAddress,
+                       galleryBaseAddress: GalleryBaseAddress,
                        partitionSize: PartitionSize,
                        packageCountThreshold: PackageCountThreshold,
                        telemetryService: _telemetryService,

--- a/src/Catalog/Registration/RegistrationMaker.cs
+++ b/src/Catalog/Registration/RegistrationMaker.cs
@@ -18,6 +18,7 @@ namespace NuGet.Services.Metadata.Catalog.Registration
             IReadOnlyDictionary<string, IGraph> newItems,
             StorageFactory storageFactory,
             Uri contentBaseAddress,
+            Uri galleryBaseAddress,
             int partitionSize,
             int packageCountThreshold,
             ITelemetryService telemetryService,
@@ -29,6 +30,7 @@ namespace NuGet.Services.Metadata.Catalog.Registration
                 (k, u, g) => true,
                 storageFactory,
                 contentBaseAddress,
+                galleryBaseAddress,
                 partitionSize,
                 packageCountThreshold,
                 telemetryService,
@@ -41,6 +43,7 @@ namespace NuGet.Services.Metadata.Catalog.Registration
             ShouldIncludeRegistrationPackage shouldInclude,
             StorageFactory storageFactory,
             Uri contentBaseAddress,
+            Uri galleryBaseAddress,
             int partitionSize,
             int packageCountThreshold,
             ITelemetryService telemetryService,
@@ -48,7 +51,7 @@ namespace NuGet.Services.Metadata.Catalog.Registration
         {
             Trace.TraceInformation("RegistrationMaker.Process: registrationKey = {0} newItems: {1}", registrationKey, newItems.Count);
 
-            IRegistrationPersistence registration = new RegistrationPersistence(storageFactory, registrationKey, partitionSize, packageCountThreshold, contentBaseAddress);
+            IRegistrationPersistence registration = new RegistrationPersistence(storageFactory, registrationKey, partitionSize, packageCountThreshold, contentBaseAddress, galleryBaseAddress);
 
             IDictionary<RegistrationEntryKey, RegistrationCatalogEntry> existing = await registration.Load(cancellationToken);
 
@@ -59,7 +62,8 @@ namespace NuGet.Services.Metadata.Catalog.Registration
             Trace.TraceInformation("RegistrationMaker.Process: delta = {0}", delta.Count);
             telemetryService.TrackMetric(TelemetryConstants.RegistrationDeltaCount, (uint)delta.Count, new Dictionary<string, string>()
             {
-                { TelemetryConstants.ContentBaseAddress, contentBaseAddress.AbsoluteUri }
+                { TelemetryConstants.ContentBaseAddress, contentBaseAddress.AbsoluteUri },
+                { TelemetryConstants.GalleryBaseAddress, galleryBaseAddress.AbsoluteUri }
             });
 
             IDictionary<RegistrationEntryKey, RegistrationCatalogEntry> resulting = Apply(existing, delta);

--- a/src/Catalog/Registration/RegistrationMakerCatalogItem.cs
+++ b/src/Catalog/Registration/RegistrationMakerCatalogItem.cs
@@ -189,7 +189,9 @@ namespace NuGet.Services.Metadata.Catalog.Registration
 
         private string GetOverWriteLicenseUrl(string id, string version)
         {
-            return string.Join("/", new string[] { _galleryBaseAddress.AbsoluteUri.TrimEnd('/'), "packages", id, version, "license" });
+            var uriBuilder = new UriBuilder(_galleryBaseAddress.AbsoluteUri);
+            uriBuilder.Path = string.Join("/", new string[] { "packages", id, version, "license" });
+            return uriBuilder.Uri.ToString();
         }
 
         public override IGraph CreatePageContent(CatalogContext context)

--- a/src/Catalog/Registration/RegistrationMakerCatalogItem.cs
+++ b/src/Catalog/Registration/RegistrationMakerCatalogItem.cs
@@ -19,6 +19,7 @@ namespace NuGet.Services.Metadata.Catalog.Registration
         private readonly IGraph _catalogItem;
         private Uri _itemAddress;
         private readonly Uri _packageContentBaseAddress;
+        private readonly Uri _galleryBaseAddress;
         private Uri _packageContentAddress;
         private readonly Uri _registrationBaseAddress;
         private Uri _registrationAddress;
@@ -28,11 +29,12 @@ namespace NuGet.Services.Metadata.Catalog.Registration
         // This should be set before class is instantiated
         public static IPackagePathProvider PackagePathProvider = null;
 
-        public RegistrationMakerCatalogItem(Uri catalogUri, IGraph catalogItem, Uri registrationBaseAddress, bool isExistingItem, Uri packageContentBaseAddress = null)
+        public RegistrationMakerCatalogItem(Uri catalogUri, IGraph catalogItem, Uri registrationBaseAddress, bool isExistingItem, Uri packageContentBaseAddress = null, Uri galleryBaseAddress = null)
         {
             _catalogUri = catalogUri;
             _catalogItem = catalogItem;
             _packageContentBaseAddress = packageContentBaseAddress;
+            _galleryBaseAddress = galleryBaseAddress;
             _registrationBaseAddress = registrationBaseAddress;
 
             IsExistingItem = isExistingItem;
@@ -155,6 +157,41 @@ namespace NuGet.Services.Metadata.Catalog.Registration
             return _packageContentAddress;
         }
 
+        private string GetLicenseUrl()
+        {
+            INode subject = _catalogItem.CreateUriNode(_catalogUri);
+
+            string id = _catalogItem.GetTriplesWithSubjectPredicate(subject, _catalogItem.CreateUriNode(Schema.Predicates.Id)).FirstOrDefault().Object.ToString();
+            string version = _catalogItem.GetTriplesWithSubjectPredicate(subject, _catalogItem.CreateUriNode(Schema.Predicates.Version)).FirstOrDefault().Object.ToString();
+            Triple licenseExpression = _catalogItem.GetTriplesWithSubjectPredicate(subject, _catalogItem.CreateUriNode(Schema.Predicates.LicenseExpression)).FirstOrDefault();
+            Triple licenseFile = _catalogItem.GetTriplesWithSubjectPredicate(subject, _catalogItem.CreateUriNode(Schema.Predicates.LicenseFile)).FirstOrDefault();
+            Triple licenseUrl = _catalogItem.GetTriplesWithSubjectPredicate(subject, _catalogItem.CreateUriNode(Schema.Predicates.LicenseUrl)).FirstOrDefault();
+
+            if (_galleryBaseAddress != null)
+            {
+                if (licenseExpression != null && !string.IsNullOrWhiteSpace(licenseExpression.Object.ToString()))
+                {
+                    return GetOverWriteLicenseUrl(id, version);
+                }
+                if (licenseFile != null && !string.IsNullOrWhiteSpace(licenseFile.Object.ToString()))
+                {
+                    return GetOverWriteLicenseUrl(id, version);
+                }
+            }
+
+            if (licenseUrl != null)
+            {
+                return licenseUrl.Object.ToString();
+            }
+
+            return string.Empty;
+        }
+
+        private string GetOverWriteLicenseUrl(string id, string version)
+        {
+            return string.Join("/", new string[] { _galleryBaseAddress.AbsoluteUri.TrimEnd('/'), "packages", id, version, "license" });
+        }
+
         public override IGraph CreatePageContent(CatalogContext context)
         {
             try
@@ -173,6 +210,7 @@ namespace NuGet.Services.Metadata.Catalog.Registration
                     sparql.SetUri("baseAddress", BaseAddress);
                     sparql.SetUri("packageContent", GetPackageContentAddress());
                     sparql.SetUri("registrationBaseAddress", _registrationBaseAddress);
+                    sparql.SetLiteral("licenseUrl", GetLicenseUrl());
 
                     content = SparqlHelpers.Construct(store, sparql.ToString());
                 }

--- a/src/Catalog/Schema.cs
+++ b/src/Catalog/Schema.cs
@@ -148,6 +148,9 @@ namespace NuGet.Services.Metadata.Catalog
             public static readonly Uri Surname = new Uri(Prefixes.NuGet + "surname");
             public static readonly Uri Email = new Uri(Prefixes.NuGet + "email");
             public static readonly Uri Iss = new Uri(Prefixes.NuGet + "iss");
+
+            public static readonly Uri LicenseExpression = new Uri(Prefixes.NuGet + "licenseExpression");
+            public static readonly Uri LicenseFile = new Uri(Prefixes.NuGet + "licenseFile");
         }
     }
 }

--- a/src/Catalog/Telemetry/TelemetryConstants.cs
+++ b/src/Catalog/Telemetry/TelemetryConstants.cs
@@ -17,6 +17,7 @@ namespace NuGet.Services.Metadata.Catalog
         public const string PackageAlreadyHasHash = "PackageAlreadyHasHash";
         public const string PackageHashFixed = "PackageHashFixed";
         public const string ContentBaseAddress = "ContentBaseAddress";
+        public const string GalleryBaseAddress = "GalleryBaseAddress";
         public const string ContentLength = "ContentLength";
         public const string CreatedPackagesCount = "CreatedPackagesCount";
         public const string CreatedPackagesSeconds = "CreatedPackagesSeconds";

--- a/src/Catalog/sparql/ConstructCatalogEntryGraph.rq
+++ b/src/Catalog/sparql/ConstructCatalogEntryGraph.rq
@@ -15,6 +15,7 @@ CONSTRUCT
                   nuget:summary ?summary ;
                   nuget:iconUrl ?iconUrl ;
                   nuget:licenseUrl ?licenseUrl ;
+				  nuget:licenseExpression ?licenseExpression ;
                   nuget:projectUrl ?projectUrl ;
                   nuget:requireLicenseAcceptance ?requireLicenseAcceptance ;
                   nuget:language ?language ;
@@ -38,14 +39,15 @@ WHERE
     ?catalogEntry nuget:version ?version ;
                   nuget:id ?id ;
 	              nuget:published ?published ;
-	              OPTIONAL { ?catalogEntry nuget:packageContent ?packageContent . }
-    
+
+	OPTIONAL { ?catalogEntry nuget:packageContent ?packageContent . }
 	OPTIONAL { ?catalogEntry nuget:listed ?listed . }
     OPTIONAL { ?catalogEntry nuget:description ?description . }
     OPTIONAL { ?catalogEntry nuget:title ?title . }
     OPTIONAL { ?catalogEntry nuget:summary ?summary . }
     OPTIONAL { ?catalogEntry nuget:iconUrl ?iconUrl . }
     OPTIONAL { ?catalogEntry nuget:licenseUrl ?licenseUrl . }
+	OPTIONAL { ?catalogEntry nuget:licenseExpression ?licenseExpression . }
     OPTIONAL { ?catalogEntry nuget:projectUrl ?projectUrl . }
     OPTIONAL { ?catalogEntry nuget:requireLicenseAcceptance ?requireLicenseAcceptance . }
     OPTIONAL { ?catalogEntry nuget:language ?language . }

--- a/src/Catalog/sparql/ConstructCatalogEntryGraph.rq
+++ b/src/Catalog/sparql/ConstructCatalogEntryGraph.rq
@@ -15,7 +15,7 @@ CONSTRUCT
                   nuget:summary ?summary ;
                   nuget:iconUrl ?iconUrl ;
                   nuget:licenseUrl ?licenseUrl ;
-				  nuget:licenseExpression ?licenseExpression ;
+                  nuget:licenseExpression ?licenseExpression ;
                   nuget:projectUrl ?projectUrl ;
                   nuget:requireLicenseAcceptance ?requireLicenseAcceptance ;
                   nuget:language ?language ;
@@ -47,7 +47,7 @@ WHERE
     OPTIONAL { ?catalogEntry nuget:summary ?summary . }
     OPTIONAL { ?catalogEntry nuget:iconUrl ?iconUrl . }
     OPTIONAL { ?catalogEntry nuget:licenseUrl ?licenseUrl . }
-	OPTIONAL { ?catalogEntry nuget:licenseExpression ?licenseExpression . }
+    OPTIONAL { ?catalogEntry nuget:licenseExpression ?licenseExpression . }
     OPTIONAL { ?catalogEntry nuget:projectUrl ?projectUrl . }
     OPTIONAL { ?catalogEntry nuget:requireLicenseAcceptance ?requireLicenseAcceptance . }
     OPTIONAL { ?catalogEntry nuget:language ?language . }

--- a/src/Catalog/sparql/ConstructRegistrationPageContentGraph.rq
+++ b/src/Catalog/sparql/ConstructRegistrationPageContentGraph.rq
@@ -20,7 +20,7 @@ CONSTRUCT
                   nuget:summary ?summary ;
                   nuget:iconUrl ?iconUrl ;
                   nuget:licenseUrl ?licenseUrl ;
-				  nuget:licenseExpression ?licenseExpression ;
+                  nuget:licenseExpression ?licenseExpression ;
                   nuget:projectUrl ?projectUrl ;
                   nuget:requireLicenseAcceptance ?requireLicenseAcceptance ;
                   nuget:language ?language ;

--- a/src/Catalog/sparql/ConstructRegistrationPageContentGraph.rq
+++ b/src/Catalog/sparql/ConstructRegistrationPageContentGraph.rq
@@ -11,7 +11,7 @@ CONSTRUCT
     ?catalogEntry a nuget:PackageDetails ;
                   nuget:id ?id ;
                   nuget:version ?version ;
-				  nuget:published ?published ;
+                  nuget:published ?published ;
                   nuget:packageContent ?packageContent ;
                   nuget:dependencyGroup ?dependency_group ;
                   nuget:listed ?listed ;

--- a/src/Catalog/sparql/ConstructRegistrationPageContentGraph.rq
+++ b/src/Catalog/sparql/ConstructRegistrationPageContentGraph.rq
@@ -11,7 +11,7 @@ CONSTRUCT
     ?catalogEntry a nuget:PackageDetails ;
                   nuget:id ?id ;
                   nuget:version ?version ;
-	              nuget:published ?published ;
+				  nuget:published ?published ;
                   nuget:packageContent ?packageContent ;
                   nuget:dependencyGroup ?dependency_group ;
                   nuget:listed ?listed ;
@@ -20,10 +20,11 @@ CONSTRUCT
                   nuget:summary ?summary ;
                   nuget:iconUrl ?iconUrl ;
                   nuget:licenseUrl ?licenseUrl ;
+				  nuget:licenseExpression ?licenseExpression ;
                   nuget:projectUrl ?projectUrl ;
                   nuget:requireLicenseAcceptance ?requireLicenseAcceptance ;
                   nuget:language ?language ;
-                  nuget:authors ?authors ;
+				  nuget:authors ?authors ;
                   nuget:tag ?tag ;
                   nuget:minClientVersion ?minClientVersion .
 
@@ -44,19 +45,21 @@ WHERE
 
 	BIND (IRI(CONCAT(STR(@baseAddress), "index.json")) AS ?registration)
 
+	BIND(@licenseUrl AS ?licenseUrl)
+
     ?catalogEntry nuget:version ?version ;
                   nuget:id ?id ;
 	              nuget:published ?published .
 
 	OPTIONAL { ?catalogEntry nuget:packageContent ?optionalPackageContent . }
-
 	BIND(COALESCE(?optionalPackageContent, @packageContent) AS ?packageContent)
 
 	OPTIONAL { ?catalogEntry nuget:description ?optionalDescription . }
 	OPTIONAL { ?catalogEntry nuget:title ?optionalTitle . }
 	OPTIONAL { ?catalogEntry nuget:summary ?optionalSummary . }
 	OPTIONAL { ?catalogEntry nuget:iconUrl ?optionalIconUrl . }
-	OPTIONAL { ?catalogEntry nuget:licenseUrl ?optionalLicenseUrl . }
+	OPTIONAL { ?catalogEntry nuget:licenseUrl ?licenseUrl . }
+	OPTIONAL { ?catalogEntry nuget:licenseExpression ?optionalLicenseExpression . }
 	OPTIONAL { ?catalogEntry nuget:projectUrl ?optionalProjectUrl . }
 	OPTIONAL { ?catalogEntry nuget:requireLicenseAcceptance ?optionalRequireLicenseAcceptance . }
 	OPTIONAL { ?catalogEntry nuget:language ?optionalLanguage . }
@@ -69,7 +72,7 @@ WHERE
 	BIND(COALESCE(?optionalTitle, "") AS ?title)
 	BIND(COALESCE(?optionalSummary, "") AS ?summary)
 	BIND(COALESCE(?optionalIconUrl, "") AS ?iconUrl)
-	BIND(COALESCE(?optionalLicenseUrl, "") AS ?licenseUrl)
+	BIND(COALESCE(?optionalLicenseExpression, "") AS ?licenseExpression)
 	BIND(COALESCE(?optionalProjectUrl, "") AS ?projectUrl)
 	BIND(COALESCE(?optionalRequireLicenseAcceptance, false) AS ?requireLicenseAcceptance)
 	BIND(COALESCE(?optionalLanguage, "") AS ?language)

--- a/src/Catalog/sparql/ConstructRegistrationPageContentGraph.rq
+++ b/src/Catalog/sparql/ConstructRegistrationPageContentGraph.rq
@@ -24,7 +24,7 @@ CONSTRUCT
                   nuget:projectUrl ?projectUrl ;
                   nuget:requireLicenseAcceptance ?requireLicenseAcceptance ;
                   nuget:language ?language ;
-				  nuget:authors ?authors ;
+                  nuget:authors ?authors ;
                   nuget:tag ?tag ;
                   nuget:minClientVersion ?minClientVersion .
 

--- a/src/Ng/Arguments.cs
+++ b/src/Ng/Arguments.cs
@@ -37,6 +37,7 @@ namespace Ng
 
         public const string ConnectionString = "connectionString";
         public const string ContentBaseAddress = "contentBaseAddress";
+        public const string GalleryBaseAddress = "galleryBaseAddress";
         public const string StorageAccountName = "storageAccountName";
         public const string StorageBaseAddress = "storageBaseAddress";
         public const string StorageContainer = "storageContainer";

--- a/src/Ng/Jobs/Catalog2RegistrationJob.cs
+++ b/src/Ng/Jobs/Catalog2RegistrationJob.cs
@@ -29,6 +29,7 @@ namespace Ng.Jobs
             return "Usage: ng catalog2registration "
                    + $"-{Arguments.Source} <catalog> "
                    + $"-{Arguments.ContentBaseAddress} <content-address> "
+                   + $"-{Arguments.GalleryBaseAddress} <gallery-base-address> "
                    + $"-{Arguments.StorageBaseAddress} <storage-base-address> "
                    + $"-{Arguments.StorageType} file|azure "
                    + $"[-{Arguments.StoragePath} <path>]"
@@ -71,6 +72,7 @@ namespace Ng.Jobs
             var verbose = arguments.GetOrDefault(Arguments.Verbose, false);
 
             var contentBaseAddress = arguments.GetOrDefault<string>(Arguments.ContentBaseAddress);
+            var galleryBaseAddress = arguments.GetOrDefault<string>(Arguments.GalleryBaseAddress);
             var isContentFlatContainer = arguments.GetOrDefault<bool>(Arguments.ContentIsFlatContainer);
 
             // The term "legacy" here refers to the registration hives that do not contain any SemVer 2.0.0 packages.
@@ -103,6 +105,7 @@ namespace Ng.Jobs
                 storageFactories.LegacyStorageFactory,
                 storageFactories.SemVer2StorageFactory,
                 contentBaseAddress == null ? null : new Uri(contentBaseAddress),
+                galleryBaseAddress == null ? null : new Uri(galleryBaseAddress),
                 TelemetryService,
                 Logger,
                 CommandHelpers.GetHttpMessageHandlerFactory(TelemetryService, verbose));

--- a/src/Ng/Jobs/LightningJob.cs
+++ b/src/Ng/Jobs/LightningJob.cs
@@ -51,6 +51,9 @@ namespace Ng.Jobs
             sw.WriteLine($"  -{Arguments.ContentBaseAddress} <content-address>");
             sw.WriteLine($"      The base address for package contents.");
             sw.WriteLine();
+            sw.WriteLine($"  -{Arguments.GalleryBaseAddress} <gallery-base-address>");
+            sw.WriteLine($"      The base address for gallery.");
+            sw.WriteLine();
             sw.WriteLine($"  -{Arguments.Verbose} true|false");
             sw.WriteLine($"      Switch output verbosity on/off.");
             sw.WriteLine();
@@ -130,6 +133,7 @@ namespace Ng.Jobs
         private bool _verbose;
         private TextWriter _log;
         private string _contentBaseAddress;
+        private string _galleryBaseAddress;
         private RegistrationStorageFactories _storageFactories;
         private ShouldIncludeRegistrationPackage _shouldIncludeSemVer2;
         private IDictionary<string, string> _arguments;
@@ -170,6 +174,7 @@ namespace Ng.Jobs
             _verbose = arguments.GetOrDefault(Arguments.Verbose, false);
             _log = _verbose ? Console.Out : new StringWriter();
             _contentBaseAddress = arguments.GetOrThrow<string>(Arguments.ContentBaseAddress);
+            _galleryBaseAddress = arguments.GetOrThrow<string>(Arguments.GalleryBaseAddress);
             _storageFactories = CommandHelpers.CreateRegistrationStorageFactories(arguments, _verbose);
             _shouldIncludeSemVer2 = RegistrationCollector.GetShouldIncludeRegistrationPackage(_storageFactories.SemVer2StorageFactory);
             // We save the arguments because the "prepare" command generates "strike" commands. Some of the arguments
@@ -483,6 +488,7 @@ namespace Ng.Jobs
                 _shouldIncludeSemVer2,
                 _storageFactories.LegacyStorageFactory,
                 new Uri(_contentBaseAddress),
+                new Uri(_galleryBaseAddress),
                 RegistrationCollector.PartitionSize,
                 RegistrationCollector.PackageCountThreshold,
                 TelemetryService,
@@ -495,6 +501,7 @@ namespace Ng.Jobs
                     sortedGraphs,
                     _storageFactories.SemVer2StorageFactory,
                     new Uri(_contentBaseAddress),
+                    new Uri(_galleryBaseAddress),
                     RegistrationCollector.PartitionSize,
                     RegistrationCollector.PackageCountThreshold,
                     TelemetryService,

--- a/src/Ng/Scripts/Catalog2RegistrationV3-Reg3-China.cmd
+++ b/src/Ng/Scripts/Catalog2RegistrationV3-Reg3-China.cmd
@@ -36,7 +36,8 @@ start /w ng.exe catalog2registration ^
     -cursorUri #{Jobs.China.catalog2registrationv3reg3.CursorUri} ^
     -flatContainerName #{Jobs.China.catalog2registrationv3reg3.FlatContainerName} ^
     -storageOperationMaxExecutionTimeInSeconds #{Jobs.Common.China.AzureOperationMaxTimeout} ^
-    -storageServerTimeoutInSeconds #{Jobs.Common.China.StorageServerTimeoutInSeconds}
+    -storageServerTimeoutInSeconds #{Jobs.Common.China.StorageServerTimeoutInSeconds} ^
+    -galleryBaseAddress #{Jobs.China.catalog2registrationv3reg3.GalleryBaseAddress}
 
 echo "Finished #{Jobs.China.catalog2registrationv3reg3.Title}"
 

--- a/src/Ng/Scripts/Catalog2RegistrationV3-Reg3.cmd
+++ b/src/Ng/Scripts/Catalog2RegistrationV3-Reg3.cmd
@@ -33,7 +33,8 @@ start /w ng.exe catalog2registration ^
     -semVer2StorageContainer #{Jobs.catalog2registrationv3reg3.StorageContainerSemVer2} ^
     -contentIsFlatContainer #{Jobs.catalog2registrationv3reg3.IsContentFlatContainer} ^
     -cursorUri #{Jobs.catalog2registrationv3reg3.CursorUri} ^
-    -flatContainerName #{Jobs.catalog2registrationv3reg3.FlatContainerName}
+    -flatContainerName #{Jobs.catalog2registrationv3reg3.FlatContainerName} ^
+    -galleryBaseAddress #{Jobs.catalog2registrationv3reg3.GalleryBaseAddress}
 
 echo "Finished #{Jobs.catalog2registrationv3reg3.Title}"
 

--- a/src/V3PerPackage/GlobalContext.cs
+++ b/src/V3PerPackage/GlobalContext.cs
@@ -10,18 +10,20 @@ namespace NuGet.Services.V3PerPackage
     /// </summary>
     public class GlobalContext
     {
-        public GlobalContext(string storageBaseAddress, string storageAccountName, string storageKeyValue, Uri contentBaseAddress)
+        public GlobalContext(string storageBaseAddress, string storageAccountName, string storageKeyValue, Uri contentBaseAddress, Uri galleryBaseAddress)
         {
             StorageBaseAddress = storageBaseAddress;
             StorageAccountName = storageAccountName;
             StorageKeyValue = storageKeyValue;
             ContentBaseAddress = contentBaseAddress;
+            GalleryBaseAddress = galleryBaseAddress;
         }
 
         public string StorageBaseAddress { get; }
         public string StorageAccountName { get; }
         public string StorageKeyValue { get; }
         public Uri ContentBaseAddress { get; }
+        public Uri GalleryBaseAddress { get; }
 
         public string CatalogContainerName => "v3-catalog";
         public string FlatContainerContainerName => "v3-flatcontainer";

--- a/src/V3PerPackage/PerBatchProcessor.cs
+++ b/src/V3PerPackage/PerBatchProcessor.cs
@@ -254,6 +254,7 @@ namespace NuGet.Services.V3PerPackage
                 registrationStorageFactories.LegacyStorageFactory,
                 registrationStorageFactories.SemVer2StorageFactory,
                 context.Global.ContentBaseAddress,
+                context.Global.GalleryBaseAddress,
                 serviceProvider.GetRequiredService<ITelemetryService>(),
                 _logger,
                 () => serviceProvider.GetRequiredService<HttpMessageHandler>());

--- a/src/V3PerPackage/Program.cs
+++ b/src/V3PerPackage/Program.cs
@@ -180,7 +180,8 @@ namespace NuGet.Services.V3PerPackage
                     settings.Value.StorageBaseAddress,
                     settings.Value.StorageAccountName,
                     settings.Value.StorageKeyValue,
-                    settings.Value.ContentBaseAddress);
+                    settings.Value.ContentBaseAddress,
+                    settings.Value.GalleryBaseAddress);
             });
 
             serviceCollection.AddSingleton(new TelemetryClient());

--- a/src/V3PerPackage/Settings.example.json
+++ b/src/V3PerPackage/Settings.example.json
@@ -5,6 +5,7 @@
     "StorageAccountName": "example",
     "StorageKeyValue": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
     "InstrumentationKey": "46b47802-8492-4acb-a372-ac862fb645b9",
-    "ContentBaseAddress": "https://api.nuget.org/packages/"
+    "ContentBaseAddress": "https://api.nuget.org/packages/",
+    "GalleryBaseAddress": "https://nuget.org"
   }
 }

--- a/src/V3PerPackage/Settings.example.json
+++ b/src/V3PerPackage/Settings.example.json
@@ -6,6 +6,6 @@
     "StorageKeyValue": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
     "InstrumentationKey": "46b47802-8492-4acb-a372-ac862fb645b9",
     "ContentBaseAddress": "https://api.nuget.org/packages/",
-    "GalleryBaseAddress": "www.nuget.org"
+    "GalleryBaseAddress": "https://www.nuget.org"
   }
 }

--- a/src/V3PerPackage/Settings.example.json
+++ b/src/V3PerPackage/Settings.example.json
@@ -6,6 +6,6 @@
     "StorageKeyValue": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
     "InstrumentationKey": "46b47802-8492-4acb-a372-ac862fb645b9",
     "ContentBaseAddress": "https://api.nuget.org/packages/",
-    "GalleryBaseAddress": "https://nuget.org"
+    "GalleryBaseAddress": "www.nuget.org"
   }
 }

--- a/src/V3PerPackage/V3PerPackageConfiguration.cs
+++ b/src/V3PerPackage/V3PerPackageConfiguration.cs
@@ -12,6 +12,7 @@ namespace NuGet.Services.V3PerPackage
         public string StorageAccountName { get; set; }
         public string StorageKeyValue { get; set; }
         public Uri ContentBaseAddress { get; set; }
+        public Uri GalleryBaseAddress { get; set; }
         public string InstrumentationKey { get; set; }
     }
 }

--- a/tests/CatalogTests/Registration/RegistrationCollectorTests.cs
+++ b/tests/CatalogTests/Registration/RegistrationCollectorTests.cs
@@ -56,7 +56,7 @@ namespace CatalogTests.Registration
         private MemoryStorage _semVer2Storage;
         private TestStorageFactory _semVer2StorageFactory;
 
-        private void SharedInit(bool useLegacy, bool useSemVer2, Uri baseUri = null, Uri indexUri = null, Uri contentBaseUri = null)
+        private void SharedInit(bool useLegacy, bool useSemVer2, Uri baseUri = null, Uri indexUri = null, Uri contentBaseUri = null, Uri galleryBaseUri = null)
         {
             if (useLegacy)
             {
@@ -78,6 +78,7 @@ namespace CatalogTests.Registration
                 _legacyStorageFactory,
                 _semVer2StorageFactory,
                 contentBaseUri ?? new Uri("http://tempuri.org/packages"),
+                galleryBaseUri ?? new Uri("http://tempuri.org/gallery"),
                 Mock.Of<ITelemetryService>(),
                 Mock.Of<ILogger>(),
                 handlerFunc: () => _mockServer,
@@ -98,6 +99,7 @@ namespace CatalogTests.Registration
                     _baseUri,
                     storageFactory,
                     storageFactory,
+                    _baseUri,
                     _baseUri,
                     Mock.Of<ITelemetryService>(),
                     Mock.Of<ILogger>(),

--- a/tests/CatalogTests/Registration/RegistrationMakerCatalogItemTests.cs
+++ b/tests/CatalogTests/Registration/RegistrationMakerCatalogItemTests.cs
@@ -109,38 +109,43 @@ namespace CatalogTests.Registration
             }
 
             [Theory]
-            [InlineData(false, false, false, "", "", "http://gallery.org")]
-            [InlineData(true, false, false, "https://test.org", "", "http://gallery.org")]
-            [InlineData(true, true, false, "http://gallery.org/packages/MyPackage/1.2.3/license", "MIT", "http://gallery.org")]
-            [InlineData(true, false, true, "http://gallery.org/packages/MyPackage/1.2.3/license", "", "http://gallery.org")]
-            [InlineData(false, true, false, "http://gallery.org/packages/MyPackage/1.2.3/license", "MIT", "http://gallery.org")]
-            [InlineData(false, false, true, "http://gallery.org/packages/MyPackage/1.2.3/license", "", "http://gallery.org")]
-            [InlineData(false, false, true, "http://gallery.org/packages/MyPackage/1.2.3/license", "", "http://gallery.org/")]
-            [InlineData(false, false, true, "http://gallery.org/packages/MyPackage/1.2.3/license", "", "http://gallery.org//")]
-            public void CreatePageContent_SetsLicenseUrlAndExpressionProperly(bool hasLicenseUrl, bool hasLicenseExpression, bool hasLicenseFile,
-                                                                             string expectedLicenseUrlValue, string expectedLicenseExpressionValue, string galleryBaseAddress)
+            [InlineData(null, null, null, "", "http://gallery.org")]
+            [InlineData("https://test.org", null, null, "https://test.org", "http://gallery.org")]
+            [InlineData("https://test.org", "TestExpression", null, "http://gallery.org/packages/MyPackage/1.2.3/license", "http://gallery.org")]
+            [InlineData("https://test.org", null, "TestLicense", "http://gallery.org/packages/MyPackage/1.2.3/license", "http://gallery.org")]
+            [InlineData(null, "TestExpression", null, "http://gallery.org/packages/MyPackage/1.2.3/license", "http://gallery.org")]
+            [InlineData(null, null, "TestLicense", "http://gallery.org/packages/MyPackage/1.2.3/license", "http://gallery.org")]
+            [InlineData(null, null, "TestFile", "http://gallery.org/packages/MyPackage/1.2.3/license", "http://gallery.org")]
+            [InlineData(null, null, "TestLicense.txt", "http://gallery.org/packages/MyPackage/1.2.3/license", "http://gallery.org")]
+            [InlineData(null, null, "TestLicense.exe", "http://gallery.org/packages/MyPackage/1.2.3/license", "http://gallery.org")]
+            [InlineData(null, null, "TestLicense.any", "http://gallery.org/packages/MyPackage/1.2.3/license", "http://gallery.org")]
+            [InlineData(null, null, "/Folder/TestLicense", "http://gallery.org/packages/MyPackage/1.2.3/license", "http://gallery.org")]
+            [InlineData(null, null, "TestLicense", "http://gallery.org/packages/MyPackage/1.2.3/license", "http://gallery.org/")]
+            [InlineData(null, null, "TestLicense", "http://gallery.org/packages/MyPackage/1.2.3/license", "http://gallery.org//")]
+            public void CreatePageContent_SetsLicenseUrlAndExpressionProperly(string licenseUrl, string licenseExpression, string licenseFile,
+                                                                             string expectedLicenseUrlValue, string galleryBaseAddress)
             {
                 // Arrange
-                if (hasLicenseUrl)
+                if (licenseUrl != null)
                 {
                     _graph.Assert(
                     _graph.CreateUriNode(_catalogUri),
                     _graph.CreateUriNode(Schema.Predicates.LicenseUrl),
-                    _graph.CreateLiteralNode("https://test.org"));
+                    _graph.CreateLiteralNode(licenseUrl));
                 }
-                if (hasLicenseExpression)
+                if (licenseExpression != null)
                 {
                     _graph.Assert(
                     _graph.CreateUriNode(_catalogUri),
                     _graph.CreateUriNode(Schema.Predicates.LicenseExpression),
-                    _graph.CreateLiteralNode("MIT"));
+                    _graph.CreateLiteralNode(licenseExpression));
                 }
-                if (hasLicenseFile)
+                if (licenseFile != null)
                 {
                     _graph.Assert(
                     _graph.CreateUriNode(_catalogUri),
                     _graph.CreateUriNode(Schema.Predicates.LicenseFile),
-                    _graph.CreateLiteralNode("license"));
+                    _graph.CreateLiteralNode(licenseFile));
                 }
 
                 var item = new RegistrationMakerCatalogItem(
@@ -172,7 +177,7 @@ namespace CatalogTests.Registration
                 Assert.Equal(1, licenseUrlTriples.Count());
                 Assert.Equal(expectedLicenseUrlValue, licenseUrlTriples.First().Object.ToString());
                 Assert.Equal(1, licenseExpressionTriples.Count());
-                Assert.Equal(expectedLicenseExpressionValue, licenseExpressionTriples.First().Object.ToString());
+                Assert.Equal(licenseExpression == null ? "" : licenseExpression, licenseExpressionTriples.First().Object.ToString());
                 Assert.Equal(0, licenseFileTriples.Count());
             }
         }

--- a/tests/CatalogTests/Registration/RegistrationMakerCatalogItemTests.cs
+++ b/tests/CatalogTests/Registration/RegistrationMakerCatalogItemTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using Newtonsoft.Json.Linq;
 using NuGet.Services.Metadata.Catalog;
 using NuGet.Services.Metadata.Catalog.Persistence;
@@ -79,6 +80,100 @@ namespace CatalogTests.Registration
             using (var reader = new StreamReader(content.GetContentStream()))
             {
                 return reader.ReadToEnd();
+            }
+        }
+
+        public class CreatePageContent_SetsLicenseUrlAndExpression
+        {
+            private readonly Uri _catalogUri = new Uri("http://example/catalog/mypackage.1.0.0.json");
+            private readonly Uri _registrationBaseAddress = new Uri("http://example/registration/");
+            private readonly Uri _packageContentBaseAddress = new Uri("http://example/content/");
+            private readonly Uri _baseAddress = new Uri("http://example/registration/mypackage/");
+            private Graph _graph;
+
+            public CreatePageContent_SetsLicenseUrlAndExpression()
+            {
+                _graph = new Graph();
+                _graph.Assert(
+                    _graph.CreateUriNode(_catalogUri),
+                    _graph.CreateUriNode(Schema.Predicates.Id),
+                    _graph.CreateLiteralNode("MyPackage"));
+                _graph.Assert(
+                    _graph.CreateUriNode(_catalogUri),
+                    _graph.CreateUriNode(Schema.Predicates.Version),
+                    _graph.CreateLiteralNode("01.02.03+ABC"));
+                _graph.Assert(
+                    _graph.CreateUriNode(_catalogUri),
+                    _graph.CreateUriNode(Schema.Predicates.Published),
+                    _graph.CreateLiteralNode("2015-01-01T00:00:00+00:00"));
+            }
+
+            [Theory]
+            [InlineData(false, false, false, "", "", "http://gallery.org")]
+            [InlineData(true, false, false, "https://test.org", "", "http://gallery.org")]
+            [InlineData(true, true, false, "http://gallery.org/packages/MyPackage/1.2.3/license", "MIT", "http://gallery.org")]
+            [InlineData(true, false, true, "http://gallery.org/packages/MyPackage/1.2.3/license", "", "http://gallery.org")]
+            [InlineData(false, true, false, "http://gallery.org/packages/MyPackage/1.2.3/license", "MIT", "http://gallery.org")]
+            [InlineData(false, false, true, "http://gallery.org/packages/MyPackage/1.2.3/license", "", "http://gallery.org")]
+            [InlineData(false, false, true, "http://gallery.org/packages/MyPackage/1.2.3/license", "", "http://gallery.org/")]
+            [InlineData(false, false, true, "http://gallery.org/packages/MyPackage/1.2.3/license", "", "http://gallery.org//")]
+            public void CreatePageContent_SetsLicenseUrlAndExpressionProperly(bool hasLicenseUrl, bool hasLicenseExpression, bool hasLicenseFile,
+                                                                             string expectedLicenseUrlValue, string expectedLicenseExpressionValue, string galleryBaseAddress)
+            {
+                // Arrange
+                if (hasLicenseUrl)
+                {
+                    _graph.Assert(
+                    _graph.CreateUriNode(_catalogUri),
+                    _graph.CreateUriNode(Schema.Predicates.LicenseUrl),
+                    _graph.CreateLiteralNode("https://test.org"));
+                }
+                if (hasLicenseExpression)
+                {
+                    _graph.Assert(
+                    _graph.CreateUriNode(_catalogUri),
+                    _graph.CreateUriNode(Schema.Predicates.LicenseExpression),
+                    _graph.CreateLiteralNode("MIT"));
+                }
+                if (hasLicenseFile)
+                {
+                    _graph.Assert(
+                    _graph.CreateUriNode(_catalogUri),
+                    _graph.CreateUriNode(Schema.Predicates.LicenseFile),
+                    _graph.CreateLiteralNode("license"));
+                }
+
+                var item = new RegistrationMakerCatalogItem(
+                    _catalogUri,
+                    _graph,
+                    _registrationBaseAddress,
+                    isExistingItem: false,
+                    packageContentBaseAddress: _packageContentBaseAddress,
+                    galleryBaseAddress: new Uri(galleryBaseAddress))
+                {
+                    BaseAddress = _baseAddress,
+                };
+                RegistrationMakerCatalogItem.PackagePathProvider = new PackagesFolderPackagePathProvider();
+                var context = new CatalogContext();
+
+                // Act
+                var content = item.CreatePageContent(context);
+                var licenseUrlTriples = content.GetTriplesWithSubjectPredicate(
+                    content.CreateUriNode(_catalogUri),
+                    content.CreateUriNode(Schema.Predicates.LicenseUrl));
+                var licenseExpressionTriples = content.GetTriplesWithSubjectPredicate(
+                    content.CreateUriNode(_catalogUri),
+                    content.CreateUriNode(Schema.Predicates.LicenseExpression));
+                var licenseFileTriples = content.GetTriplesWithSubjectPredicate(
+                    content.CreateUriNode(_catalogUri),
+                    content.CreateUriNode(Schema.Predicates.LicenseFile));
+
+                // Assert
+                Assert.Equal(1, licenseUrlTriples.Count());
+                Assert.Equal(expectedLicenseUrlValue, licenseUrlTriples.First().Object.ToString());
+                Assert.Equal(1, licenseExpressionTriples.Count());
+                Assert.Equal(expectedLicenseExpressionValue, licenseExpressionTriples.First().Object.ToString());
+                Assert.Equal(0, licenseFileTriples.Count());
             }
         }
     }

--- a/tests/CatalogTests/Registration/RegistrationMakerTests.cs
+++ b/tests/CatalogTests/Registration/RegistrationMakerTests.cs
@@ -359,7 +359,7 @@ namespace CatalogTests.Registration
 
             Assert.Equal(pageUri.AbsoluteUri, page.IdKeyword);
             Assert.Equal(CatalogConstants.CatalogCatalogPage, page.TypeKeyword);
-            Assert.Equal(commitId, page.CommitId);     
+            Assert.Equal(commitId, page.CommitId);
             Assert.Equal(commitTimeStamp, page.CommitTimeStamp);
             Assert.Equal(expectedPage.LowerVersion, page.Lower);
             Assert.Equal(expectedPage.UpperVersion, page.Upper);

--- a/tests/CatalogTests/Registration/RegistrationMakerTests.cs
+++ b/tests/CatalogTests/Registration/RegistrationMakerTests.cs
@@ -25,6 +25,7 @@ namespace CatalogTests.Registration
         private const int _defaultPackageCountThreshold = 128;
 
         private static readonly Uri _contentBaseAddress = new Uri("https://nuget.test/");
+        private static readonly Uri _galleryBaseAddress = new Uri("https://nuget.org/");
 
         private readonly MemoryStorageFactory _storageFactory = new MemoryStorageFactory(new Uri("https://nuget.test/v3-registration3/"));
         private readonly Mock<ITelemetryService> _telemetryService = new Mock<ITelemetryService>();
@@ -197,6 +198,7 @@ namespace CatalogTests.Registration
                 newItems,
                 _storageFactory,
                 _contentBaseAddress,
+                _galleryBaseAddress,
                 partitionSize,
                 packageCountThreshold,
                 _telemetryService.Object,
@@ -357,7 +359,7 @@ namespace CatalogTests.Registration
 
             Assert.Equal(pageUri.AbsoluteUri, page.IdKeyword);
             Assert.Equal(CatalogConstants.CatalogCatalogPage, page.TypeKeyword);
-            Assert.Equal(commitId, page.CommitId);
+            Assert.Equal(commitId, page.CommitId);     
             Assert.Equal(commitTimeStamp, page.CommitTimeStamp);
             Assert.Equal(expectedPage.LowerVersion, page.Lower);
             Assert.Equal(expectedPage.UpperVersion, page.Upper);


### PR DESCRIPTION
Cat2Registration pipeline to support the license expression/file;
Overwirte license URL when the license file/expression exists.

Fix: https://github.com/NuGet/NuGetGallery/issues/6522