### PR TITLE
[Search 11] Add IndexBuilder to contain all of the logic to initialize the index

### DIFF
--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -124,6 +124,7 @@ namespace NuGet.Services.AzureSearch
             services.AddTransient<IDiagnosticsService, LoggerDiagnosticsService>();
             services.AddTransient<IEntitiesContextFactory, EntitiesContextFactory>();
             services.AddTransient<IHijackDocumentBuilder, HijackDocumentBuilder>();
+            services.AddTransient<IIndexBuilder, IndexBuilder>();
             services.AddTransient<INewPackageRegistrationProducer, NewPackageRegistrationProducer>();
             services.AddTransient<IPackageEntityIndexActionBuilder, PackageEntityIndexActionBuilder>();
             services.AddTransient<IRegistrationClient, RegistrationClient>();

--- a/src/NuGet.Services.AzureSearch/IIndexBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/IIndexBuilder.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace NuGet.Services.AzureSearch
+{
+    public interface IIndexBuilder
+    {
+        Task CreateHijackIndexAsync();
+        Task CreateHijackIndexIfNotExistsAsync();
+        Task CreateSearchIndexAsync();
+        Task CreateSearchIndexIfNotExistsAsync();
+        Task DeleteHijackIndexIfExistsAsync();
+        Task DeleteSearchIndexIfExistsAsync();
+    }
+}

--- a/src/NuGet.Services.AzureSearch/IndexBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/IndexBuilder.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.Search;
+using Microsoft.Azure.Search.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NuGet.Services.AzureSearch.Wrappers;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class IndexBuilder : IIndexBuilder
+    {
+        private readonly ISearchServiceClientWrapper _serviceClient;
+        private readonly IOptionsSnapshot<AzureSearchConfiguration> _options;
+        private readonly ILogger<IndexBuilder> _logger;
+
+        public IndexBuilder(
+            ISearchServiceClientWrapper serviceClient,
+            IOptionsSnapshot<AzureSearchConfiguration> options,
+            ILogger<IndexBuilder> logger)
+        {
+            _serviceClient = serviceClient ?? throw new ArgumentNullException(nameof(serviceClient));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task CreateSearchIndexAsync()
+        {
+            await CreateIndexAsync(InitializeSearchIndex());
+        }
+
+        public async Task CreateHijackIndexAsync()
+        {
+            await CreateIndexAsync(InitializeHijackIndex());
+        }
+
+        public async Task CreateSearchIndexIfNotExistsAsync()
+        {
+            await CreateIndexIfNotExistsAsync(InitializeSearchIndex());
+        }
+
+        public async Task CreateHijackIndexIfNotExistsAsync()
+        {
+            await CreateIndexIfNotExistsAsync(InitializeHijackIndex());
+        }
+
+        public async Task DeleteSearchIndexIfExistsAsync()
+        {
+            await DeleteIndexIfExistsAsync(_options.Value.SearchIndexName);
+        }
+
+        public async Task DeleteHijackIndexIfExistsAsync()
+        {
+            await DeleteIndexIfExistsAsync(_options.Value.HijackIndexName);
+        }
+
+        private async Task DeleteIndexIfExistsAsync(string indexName)
+        {
+            if (await _serviceClient.Indexes.ExistsAsync(indexName))
+            {
+                _logger.LogWarning("Deleting index {IndexName}.", indexName);
+                await _serviceClient.Indexes.DeleteAsync(indexName);
+                _logger.LogWarning("Done deleting index {IndexName}.", indexName);
+            }
+            else
+            {
+                _logger.LogInformation("Skipping the deletion of index {IndexName} since it does not exist.", indexName);
+            }
+        }
+
+        private async Task CreateIndexAsync(Index index)
+        {
+            _logger.LogInformation("Creating index {IndexName}.", index.Name);
+            await _serviceClient.Indexes.CreateAsync(index);
+            _logger.LogInformation("Done creating index {IndexName}.", index.Name);
+        }
+
+        private async Task CreateIndexIfNotExistsAsync(Index index)
+        {
+            if (!(await _serviceClient.Indexes.ExistsAsync(index.Name)))
+            {
+                await CreateIndexAsync(index);
+            }
+            else
+            {
+                _logger.LogInformation("Skipping the creation of index {IndexName} since it already exists.", index.Name);
+            }
+        }
+
+        private Index InitializeSearchIndex()
+        {
+            return new Index
+            {
+                Name = _options.Value.SearchIndexName,
+                Fields = FieldBuilder.BuildForType<SearchDocument.Full>(),
+            };
+        }
+
+        private Index InitializeHijackIndex()
+        {
+            return new Index
+            {
+                Name = _options.Value.HijackIndexName,
+                Fields = FieldBuilder.BuildForType<HijackDocument.Full>(),
+            };
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -63,8 +63,10 @@
     <Compile Include="Db2AzureSearch\NewPackageRegistrationProducer.cs" />
     <Compile Include="IdAndValue.cs" />
     <Compile Include="IHijackDocumentBuilder.cs" />
+    <Compile Include="IIndexBuilder.cs" />
     <Compile Include="IndexActions.cs" />
     <Compile Include="Db2AzureSearch\IPackageEntityIndexActionBuilder.cs" />
+    <Compile Include="IndexBuilder.cs" />
     <Compile Include="ISearchDocumentBuilder.cs" />
     <Compile Include="Models\IBaseMetadataDocument.cs" />
     <Compile Include="Models\KeyedDocument.cs" />

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Catalog2AzureSearchCommandFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Catalog2AzureSearchCommandFacts.cs
@@ -1,0 +1,202 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Moq;
+using Newtonsoft.Json;
+using NuGet.Services.AzureSearch.Support;
+using NuGet.Services.Metadata.Catalog;
+using NuGet.Services.Metadata.Catalog.Persistence;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
+{
+    public class Catalog2AzureSearchCommandFacts
+    {
+        public class ExecuteAsync : BaseFacts
+        {
+            public ExecuteAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+            
+            [Fact]
+            public async Task CreatesIndexesIfConfigured()
+            {
+                _config.CreateIndexes = true;
+
+                await _target.ExecuteAsync();
+
+                _indexBuilder.Verify(x => x.CreateSearchIndexIfNotExistsAsync(), Times.Once);
+                _indexBuilder.Verify(x => x.CreateHijackIndexIfNotExistsAsync(), Times.Once);
+            }
+
+            [Fact]
+            public async Task UsesCurrentCursorValueForFront()
+            {
+                var front = new DateTime(2019, 1, 3, 0, 0, 0);
+                _storage.CursorValue = front;
+
+                await _target.ExecuteAsync();
+
+                _collector.Verify(
+                    x => x.RunAsync(
+                        It.Is<ReadWriteCursor>(c => c.Value == front),
+                        It.IsAny<ReadCursor>(),
+                        It.IsAny<CancellationToken>()),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task UsesMaxForCursorWithNoDependencies()
+            {
+                _config.DependencyCursorUrls = null;
+
+                await _target.ExecuteAsync();
+
+                _collector.Verify(
+                    x => x.RunAsync(
+                        It.IsAny<ReadWriteCursor>(),
+                        It.Is<ReadCursor>(c => c.Value == DateTime.MaxValue),
+                        It.IsAny<CancellationToken>()),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task UsesMinOfDependencyUrlsForBack()
+            {
+                var cursor1 = "https://example/dep-cursor/1.json";
+                var cursorValue1 = new DateTime(2020, 1, 1);
+                var cursor2 = "https://example/dep-cursor/2.json";
+                var cursorValue2 = new DateTime(2020, 1, 2);
+                _config.DependencyCursorUrls = new List<string> { cursor1, cursor2 };
+                _httpMessageHandler
+                    .Setup(x => x.OnSendAsync(
+                        It.Is<HttpRequestMessage>(m => m.RequestUri.AbsoluteUri == cursor1),
+                        It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(JsonConvert.SerializeObject(new Cursor {  Value = cursorValue1 }))
+                    });
+                _httpMessageHandler
+                    .Setup(x => x.OnSendAsync(
+                        It.Is<HttpRequestMessage>(m => m.RequestUri.AbsoluteUri == cursor2),
+                        It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(JsonConvert.SerializeObject(new Cursor { Value = cursorValue2 }))
+                    });
+
+                await _target.ExecuteAsync();
+
+                _collector.Verify(
+                    x => x.RunAsync(
+                        It.IsAny<ReadWriteCursor>(),
+                        It.Is<ReadCursor>(c => c.Value == cursorValue1),
+                        It.IsAny<CancellationToken>()),
+                    Times.Once);
+            }
+        }
+
+        public abstract class BaseFacts
+        {
+            protected readonly Mock<ICollector> _collector;
+            protected readonly Mock<IStorageFactory> _storageFactory;
+            protected readonly Mock<TestHttpMessageHandler> _httpMessageHandler;
+            protected readonly Mock<IIndexBuilder> _indexBuilder;
+            protected readonly Mock<IOptionsSnapshot<Catalog2AzureSearchConfiguration>> _options;
+            protected readonly Catalog2AzureSearchConfiguration _config;
+            protected readonly TestStorage _storage;
+            protected readonly RecordingLogger<Catalog2AzureSearchCommand> _logger;
+            protected readonly Catalog2AzureSearchCommand _target;
+
+            public BaseFacts(ITestOutputHelper output)
+            {
+                _collector = new Mock<ICollector>();
+                _storageFactory = new Mock<IStorageFactory>();
+                _httpMessageHandler = new Mock<TestHttpMessageHandler>() { CallBase = true };
+                _indexBuilder = new Mock<IIndexBuilder>();
+                _options = new Mock<IOptionsSnapshot<Catalog2AzureSearchConfiguration>>();
+                _logger = output.GetLogger<Catalog2AzureSearchCommand>();
+
+                _config = new Catalog2AzureSearchConfiguration();
+                _storage = new TestStorage(new Uri("https://example/base/"));
+
+                _options.Setup(x => x.Value).Returns(() => _config);
+                _storageFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(() => _storage);
+
+                _target = new Catalog2AzureSearchCommand(
+                    _collector.Object,
+                    _storageFactory.Object,
+                    () => _httpMessageHandler.Object,
+                    _indexBuilder.Object,
+                    _options.Object,
+                    _logger);
+            }
+        }
+
+        public class TestHttpMessageHandler : HttpMessageHandler
+        {
+            public virtual Task<HttpResponseMessage> OnSendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return await OnSendAsync(request, cancellationToken);
+            }
+        }
+
+        public class TestStorage : Metadata.Catalog.Persistence.Storage
+        {
+            public DateTime CursorValue { get; set; }
+
+            public TestStorage(Uri baseAddress) : base(baseAddress)
+            {
+            }
+
+            protected override async Task<StorageContent> OnLoadAsync(
+                Uri resourceUri,
+                CancellationToken cancellationToken)
+            {
+                await Task.Yield();
+
+                return new StringStorageContent(JsonConvert.SerializeObject(new Cursor
+                {
+                    Value = CursorValue,
+                }));
+            }
+
+            public override bool Exists(
+                string fileName) => throw new NotImplementedException();
+            public override Task<IEnumerable<StorageListItem>> ListAsync(
+                CancellationToken cancellationToken) => throw new NotImplementedException();
+            protected override Task OnCopyAsync(
+                Uri sourceUri,
+                IStorage destinationStorage,
+                Uri destinationUri,
+                IReadOnlyDictionary<string, string> destinationProperties,
+                CancellationToken cancellationToken) => throw new NotImplementedException();
+            protected override Task OnDeleteAsync(
+                Uri resourceUri,
+                CancellationToken cancellationToken) => throw new NotImplementedException();
+            protected override Task OnSaveAsync(
+                Uri resourceUri,
+                StorageContent content,
+                CancellationToken cancellationToken) => throw new NotImplementedException();
+        }
+
+        public class Cursor
+        {
+            [JsonProperty("value")]
+            public DateTime Value { get; set; }
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/IndexBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/IndexBuilderFacts.cs
@@ -1,0 +1,244 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Azure.Search.Models;
+using Microsoft.Extensions.Options;
+using Moq;
+using NuGet.Services.AzureSearch.Support;
+using NuGet.Services.AzureSearch.Wrappers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class IndexBuilderFacts
+    {
+        public class CreateSearchIndexAsync : BaseFacts
+        {
+            public CreateSearchIndexAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task CreatesIndex()
+            {
+                await _target.CreateSearchIndexAsync();
+
+                _indexesOperations.Verify(
+                    x => x.CreateAsync(It.Is<Index>(y => y.Name == _config.SearchIndexName)),
+                    Times.Once);
+                _indexesOperations.Verify(
+                    x => x.CreateAsync(It.IsAny<Index>()),
+                    Times.Once);
+            }
+        }
+
+        public class CreateHijackIndexAsync : BaseFacts
+        {
+            public CreateHijackIndexAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task CreatesIndex()
+            {
+                await _target.CreateHijackIndexAsync();
+
+                _indexesOperations.Verify(
+                    x => x.CreateAsync(It.Is<Index>(y => y.Name == _config.HijackIndexName)),
+                    Times.Once);
+                _indexesOperations.Verify(
+                    x => x.CreateAsync(It.IsAny<Index>()),
+                    Times.Once);
+            }
+        }
+
+        public class CreateSearchIndexIfNotExistsAsync : BaseFacts
+        {
+            public CreateSearchIndexIfNotExistsAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task CreatesIndexIfNotExists()
+            {
+                _indexesOperations
+                    .Setup(x => x.ExistsAsync(_config.SearchIndexName))
+                    .ReturnsAsync(false);
+
+                await _target.CreateSearchIndexIfNotExistsAsync();
+
+                _indexesOperations.Verify(
+                    x => x.CreateAsync(It.Is<Index>(y => y.Name == _config.SearchIndexName)),
+                    Times.Once);
+                _indexesOperations.Verify(
+                    x => x.CreateAsync(It.IsAny<Index>()),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task DoesNotCreateIndexIfExists()
+            {
+                _indexesOperations
+                    .Setup(x => x.ExistsAsync(_config.SearchIndexName))
+                    .ReturnsAsync(true);
+
+                await _target.CreateSearchIndexIfNotExistsAsync();
+
+                _indexesOperations.Verify(
+                    x => x.CreateAsync(It.IsAny<Index>()),
+                    Times.Never);
+            }
+        }
+
+        public class CreateHijackIndexIfNotExistsAsync : BaseFacts
+        {
+            public CreateHijackIndexIfNotExistsAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task CreatesIndexIfNotExists()
+            {
+                _indexesOperations
+                    .Setup(x => x.ExistsAsync(_config.HijackIndexName))
+                    .ReturnsAsync(false);
+
+                await _target.CreateHijackIndexIfNotExistsAsync();
+
+                _indexesOperations.Verify(
+                    x => x.CreateAsync(It.Is<Index>(y => y.Name == _config.HijackIndexName)),
+                    Times.Once);
+                _indexesOperations.Verify(
+                    x => x.CreateAsync(It.IsAny<Index>()),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task DoesNotCreateIndexIfExists()
+            {
+                _indexesOperations
+                    .Setup(x => x.ExistsAsync(_config.HijackIndexName))
+                    .ReturnsAsync(true);
+
+                await _target.CreateHijackIndexIfNotExistsAsync();
+
+                _indexesOperations.Verify(
+                    x => x.CreateAsync(It.IsAny<Index>()),
+                    Times.Never);
+            }
+        }
+
+        public class DeleteSearchIndexIfExistsAsync : BaseFacts
+        {
+            public DeleteSearchIndexIfExistsAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task DoesNotDeleteIndexIfNotExists()
+            {
+                _indexesOperations
+                    .Setup(x => x.ExistsAsync(_config.SearchIndexName))
+                    .ReturnsAsync(false);
+
+                await _target.CreateSearchIndexIfNotExistsAsync();
+
+                _indexesOperations.Verify(
+                    x => x.DeleteAsync(It.IsAny<string>()),
+                    Times.Never);
+            }
+
+            [Fact]
+            public async Task DeletesIndexIfExists()
+            {
+                _indexesOperations
+                    .Setup(x => x.ExistsAsync(_config.SearchIndexName))
+                    .ReturnsAsync(true);
+
+                await _target.DeleteSearchIndexIfExistsAsync();
+
+                _indexesOperations.Verify(
+                    x => x.DeleteAsync(_config.SearchIndexName),
+                    Times.Once);
+                _indexesOperations.Verify(
+                    x => x.DeleteAsync(It.IsAny<string>()),
+                    Times.Once);
+            }
+        }
+
+        public class DeleteHijackIndexIfExistsAsync : BaseFacts
+        {
+            public DeleteHijackIndexIfExistsAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task DoesNotDeleteIndexIfNotExists()
+            {
+                _indexesOperations
+                    .Setup(x => x.ExistsAsync(_config.HijackIndexName))
+                    .ReturnsAsync(false);
+
+                await _target.CreateHijackIndexIfNotExistsAsync();
+
+                _indexesOperations.Verify(
+                    x => x.DeleteAsync(It.IsAny<string>()),
+                    Times.Never);
+            }
+
+            [Fact]
+            public async Task DeletesIndexIfExists()
+            {
+                _indexesOperations
+                    .Setup(x => x.ExistsAsync(_config.HijackIndexName))
+                    .ReturnsAsync(true);
+
+                await _target.DeleteHijackIndexIfExistsAsync();
+
+                _indexesOperations.Verify(
+                    x => x.DeleteAsync(_config.HijackIndexName),
+                    Times.Once);
+                _indexesOperations.Verify(
+                    x => x.DeleteAsync(It.IsAny<string>()),
+                    Times.Once);
+            }
+        }
+
+        public abstract class BaseFacts
+        {
+            protected readonly Mock<ISearchServiceClientWrapper> _serviceClient;
+            protected readonly Mock<IIndexesOperationsWrapper> _indexesOperations;
+            protected readonly Mock<IOptionsSnapshot<AzureSearchConfiguration>> _options;
+            protected readonly AzureSearchConfiguration _config;
+            protected readonly RecordingLogger<IndexBuilder> _logger;
+            protected readonly IndexBuilder _target;
+
+            public BaseFacts(ITestOutputHelper output)
+            {
+                _serviceClient = new Mock<ISearchServiceClientWrapper>();
+                _indexesOperations = new Mock<IIndexesOperationsWrapper>();
+                _options = new Mock<IOptionsSnapshot<AzureSearchConfiguration>>();
+                _config = new AzureSearchConfiguration
+                {
+                    SearchIndexName = "search",
+                    HijackIndexName = "hijack",
+                };
+                _logger = output.GetLogger<IndexBuilder>();
+
+                _options
+                    .Setup(x => x.Value)
+                    .Returns(() => _config);
+                _serviceClient
+                    .Setup(x => x.Indexes)
+                    .Returns(() => _indexesOperations.Object);
+
+                _target = new IndexBuilder(
+                    _serviceClient.Object,
+                    _options.Object,
+                    _logger);
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -39,6 +39,7 @@
   <ItemGroup>
     <Compile Include="BatchPusherFacts.cs" />
     <Compile Include="Catalog2AzureSearch\AzureSearchCollectorLogicFacts.cs" />
+    <Compile Include="Catalog2AzureSearch\Catalog2AzureSearchCommandFacts.cs" />
     <Compile Include="Catalog2AzureSearch\CatalogIndexActionBuilderFacts.cs" />
     <Compile Include="Catalog2AzureSearch\CatalogLeafFetcherFacts.cs" />
     <Compile Include="Db2AzureSearch\Db2AzureSearchCommandFacts.cs" />
@@ -47,6 +48,7 @@
     <Compile Include="Db2AzureSearch\PackageEntityIndexActionBuilderFacts.cs" />
     <Compile Include="DocumentUtilitiesFacts.cs" />
     <Compile Include="HijackDocumentBuilderFacts.cs" />
+    <Compile Include="IndexBuilderFacts.cs" />
     <Compile Include="SearchDocumentBuilderFacts.cs" />
     <Compile Include="Registration\RegistrationClientFacts.cs" />
     <Compile Include="Support\SerializationUtilities.cs" />


### PR DESCRIPTION
Also, add unit tests for Catalog2AzureSearchCommand

Eventually building the index will be a little more complex, due to custom tokenization and scoring rules. This will help keep it in one place for both db2azuresearch and catalog2azuresearch.