### PR TITLE
Determine IsLatest and IsLatestStable for the search documents

### DIFF
--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/PackageEntityIndexActionBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/PackageEntityIndexActionBuilder.cs
@@ -132,8 +132,8 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                      nameof(changeType));
             }
 
-            var latest = versionLists.GetLatestVersionInfoOrNull(searchFilters);
-            var package = versionToPackage[latest.ParsedVersion];
+            var latestFlags = _search.LatestFlagsOrNull(versionLists, searchFilters);
+            var package = versionToPackage[latestFlags.LatestVersionInfo.ParsedVersion];
             var owners = packageRegistration
                 .Owners
                 .OrderBy(u => u, StringComparer.InvariantCultureIgnoreCase)
@@ -144,8 +144,10 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
             return IndexAction.Upload<KeyedDocument>(_search.Full(
                 packageRegistration.PackageId,
                 searchFilters,
-                latest.ListedFullVersions,
-                latest.FullVersion,
+                latestFlags.LatestVersionInfo.ListedFullVersions,
+                latestFlags.IsLatestStable,
+                latestFlags.IsLatest,
+                latestFlags.LatestVersionInfo.FullVersion,
                 package,
                 owners,
                 packageRegistration.TotalDownloadCount));

--- a/src/NuGet.Services.AzureSearch/ISearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/ISearchDocumentBuilder.cs
@@ -8,6 +8,10 @@ namespace NuGet.Services.AzureSearch
 {
     public interface ISearchDocumentBuilder
     {
+        SearchDocument.LatestFlags LatestFlagsOrNull(
+            VersionLists versionLists,
+            SearchFilters searchFilters);
+
         KeyedDocument Keyed(
             string packageId,
             SearchFilters searchFilters);
@@ -15,12 +19,16 @@ namespace NuGet.Services.AzureSearch
         SearchDocument.UpdateVersionList UpdateVersionList(
             string packageId,
             SearchFilters searchFilters,
-            string[] versions);
+            string[] versions,
+            bool isLatestStable,
+            bool isLatest);
 
         SearchDocument.Full Full(
             string packageId, 
             SearchFilters searchFilters,
             string[] versions,
+            bool isLatestStable,
+            bool isLatest,
             string fullVersion,
             Package package,
             string[] owners,
@@ -29,6 +37,8 @@ namespace NuGet.Services.AzureSearch
         SearchDocument.UpdateLatest UpdateLatest(
             SearchFilters searchFilters,
             string[] versions,
+            bool isLatestStable,
+            bool isLatest,
             string normalizedVersion,
             string fullVersion,
             PackageDetailsCatalogLeaf leaf);

--- a/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
@@ -46,6 +46,8 @@ namespace NuGet.Services.AzureSearch
             public DateTimeOffset? LastEdited { get; set; }
             public DateTimeOffset? Published { get; set; }
             public string[] Versions { get; set; }
+            public bool? IsLatestStable { get; set; }
+            public bool? IsLatest { get; set; }
         }
 
         /// <summary>
@@ -55,6 +57,8 @@ namespace NuGet.Services.AzureSearch
         public class UpdateVersionList : KeyedDocument, IVersions
         {
             public string[] Versions { get; set; }
+            public bool? IsLatestStable { get; set; }
+            public bool? IsLatest { get; set; }
         }
 
         /// <summary>
@@ -63,6 +67,28 @@ namespace NuGet.Services.AzureSearch
         public interface IVersions : IKeyedDocument
         {
             string[] Versions { get; set; }
+            bool? IsLatestStable { get; set; }
+            bool? IsLatest { get; set; }
+        }
+
+        /// <summary>
+        /// The data required to populate <see cref="IVersions"/> and other <see cref="SearchDocument"/> classes.
+        /// This information, as with all other types under <see cref="SearchDocument"/>, are specific to a single
+        /// <see cref="SearchFilters"/>. That is, the latest version and its metadata given a filtered set of versions
+        /// per package ID.
+        /// </summary>
+        public class LatestFlags
+        {
+            public LatestFlags(LatestVersionInfo latest, bool isLatestStable, bool isLatest)
+            {
+                LatestVersionInfo = latest;
+                IsLatestStable = isLatestStable;
+                IsLatest = isLatest;
+            }
+
+            public LatestVersionInfo LatestVersionInfo { get; }
+            public bool IsLatestStable { get; }
+            public bool IsLatest { get; }
         }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -8,6 +8,77 @@ namespace NuGet.Services.AzureSearch
 {
     public class SearchDocumentBuilder : ISearchDocumentBuilder
     {
+        public SearchDocument.LatestFlags LatestFlagsOrNull(VersionLists versionLists, SearchFilters searchFilters)
+        {
+            var latest = versionLists.GetLatestVersionInfoOrNull(searchFilters);
+            if (latest == null)
+            {
+                return null;
+            }
+
+            // The latest version, given the "include prerelease" bit of the search filter, may or may not be the
+            // absolute latest version when considering both prerelease and stable versions. Consider the following
+            // cases:
+            //
+            // Case #1:
+            //   SearchFilters.Default:
+            //     All versions: 1.0.0, 2.0.0-alpha
+            //     Latest version given filters: 1.0.0
+            //     V2 search document flags:
+            //       IsLatestStable = true
+            //       IsLatest       = false
+            //
+            // Case #2:
+            //   SearchFilters.Default:
+            //     All versions: 1.0.0
+            //     Latest version given filters: 1.0.0
+            //     V2 search document flags:
+            //       IsLatestStable = true
+            //       IsLatest       = true
+            //
+            // Case #3:
+            //   SearchFilters.IncludePrerelease:
+            //     All versions: 1.0.0, 2.0.0-alpha
+            //     Latest version given filters: 2.0.0-alpha
+            //     V2 search document flags:
+            //       IsLatestStable = false
+            //       IsLatest       = true
+            //
+            // Case #4:
+            //   SearchFilters.IncludePrerelease:
+            //     All versions: 1.0.0
+            //     Latest version given filters: 1.0.0
+            //     V2 search document flags:
+            //       IsLatestStable = true
+            //       IsLatest       = true
+            //
+            // In cases #1 and #2, we know the value of IsLatestStable will always be true. We cannot know whether
+            // IsLatest is true or false without looking at the version list that includes prerelease versions. For
+            // cases #3 and #4, we know IsLatest will always be true and we can determine IsLatestStable by looking
+            // at whether the latest version is prerelease or not.
+            bool isLatestStable;
+            bool isLatest;
+            if ((searchFilters & SearchFilters.IncludePrerelease) == 0)
+            {
+                // This is the case where prerelease versions are excluded.
+                var latestIncludePrerelease = versionLists
+                    .GetLatestVersionInfoOrNull(searchFilters | SearchFilters.IncludePrerelease);
+                Guard.Assert(
+                    latestIncludePrerelease != null,
+                    "If a search filter excludes prerelease and has a latest version, then there is a latest version including prerelease.");
+                isLatestStable = true;
+                isLatest = latestIncludePrerelease.ParsedVersion == latest.ParsedVersion;
+            }
+            else
+            {
+                // This is the case where prerelease versions are included.
+                isLatestStable = !latest.ParsedVersion.IsPrerelease;
+                isLatest = true;
+            }
+
+            return new SearchDocument.LatestFlags(latest, isLatestStable, isLatest);
+        }
+
         public KeyedDocument Keyed(
             string packageId,
             SearchFilters searchFilters)
@@ -22,11 +93,13 @@ namespace NuGet.Services.AzureSearch
         public SearchDocument.UpdateVersionList UpdateVersionList(
             string packageId,
             SearchFilters searchFilters,
-            string[] versions)
+            string[] versions,
+            bool isLatestStable,
+            bool isLatest)
         {
             var document = new SearchDocument.UpdateVersionList();
 
-            PopulateVersions(document, packageId, searchFilters, versions);
+            PopulateVersions(document, packageId, searchFilters, versions, isLatestStable, isLatest);
 
             return document;
         }
@@ -34,13 +107,15 @@ namespace NuGet.Services.AzureSearch
         public SearchDocument.UpdateLatest UpdateLatest(
             SearchFilters searchFilters,
             string[] versions,
+            bool isLatestStable,
+            bool isLatest,
             string normalizedVersion,
             string fullVersion,
             PackageDetailsCatalogLeaf leaf)
         {
             var document = new SearchDocument.UpdateLatest();
 
-            PopulateUpdateLatest(document, leaf.PackageId, searchFilters, versions, fullVersion);
+            PopulateUpdateLatest(document, leaf.PackageId, searchFilters, versions, isLatestStable, isLatest, fullVersion);
             DocumentUtilities.PopulateMetadata(document, normalizedVersion, leaf);
 
             return document;
@@ -50,6 +125,8 @@ namespace NuGet.Services.AzureSearch
             string packageId,
             SearchFilters searchFilters,
             string[] versions,
+            bool isLatestStable,
+            bool isLatest,
             string fullVersion,
             Package package,
             string[] owners,
@@ -57,7 +134,7 @@ namespace NuGet.Services.AzureSearch
         {
             var document = new SearchDocument.Full();
 
-            PopulateAddFirst(document, packageId, searchFilters, versions, fullVersion, owners);
+            PopulateAddFirst(document, packageId, searchFilters, versions, isLatestStable, isLatest, fullVersion, owners);
             DocumentUtilities.PopulateMetadata(document, packageId, package);
             document.TotalDownloadCount = totalDownloadCount;
 
@@ -68,10 +145,14 @@ namespace NuGet.Services.AzureSearch
             T document,
             string packageId,
             SearchFilters searchFilters,
-            string[] versions) where T : KeyedDocument, SearchDocument.IVersions
+            string[] versions,
+            bool isLatestStable,
+            bool isLatest) where T : KeyedDocument, SearchDocument.IVersions
         {
             PopulateKey(document, packageId, searchFilters);
             document.Versions = versions;
+            document.IsLatestStable = isLatestStable;
+            document.IsLatest = isLatest;
         }
 
         private static void PopulateKey(KeyedDocument document, string packageId, SearchFilters searchFilters)
@@ -84,9 +165,11 @@ namespace NuGet.Services.AzureSearch
             string packageId,
             SearchFilters searchFilters,
             string[] versions,
+            bool isLatestStable,
+            bool isLatest,
             string fullVersion)
         {
-            PopulateVersions(document, packageId, searchFilters, versions);
+            PopulateVersions(document, packageId, searchFilters, versions, isLatestStable, isLatest);
             document.SearchFilters = searchFilters.ToString();
             document.FullVersion = fullVersion;
         }
@@ -96,10 +179,12 @@ namespace NuGet.Services.AzureSearch
             string packageId,
             SearchFilters searchFilters,
             string[] versions,
+            bool isLatestStable,
+            bool isLatest,
             string fullVersion,
             string[] owners)
         {
-            PopulateUpdateLatest(document, packageId, searchFilters, versions, fullVersion);
+            PopulateUpdateLatest(document, packageId, searchFilters, versions, isLatestStable, isLatest, fullVersion);
             document.Owners = owners;
         }
     }

--- a/src/NuGet.Services.AzureSearch/VersionList/SearchIndexChangeType.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/SearchIndexChangeType.cs
@@ -6,8 +6,8 @@ namespace NuGet.Services.AzureSearch
     public enum SearchIndexChangeType
     {
         /// <summary>
-        /// The only change necessary is updating the version list. Some potentially no-op cases also fall into this
-        /// category to support reflowing.
+        /// The only change necessary is updating the version list and "is latest" flags. Some potentially no-op cases
+        /// also fall into this category to support reflowing.
         /// </summary>
         UpdateVersionList,
 

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/CatalogIndexActionBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/CatalogIndexActionBuilderFacts.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Azure.Search.Models;
 using Moq;
@@ -609,22 +608,30 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                     new Dictionary<NuGetVersion, PackageDetailsCatalogLeaf>());
 
                 _search
+                    .Setup(x => x.LatestFlagsOrNull(It.IsAny<VersionLists>(), It.IsAny<SearchFilters>()))
+                    .Returns<VersionLists, SearchFilters>((vl, sf) => new SearchDocument.LatestFlags(
+                        vl.GetLatestVersionInfoOrNull(sf),
+                        isLatestStable: true,
+                        isLatest: true));
+                _search
                     .Setup(x => x.Keyed(It.IsAny<string>(), It.IsAny<SearchFilters>()))
                     .Returns<string, SearchFilters>(
                         (i, sf) => new KeyedDocument { Key = sf.ToString() });
                 _search
-                    .Setup(x => x.UpdateVersionList(It.IsAny<string>(), It.IsAny<SearchFilters>(), It.IsAny<string[]>()))
-                    .Returns<string, SearchFilters, string[]>(
-                        (i, sf, v) => new SearchDocument.UpdateVersionList { Key = sf.ToString() });
+                    .Setup(x => x.UpdateVersionList(It.IsAny<string>(), It.IsAny<SearchFilters>(), It.IsAny<string[]>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                    .Returns<string, SearchFilters, string[], bool, bool>(
+                        (i, sf, v, ls, l) => new SearchDocument.UpdateVersionList { Key = sf.ToString() });
                 _search
                     .Setup(x => x.UpdateLatest(
                         It.IsAny<SearchFilters>(),
                         It.IsAny<string[]>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<bool>(),
                         It.IsAny<string>(),
                         It.IsAny<string>(),
                         It.IsAny<PackageDetailsCatalogLeaf>()))
-                    .Returns<SearchFilters, string[], string, string, PackageDetailsCatalogLeaf>(
-                        (sf, vs, nv, fv, l) => new SearchDocument.UpdateLatest { Key = sf.ToString() });
+                    .Returns<SearchFilters, string[], bool, bool, string, string, PackageDetailsCatalogLeaf>(
+                        (sf, v, ls, l, nv, fv, lf) => new SearchDocument.UpdateLatest { Key = sf.ToString() });
 
                 _hijack
                     .Setup(x => x.Keyed(It.IsAny<string>(), It.IsAny<string>()))

--- a/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/PackageEntityIndexActionBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/PackageEntityIndexActionBuilderFacts.cs
@@ -48,6 +48,8 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                         input.PackageId,
                         SearchFilters.IncludePrereleaseAndSemVer2,
                         It.IsAny<string[]>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<bool>(),
                         fullVersion,
                         input.Packages[0],
                         input.Owners,
@@ -63,12 +65,14 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                         It.IsAny<string>(),
                         It.IsAny<SearchFilters>(),
                         It.IsAny<string[]>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<bool>(),
                         It.IsAny<string>(),
                         It.IsAny<Package>(),
                         It.IsAny<string[]>(),
                         It.IsAny<long>()))
-                    .Returns<string, SearchFilters, string[], string, Package, string[], long>(
-                        (i, sf, v, fv, p, o, d) => new SearchDocument.Full { OriginalVersion = p.Version });
+                    .Returns<string, SearchFilters, string[], bool, bool, string, Package, string[], long>(
+                        (i, sf, v, ls, l, fv, p, o, d) => new SearchDocument.Full { OriginalVersion = p.Version });
                 var package1 = new TestPackage("1.0.0") { Description = "This is version 1.0.0." };
                 var package2 = new TestPackage("2.0.0-alpha") { Description = "This is version 2.0.0." };
                 var input = new NewPackageRegistration(
@@ -120,6 +124,8 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                         It.IsAny<string>(),
                         It.IsAny<SearchFilters>(),
                         It.IsAny<string[]>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<bool>(),
                         It.IsAny<string>(),
                         It.IsAny<Package>(),
                         It.IsAny<string[]>(),
@@ -169,6 +175,14 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                 _search = new Mock<ISearchDocumentBuilder>();
                 _hijack = new Mock<IHijackDocumentBuilder>();
                 _logger = output.GetLogger<PackageEntityIndexActionBuilder>();
+
+                _search
+                    .Setup(x => x.LatestFlagsOrNull(It.IsAny<VersionLists>(), It.IsAny<SearchFilters>()))
+                    .Returns<VersionLists, SearchFilters>((vl, sf) => new SearchDocument.LatestFlags(
+                        vl.GetLatestVersionInfoOrNull(sf),
+                        isLatestStable: true,
+                        isLatest: true));
+
                 _target = new PackageEntityIndexActionBuilder(
                     _search.Object,
                     _hijack.Object,


### PR DESCRIPTION
V2 search has `IsLatest` and `IsLatestStable`. We already have these values in the hijack index but we need them in the search service as well for `/api/v2/Search()`.

When the search filter includes prerelease, we can determine the `IsLatestStable` by using the inverse of the latest version's `Prerelease` flag.

When the search filter does not include the prerelease, we can determine the `IsLatest` by checking the latest version on the corresponding search filter that includes prerelease.