### PR TITLE
Add some basic integration tests for the AzureSearchCollector logic

### DIFF
--- a/src/NuGet.Services.AzureSearch/BatchPusher.cs
+++ b/src/NuGet.Services.AzureSearch/BatchPusher.cs
@@ -53,6 +53,13 @@ namespace NuGet.Services.AzureSearch
                     $"The {nameof(AzureSearchJobConfiguration.MaxConcurrentVersionListWriters)} must be greater than zero.",
                     nameof(options));
             }
+
+            if (_options.Value.AzureSearchBatchSize <= 0)
+            {
+                throw new ArgumentException(
+                    $"The {nameof(AzureSearchJobConfiguration.AzureSearchBatchSize)} must be greater than zero.",
+                    nameof(options));
+            }
         }
 
         public void EnqueueIndexActions(string packageId, IndexActions indexActions)

--- a/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/CatalogLeafFetcher.cs
+++ b/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/CatalogLeafFetcher.cs
@@ -38,6 +38,13 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                     $"The {nameof(AzureSearchJobConfiguration.MaxConcurrentBatches)} must be greater than zero.",
                     nameof(options));
             }
+
+            if (_options.Value.RegistrationsBaseUrl == null)
+            {
+                throw new ArgumentException(
+                    $"The {nameof(Catalog2AzureSearchConfiguration.RegistrationsBaseUrl)} must be set.",
+                    nameof(options));
+            }
         }
 
         public async Task<LatestCatalogLeaves> GetLatestLeavesAsync(

--- a/src/NuGet.Services.AzureSearch/HijackDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/HijackDocumentBuilder.cs
@@ -38,7 +38,7 @@ namespace NuGet.Services.AzureSearch
         {
             var document = new HijackDocument.Full();
 
-            PopulateFull(document, leaf.PackageId, normalizedVersion, changes, leaf.Title);
+            PopulateLatest(document, leaf.PackageId, normalizedVersion, changes);
             DocumentUtilities.PopulateMetadata(document, normalizedVersion, leaf);
 
             return document;
@@ -51,21 +51,10 @@ namespace NuGet.Services.AzureSearch
         {
             var document = new HijackDocument.Full();
 
-            PopulateFull(document, packageId, package.NormalizedVersion, changes, package.Title);
+            PopulateLatest(document, packageId, package.NormalizedVersion, changes);
             DocumentUtilities.PopulateMetadata(document, packageId, package);
 
             return document;
-        }
-
-        private static void PopulateFull(
-            HijackDocument.Full document,
-            string packageId,
-            string normalizedVersion,
-            HijackDocumentChanges changes,
-            string title)
-        {
-            PopulateLatest(document, packageId, normalizedVersion, changes);
-            document.SortableTitle = title ?? packageId;
         }
 
         private static void PopulateLatest<T>(

--- a/src/NuGet.Services.AzureSearch/Models/BaseMetadataDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/BaseMetadataDocument.cs
@@ -3,39 +3,64 @@
 
 using System;
 using Microsoft.Azure.Search;
+using Microsoft.Azure.Search.Models;
 
 namespace NuGet.Services.AzureSearch
 {
-    /// <summary>
-    /// Implements most of <see cref="IBaseMetadataDocument"/>. Some fields are not defined here since they have
-    /// different Azure Search attributes.
-    /// </summary>
-    public abstract class BaseMetadataDocument : KeyedDocument
+    public abstract class BaseMetadataDocument : KeyedDocument, IBaseMetadataDocument
     {
         [IsFilterable]
         public int? SemVerLevel { get; set; }
 
+        [IsSearchable]
         public string Authors { get; set; }
+
         public string Copyright { get; set; }
         public DateTimeOffset? Created { get; set; }
+
+        [IsSearchable]
         public string Description { get; set; }
+
         public long? FileSize { get; set; }
         public string FlattenedDependencies { get; set; }
         public string Hash { get; set; }
         public string HashAlgorithm { get; set; }
         public string IconUrl { get; set; }
         public string Language { get; set; }
+
+        [IsSortable]
+        public DateTimeOffset? LastEdited { get; set; }
+
         public string LicenseUrl { get; set; }
         public string MinClientVersion { get; set; }
+
+        [IsSearchable]
         public string NormalizedVersion { get; set; }
+
         public string OriginalVersion { get; set; }
+
+        [IsSearchable]
         public string PackageId { get; set; }
+
         public bool? Prerelease { get; set; }
         public string ProjectUrl { get; set; }
+
+        [IsSortable]
+        public DateTimeOffset? Published { get; set; }
+
         public string ReleaseNotes { get; set; }
         public bool? RequiresLicenseAcceptance { get; set; }
+
+        [IsSortable]
+        public string SortableTitle { get; set; }
+
+        [IsSearchable]
         public string Summary { get; set; }
+
+        [IsSearchable]
         public string[] Tags { get; set; }
+
+        [IsSearchable]
         public string Title { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/Models/HijackDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/HijackDocument.cs
@@ -19,13 +19,6 @@ namespace NuGet.Services.AzureSearch
         [SerializePropertyNamesAsCamelCase]
         public class Full : BaseMetadataDocument, ILatest, IBaseMetadataDocument
         {
-            [IsSortable]
-            public DateTimeOffset? LastEdited { get; set; }
-            [IsSortable]
-            public DateTimeOffset? Published { get; set; }
-            [IsSortable]
-            public string SortableTitle { get; set; }
-
             public bool? IsLatestStableSemVer1 { get; set; }
             public bool? IsLatestSemVer1 { get; set; }
             public bool? IsLatestStableSemVer2 { get; set; }

--- a/src/NuGet.Services.AzureSearch/Models/IBaseMetadataDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/IBaseMetadataDocument.cs
@@ -27,11 +27,12 @@ namespace NuGet.Services.AzureSearch
         string OriginalVersion { get; set; }
         string PackageId { get; set; }
         bool? Prerelease { get; set; }
-        DateTimeOffset? Published { get; set; }
         string ProjectUrl { get; set; }
+        DateTimeOffset? Published { get; set; }
         string ReleaseNotes { get; set; }
         bool? RequiresLicenseAcceptance { get; set; }
         int? SemVerLevel { get; set; }
+        string SortableTitle { get; set; }
         string Summary { get; set; }
         string[] Tags { get; set; }
         string Title { get; set; }

--- a/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
@@ -29,6 +29,7 @@ namespace NuGet.Services.AzureSearch
         [SerializePropertyNamesAsCamelCase]
         public class AddFirst : UpdateLatest
         {
+            [IsSearchable]
             public string[] Owners { get; set; }
         }
 
@@ -37,14 +38,12 @@ namespace NuGet.Services.AzureSearch
         /// <see cref="SearchIndexChangeType.DowngradeLatest"/>.
         /// </summary>
         [SerializePropertyNamesAsCamelCase]
-        public class UpdateLatest : BaseMetadataDocument, IVersions, IBaseMetadataDocument
+        public class UpdateLatest : BaseMetadataDocument, IVersions
         {
             [IsFilterable]
             public string SearchFilters { get; set; }
 
             public string FullVersion { get; set; }
-            public DateTimeOffset? LastEdited { get; set; }
-            public DateTimeOffset? Published { get; set; }
             public string[] Versions { get; set; }
             public bool? IsLatestStable { get; set; }
             public bool? IsLatest { get; set; }

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -170,7 +170,7 @@ namespace NuGet.Services.AzureSearch
             string fullVersion)
         {
             PopulateVersions(document, packageId, searchFilters, versions, isLatestStable, isLatest);
-            document.SearchFilters = searchFilters.ToString();
+            document.SearchFilters = DocumentUtilities.GetSearchFilterString(searchFilters);
             document.FullVersion = fullVersion;
         }
 

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/AzureSearchCollectorLogicIntegrationTests.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/AzureSearchCollectorLogicIntegrationTests.cs
@@ -1,0 +1,489 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.Search.Models;
+using Microsoft.Extensions.Options;
+using Moq;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Catalog;
+using NuGet.Protocol.Registration;
+using NuGet.Services.AzureSearch.Wrappers;
+using NuGet.Services.Metadata.Catalog;
+using NuGet.Versioning;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
+{
+    public class AzureSearchCollectorLogicIntegrationTests
+    {
+        private Catalog2AzureSearchConfiguration _config;
+        private Mock<IOptionsSnapshot<Catalog2AzureSearchConfiguration>> _options;
+        private InMemoryRegistrationClient _registrationClient;
+        private InMemoryCatalogClient _catalogClient;
+        private CatalogLeafFetcher _fetcher;
+        private SearchDocumentBuilder _search;
+        private HijackDocumentBuilder _hijack;
+        private CatalogIndexActionBuilder _builder;
+        private InMemoryCoreFileStorageService _coreFileStorageService;
+        private VersionListDataClient _versionListDataClient;
+        private Mock<ISearchIndexClientWrapper> _searchIndex;
+        private InMemoryDocumentsOperations _searchDocuments;
+        private Mock<ISearchIndexClientWrapper> _hijackIndex;
+        private InMemoryDocumentsOperations _hijackDocuments;
+        private AzureSearchCollectorLogic _collector;
+
+        public AzureSearchCollectorLogicIntegrationTests(ITestOutputHelper output)
+        {
+            _config = new Catalog2AzureSearchConfiguration
+            {
+                MaxConcurrentBatches = 1,
+                MaxConcurrentVersionListWriters = 1,
+                AzureSearchBatchSize = 1000,
+                StoragePath = "integration-tests",
+                RegistrationsBaseUrl = "https://example/registrations/",
+            };
+            _options = new Mock<IOptionsSnapshot<Catalog2AzureSearchConfiguration>>();
+            _options.Setup(x => x.Value).Returns(() => _config);
+
+            _registrationClient = new InMemoryRegistrationClient();
+            _catalogClient = new InMemoryCatalogClient();
+            _fetcher = new CatalogLeafFetcher(
+                _registrationClient,
+                _catalogClient,
+                _options.Object,
+                output.GetLogger<CatalogLeafFetcher>());
+            _search = new SearchDocumentBuilder();
+            _hijack = new HijackDocumentBuilder();
+            _builder = new CatalogIndexActionBuilder(
+                _fetcher,
+                _search,
+                _hijack,
+                output.GetLogger<CatalogIndexActionBuilder>());
+            _coreFileStorageService = new InMemoryCoreFileStorageService();
+            _versionListDataClient = new VersionListDataClient(
+                _coreFileStorageService,
+                _options.Object,
+                output.GetLogger<VersionListDataClient>());
+
+            _searchIndex = new Mock<ISearchIndexClientWrapper>();
+            _searchDocuments = new InMemoryDocumentsOperations();
+            _searchIndex.Setup(x => x.Documents).Returns(() => _searchDocuments);
+            _hijackIndex = new Mock<ISearchIndexClientWrapper>();
+            _hijackDocuments = new InMemoryDocumentsOperations();
+            _hijackIndex.Setup(x => x.Documents).Returns(() => _hijackDocuments);
+
+            _collector = new AzureSearchCollectorLogic(
+                _catalogClient,
+                _versionListDataClient,
+                _builder,
+                () => new BatchPusher(
+                    _searchIndex.Object,
+                    _hijackIndex.Object,
+                    _versionListDataClient,
+                    _options.Object,
+                    output.GetLogger<BatchPusher>()),
+                _options.Object,
+                output.GetLogger<AzureSearchCollectorLogic>());
+        }
+
+        [Fact]
+        public async Task AddTwoVersionsThenUnlist()
+        {
+            var identity1 = new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("1.0.0.0-alpha"));
+            var identity2 = new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("2.0.0+git"));
+
+            // Step #1 - add a version
+            {
+                // Arrange
+                var leafUrl = "https://example/catalog/0/nuget.versioning.1.0.0-alpha.json";
+                _catalogClient.PackageDetailsLeaves[leafUrl] = CreateLeaf(leafUrl, identity1, listed: true);
+                var items = new[]
+                {
+                    new CatalogCommitItem(
+                        uri: new Uri(leafUrl),
+                        commitId: null,
+                        commitTimeStamp: new DateTime(2018, 12, 10, 0, 0, 0),
+                        types: new List<string>(),
+                        typeUris: new List<Uri> { Schema.DataTypes.PackageDetails },
+                        packageIdentity: identity1)
+                };
+
+                // Act
+                await _collector.OnProcessBatchAsync(items);
+
+                // Assert
+                // Hijack documents
+                var hijackBatch = Assert.Single(_hijackDocuments.Batches);
+                var hijackAction = Assert.Single(hijackBatch.Actions);
+                Assert.Equal(IndexActionType.MergeOrUpload, hijackAction.ActionType);
+                Assert.Equal(
+                    DocumentUtilities.GetHijackDocumentKey(identity1.Id, identity1.Version.ToNormalizedString()),
+                    hijackAction.Document.Key);
+                Assert.IsType<HijackDocument.Full>(hijackAction.Document);
+
+                // Search documents
+                var searchBatch = Assert.Single(_searchDocuments.Batches);
+                AssertSearchBatch(
+                    identity1.Id,
+                    searchBatch,
+                    exDefault: IndexActionType.Delete,
+                    exIncludePrerelease: IndexActionType.MergeOrUpload,
+                    exIncludeSemVer2: IndexActionType.Delete,
+                    exIncludePrereleaseAndSemVer2: IndexActionType.MergeOrUpload);
+
+                // Version list
+                var pair = Assert.Single(_coreFileStorageService.Files);
+                Assert.Equal("content/integration-tests/version-lists/nuget.versioning.json", pair.Key);
+                var inMemoryFile = Assert.IsType<InMemoryFileReference>(pair.Value);
+                Assert.Equal(@"{
+  ""VersionProperties"": {
+    ""1.0.0-alpha"": {
+      ""Listed"": true
+    }
+  }
+}", inMemoryFile.AsString);
+            }
+
+            ClearBatches();
+
+            // Step #2 - add another version
+            {
+                // Arrange
+                var leafUrl = "https://example/catalog/0/nuget.versioning.2.0.0.json";
+                _catalogClient.PackageDetailsLeaves[leafUrl] = CreateLeaf(leafUrl, identity2, listed: true);
+                var items = new[]
+                {
+                    new CatalogCommitItem(
+                        uri: new Uri(leafUrl),
+                        commitId: null,
+                        commitTimeStamp: new DateTime(2018, 12, 11, 0, 0, 0),
+                        types: new List<string>(),
+                        typeUris: new List<Uri> { Schema.DataTypes.PackageDetails },
+                        packageIdentity: identity2)
+                };
+
+                // Act
+                await _collector.OnProcessBatchAsync(items);
+
+                // Assert
+                // Hijack documents
+                var hijackBatch = Assert.Single(_hijackDocuments.Batches);
+                var actions = hijackBatch.Actions.OrderBy(x => x.Document.Key).ToList();
+                Assert.Equal(2, actions.Count);
+                Assert.Equal(
+                    DocumentUtilities.GetHijackDocumentKey(identity2.Id, identity1.Version.ToNormalizedString()),
+                    actions[0].Document.Key);
+                Assert.Equal(IndexActionType.Merge, actions[0].ActionType);
+                Assert.IsType<HijackDocument.Latest>(actions[0].Document);
+                Assert.Equal(
+                    DocumentUtilities.GetHijackDocumentKey(identity2.Id, identity2.Version.ToNormalizedString()),
+                    actions[1].Document.Key);
+                Assert.Equal(IndexActionType.MergeOrUpload, actions[1].ActionType);
+                Assert.IsType<HijackDocument.Full>(actions[1].Document);
+
+                // Search documents
+                var searchBatch = Assert.Single(_searchDocuments.Batches);
+                AssertSearchBatch(
+                    identity2.Id,
+                    searchBatch,
+                    exDefault: IndexActionType.Delete,
+                    exIncludePrerelease: IndexActionType.Merge,
+                    exIncludeSemVer2: IndexActionType.MergeOrUpload,
+                    exIncludePrereleaseAndSemVer2: IndexActionType.MergeOrUpload);
+
+                // Version list
+                var pair = Assert.Single(_coreFileStorageService.Files);
+                Assert.Equal("content/integration-tests/version-lists/nuget.versioning.json", pair.Key);
+                var inMemoryFile = Assert.IsType<InMemoryFileReference>(pair.Value);
+                Assert.Equal(@"{
+  ""VersionProperties"": {
+    ""1.0.0-alpha"": {
+      ""Listed"": true
+    },
+    ""2.0.0+git"": {
+      ""Listed"": true,
+      ""SemVer2"": true
+    }
+  }
+}", inMemoryFile.AsString);
+            }
+
+            ClearBatches();
+
+            // Step #3 - unlist the first version
+            {
+                // Arrange
+                var leafUrl = "https://example/catalog/2/nuget.versioning.1.0.0-alpha.json";
+                _catalogClient.PackageDetailsLeaves[leafUrl] = CreateLeaf(leafUrl, identity1, listed: false);
+                var items = new[]
+                {
+                    new CatalogCommitItem(
+                        uri: new Uri(leafUrl),
+                        commitId: null,
+                        commitTimeStamp: new DateTime(2018, 12, 12, 0, 0, 0),
+                        types: new List<string>(),
+                        typeUris: new List<Uri> { Schema.DataTypes.PackageDetails },
+                        packageIdentity: identity1)
+                };
+
+                // Act
+                await _collector.OnProcessBatchAsync(items);
+
+                // Assert
+                // Hijack documents
+                var hijackBatch = Assert.Single(_hijackDocuments.Batches);
+                var actions = hijackBatch.Actions.OrderBy(x => x.Document.Key).ToList();
+                Assert.Equal(2, actions.Count);
+                Assert.Equal(
+                    DocumentUtilities.GetHijackDocumentKey(identity1.Id, identity1.Version.ToNormalizedString()),
+                    actions[0].Document.Key);
+                Assert.Equal(IndexActionType.MergeOrUpload, actions[0].ActionType);
+                Assert.IsType<HijackDocument.Full>(actions[0].Document);
+                Assert.Equal(
+                    DocumentUtilities.GetHijackDocumentKey(identity2.Id, identity2.Version.ToNormalizedString()),
+                    actions[1].Document.Key);
+                Assert.Equal(IndexActionType.Merge, actions[1].ActionType);
+                Assert.IsType<HijackDocument.Latest>(actions[1].Document);
+
+                // Search documents
+                var searchBatch = Assert.Single(_searchDocuments.Batches);
+                AssertSearchBatch(
+                    identity1.Id,
+                    searchBatch,
+                    exDefault: IndexActionType.Delete,
+                    exIncludePrerelease: IndexActionType.Delete,
+                    exIncludeSemVer2: IndexActionType.Merge,
+                    exIncludePrereleaseAndSemVer2: IndexActionType.Merge);
+
+                // Version list
+                var pair = Assert.Single(_coreFileStorageService.Files);
+                Assert.Equal("content/integration-tests/version-lists/nuget.versioning.json", pair.Key);
+                var inMemoryFile = Assert.IsType<InMemoryFileReference>(pair.Value);
+                Assert.Equal(@"{
+  ""VersionProperties"": {
+    ""1.0.0-alpha"": {},
+    ""2.0.0+git"": {
+      ""Listed"": true,
+      ""SemVer2"": true
+    }
+  }
+}", inMemoryFile.AsString);
+            }
+        }
+
+        private void ClearBatches()
+        {
+            _hijackDocuments.Clear();
+            _searchDocuments.Clear();
+        }
+
+        [Fact]
+        public async Task DowngradeDueToDelete()
+        {
+            var identity1 = new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("1.0.0"));
+            var identity2 = new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("2.0.0-alpha"));
+            var leafUrl1 = "https://example/catalog/0/nuget.versioning.1.0.0.json";
+
+            // Step #1 - add two versions
+            {
+                // Arrange
+                var leafUrl2 = "https://example/catalog/0/nuget.versioning.2.0.0-alpha.json";
+                _catalogClient.PackageDetailsLeaves[leafUrl1] = CreateLeaf(leafUrl1, identity1, listed: true);
+                _catalogClient.PackageDetailsLeaves[leafUrl2] = CreateLeaf(leafUrl2, identity2, listed: true);
+                var items = new[]
+                {
+                    new CatalogCommitItem(
+                        uri: new Uri(leafUrl1),
+                        commitId: null,
+                        commitTimeStamp: new DateTime(2018, 12, 10, 0, 0, 0),
+                        types: new List<string>(),
+                        typeUris: new List<Uri> { Schema.DataTypes.PackageDetails },
+                        packageIdentity: identity1),
+                    new CatalogCommitItem(
+                        uri: new Uri(leafUrl2),
+                        commitId: null,
+                        commitTimeStamp: new DateTime(2018, 12, 10, 0, 0, 0),
+                        types: new List<string>(),
+                        typeUris: new List<Uri> { Schema.DataTypes.PackageDetails },
+                        packageIdentity: identity2),
+                };
+
+                // Act
+                await _collector.OnProcessBatchAsync(items);
+
+                // Assert
+                // Hijack documents
+                var hijackBatch = Assert.Single(_hijackDocuments.Batches);
+                var actions = hijackBatch.Actions.OrderBy(x => x.Document.Key).ToList();
+                Assert.Equal(2, actions.Count);
+                Assert.Equal(
+                    DocumentUtilities.GetHijackDocumentKey(identity1.Id, identity1.Version.ToNormalizedString()),
+                    actions[0].Document.Key);
+                Assert.Equal(IndexActionType.MergeOrUpload, actions[0].ActionType);
+                Assert.IsType<HijackDocument.Full>(actions[0].Document);
+                Assert.Equal(
+                    DocumentUtilities.GetHijackDocumentKey(identity2.Id, identity2.Version.ToNormalizedString()),
+                    actions[1].Document.Key);
+                Assert.Equal(IndexActionType.MergeOrUpload, actions[1].ActionType);
+                Assert.IsType<HijackDocument.Full>(actions[1].Document);
+
+                // Search documents
+                var searchBatch = Assert.Single(_searchDocuments.Batches);
+                AssertSearchBatch(
+                    identity1.Id,
+                    searchBatch,
+                    exDefault: IndexActionType.MergeOrUpload,
+                    exIncludePrerelease: IndexActionType.MergeOrUpload,
+                    exIncludeSemVer2: IndexActionType.MergeOrUpload,
+                    exIncludePrereleaseAndSemVer2: IndexActionType.MergeOrUpload);
+
+                // Version list
+                var pair = Assert.Single(_coreFileStorageService.Files);
+                Assert.Equal("content/integration-tests/version-lists/nuget.versioning.json", pair.Key);
+                var inMemoryFile = Assert.IsType<InMemoryFileReference>(pair.Value);
+                Assert.Equal(@"{
+  ""VersionProperties"": {
+    ""1.0.0"": {
+      ""Listed"": true
+    },
+    ""2.0.0-alpha"": {
+      ""Listed"": true
+    }
+  }
+}", inMemoryFile.AsString);
+            }
+
+            ClearBatches();
+
+            // Step #2 - delete the latest version
+            {
+                // Arrange
+                var leafUrl = "https://example/catalog/1/nuget.versioning.2.0.0-alpha.json";
+                var items = new[]
+                {
+                    new CatalogCommitItem(
+                        uri: new Uri(leafUrl),
+                        commitId: null,
+                        commitTimeStamp: new DateTime(2018, 12, 11, 0, 0, 0),
+                        types: new List<string>(),
+                        typeUris: new List<Uri> { Schema.DataTypes.PackageDelete },
+                        packageIdentity: identity2),
+                };
+                var registrationIndexUrl = "https://example/registrations/nuget.versioning/index.json";
+                var registrationPageUrl = "https://example/registrations/nuget.versioning/page/0.json";
+                _registrationClient.Indexes[registrationIndexUrl] = new RegistrationIndex
+                {
+                    Items = new List<RegistrationPage>
+                    {
+                        new RegistrationPage
+                        {
+                            Lower = identity1.Version.ToNormalizedString(),
+                            Upper = identity1.Version.ToNormalizedString(),
+                            Url = registrationPageUrl,
+                        },
+                    },
+                };
+                _registrationClient.Pages[registrationPageUrl] = new RegistrationPage
+                {
+                    Items = new List<RegistrationLeafItem>
+                    {
+                        new RegistrationLeafItem
+                        {
+                            CatalogEntry = new RegistrationCatalogEntry
+                            {
+                                Url = leafUrl1,
+                                Version = identity1.Version.ToNormalizedString(),
+                            }
+                        }
+                    }
+                };
+
+                // Act
+                await _collector.OnProcessBatchAsync(items);
+
+                // Assert
+                // Hijack documents
+                var hijackBatch = Assert.Single(_hijackDocuments.Batches);
+                var actions = hijackBatch.Actions.OrderBy(x => x.Document.Key).ToList();
+                Assert.Equal(2, actions.Count);
+                Assert.Equal(
+                    DocumentUtilities.GetHijackDocumentKey(identity1.Id, identity1.Version.ToNormalizedString()),
+                    actions[0].Document.Key);
+                Assert.Equal(IndexActionType.MergeOrUpload, actions[0].ActionType);
+                Assert.IsType<HijackDocument.Full>(actions[0].Document);
+                Assert.Equal(
+                    DocumentUtilities.GetHijackDocumentKey(identity2.Id, identity2.Version.ToNormalizedString()),
+                    actions[1].Document.Key);
+                Assert.Equal(IndexActionType.Delete, actions[1].ActionType);
+                Assert.IsType<KeyedDocument>(actions[1].Document);
+
+                // Search documents
+                var searchBatch = Assert.Single(_searchDocuments.Batches);
+                AssertSearchBatch(
+                    identity1.Id,
+                    searchBatch,
+                    exDefault: IndexActionType.MergeOrUpload,
+                    exIncludePrerelease: IndexActionType.MergeOrUpload,
+                    exIncludeSemVer2: IndexActionType.MergeOrUpload,
+                    exIncludePrereleaseAndSemVer2: IndexActionType.MergeOrUpload);
+
+                // Version list
+                var pair = Assert.Single(_coreFileStorageService.Files);
+                Assert.Equal("content/integration-tests/version-lists/nuget.versioning.json", pair.Key);
+                var inMemoryFile = Assert.IsType<InMemoryFileReference>(pair.Value);
+                Assert.Equal(@"{
+  ""VersionProperties"": {
+    ""1.0.0"": {
+      ""Listed"": true
+    }
+  }
+}", inMemoryFile.AsString);
+            }
+        }
+
+        private static PackageDetailsCatalogLeaf CreateLeaf(string url, PackageIdentity identity, bool listed)
+        {
+            return new PackageDetailsCatalogLeaf
+            {
+                Url = url,
+                PackageId = identity.Id,
+                PackageVersion = identity.Version.ToFullString(),
+                VerbatimVersion = identity.Version.OriginalVersion,
+                IsPrerelease = identity.Version.IsPrerelease,
+                Listed = listed,
+            };
+        }
+
+        private static void AssertSearchBatch(
+            string packageId,
+            IndexBatch<KeyedDocument> batch,
+            IndexActionType exDefault,
+            IndexActionType exIncludePrerelease,
+            IndexActionType exIncludeSemVer2,
+            IndexActionType exIncludePrereleaseAndSemVer2)
+        {
+            Assert.Equal(4, batch.Actions.Count());
+            var defaultSearch = Assert.Single(
+                batch.Actions,
+                x => DocumentUtilities.GetSearchDocumentKey(packageId, SearchFilters.Default) == x.Document.Key);
+            Assert.Equal(exDefault, defaultSearch.ActionType);
+            var includePrereleaseSearch = Assert.Single(
+                batch.Actions,
+                x => DocumentUtilities.GetSearchDocumentKey(packageId, SearchFilters.IncludePrerelease) == x.Document.Key);
+            Assert.Equal(exIncludePrerelease, includePrereleaseSearch.ActionType);
+            var includeSemVer2Search = Assert.Single(
+                batch.Actions,
+                x => DocumentUtilities.GetSearchDocumentKey(packageId, SearchFilters.IncludeSemVer2) == x.Document.Key);
+            Assert.Equal(exIncludeSemVer2, includeSemVer2Search.ActionType);
+            var includePrereleaseAndSemVer2Search = Assert.Single(
+                batch.Actions,
+                x => DocumentUtilities.GetSearchDocumentKey(packageId, SearchFilters.IncludePrereleaseAndSemVer2) == x.Document.Key);
+            Assert.Equal(exIncludePrereleaseAndSemVer2, includePrereleaseAndSemVer2Search.ActionType);
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryCatalogClient.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryCatalogClient.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using NuGet.Protocol.Catalog;
+
+namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
+{
+    public class InMemoryCatalogClient : ICatalogClient
+    {
+        public ConcurrentDictionary<string, PackageDetailsCatalogLeaf> PackageDetailsLeaves { get; } = new ConcurrentDictionary<string, PackageDetailsCatalogLeaf>();
+
+        public Task<CatalogIndex> GetIndexAsync(string indexUrl)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<CatalogLeaf> GetLeafAsync(string leafUrl)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<PackageDeleteCatalogLeaf> GetPackageDeleteLeafAsync(string leafUrl)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<PackageDetailsCatalogLeaf> GetPackageDetailsLeafAsync(string leafUrl)
+        {
+            return Task.FromResult(PackageDetailsLeaves[leafUrl]);
+        }
+
+        public Task<CatalogPage> GetPageAsync(string pageUrl)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryCoreFileStorageService.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryCoreFileStorageService.cs
@@ -1,0 +1,146 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage.Blob;
+using NuGetGallery;
+
+namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
+{
+    public class InMemoryCoreFileStorageService : ICoreFileStorageService
+    {
+        private readonly object _lock = new object();
+        private int _nextContentId = 0;
+
+        public Dictionary<string, InMemoryFileReference> Files { get; } = new Dictionary<string, InMemoryFileReference>();
+
+
+        public Task CopyFileAsync(Uri srcUri, string destFolderName, string destFileName, IAccessCondition destAccessCondition)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<string> CopyFileAsync(string srcFolderName, string srcFileName, string destFolderName, string destFileName, IAccessCondition destAccessCondition)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task DeleteFileAsync(string folderName, string fileName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<bool> FileExistsAsync(string folderName, string fileName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<string> GetETagOrNullAsync(string folderName, string fileName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<Stream> GetFileAsync(string folderName, string fileName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<Uri> GetFileReadUriAsync(string folderName, string fileName, DateTimeOffset? endOfAccess)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IFileReference> GetFileReferenceAsync(string folderName, string fileName, string ifNoneMatch = null)
+        {
+            var fullFileName = GetFullFileName(folderName, fileName);
+            lock (_lock)
+            {
+                if (!Files.TryGetValue(fullFileName, out var fileReference))
+                {
+                    return Task.FromResult<IFileReference>(null);
+                }
+
+                return Task.FromResult<IFileReference>(fileReference);
+            }
+        }
+
+        private static string GetFullFileName(string folderName, string fileName)
+        {
+            return $"{folderName}/{fileName}";
+        }
+
+        public Task<Uri> GetPriviledgedFileUriAsync(string folderName, string fileName, FileUriPermissions permissions, DateTimeOffset endOfAccess)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task SaveFileAsync(string folderName, string fileName, Stream file, bool overwrite = true)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task SaveFileAsync(string folderName, string fileName, string contentType, Stream file, bool overwrite = true)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task SaveFileAsync(string folderName, string fileName, Stream file, IAccessCondition accessCondition)
+        {
+            if (accessCondition.IfMatchETag == null && accessCondition.IfNoneMatchETag == null)
+            {
+                throw new ArgumentException($"Either {nameof(accessCondition.IfMatchETag)} or {nameof(accessCondition.IfNoneMatchETag)} must be set.");
+            }
+
+            if (accessCondition.IfMatchETag != null && accessCondition.IfNoneMatchETag != null)
+            {
+                throw new ArgumentException($"Exactly one of {nameof(accessCondition.IfMatchETag)} or {nameof(accessCondition.IfNoneMatchETag)} must be set, not both.");
+            }
+
+            if (accessCondition.IfNoneMatchETag != null && accessCondition.IfNoneMatchETag != "*")
+            {
+                throw new ArgumentException($"{nameof(accessCondition.IfNoneMatchETag)} must be set to either null or '*'.");
+            }
+
+            var fullFileName = GetFullFileName(folderName, fileName);
+            var buffer = new MemoryStream();
+            await file.CopyToAsync(buffer);
+            var newFileReference = new InMemoryFileReference(
+                contentId: Interlocked.Increment(ref _nextContentId).ToString(),
+                bytes: buffer.ToArray());
+
+            lock (_lock)
+            {
+                if (!Files.TryGetValue(fullFileName, out var fileReference))
+                {
+                    if (accessCondition.IfMatchETag != null)
+                    {
+                        throw new InvalidOperationException("The If-Match condition failed because the file does not exist.");
+                    }
+                }
+                else
+                {
+                    if (accessCondition.IfMatchETag != fileReference.ContentId)
+                    {
+                        throw new InvalidOperationException("The If-Match condition failed because it does not match the current etag.");
+                    }
+                }
+
+                Files[fullFileName] = newFileReference;
+            }
+        }
+
+        public Task SetMetadataAsync(string folderName, string fileName, Func<Lazy<Task<Stream>>, IDictionary<string, string>, Task<bool>> updateMetadataAsync)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task SetPropertiesAsync(string folderName, string fileName, Func<Lazy<Task<Stream>>, BlobProperties, Task<bool>> updatePropertiesAsync)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryDocumentsOperations.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryDocumentsOperations.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.Search.Models;
+using NuGet.Services.AzureSearch.Wrappers;
+
+namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
+{
+    public class InMemoryDocumentsOperations : IDocumentsOperationsWrapper
+    {
+        public ConcurrentQueue<IndexBatch<KeyedDocument>> Batches { get; } = new ConcurrentQueue<IndexBatch<KeyedDocument>>();
+
+        public void Clear()
+        {
+            while (Batches.Count > 0)
+            {
+                Batches.TryDequeue(out var _);
+            }
+        }
+
+        public Task<DocumentIndexResult> IndexAsync<T>(IndexBatch<T> batch) where T : class
+        {
+            if (typeof(T) != typeof(KeyedDocument))
+            {
+                throw new ArgumentException();
+            }
+
+            Batches.Enqueue(batch as IndexBatch<KeyedDocument>);
+
+            return Task.FromResult(new DocumentIndexResult(new List<IndexingResult>()));
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryFileReference.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryFileReference.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using NuGetGallery;
+
+namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
+{
+    public class InMemoryFileReference : IFileReference
+    {
+        private readonly byte[] _bytes;
+
+        public InMemoryFileReference(string contentId, byte[] bytes)
+        {
+            ContentId = contentId;
+            _bytes = bytes;
+        }
+
+        public string ContentId { get; }
+
+        public Stream OpenRead()
+        {
+            return new MemoryStream(_bytes);
+        }
+
+        public string AsString
+        {
+            get
+            {
+                using (var stream = OpenRead())
+                using (var reader = new StreamReader(stream))
+                {
+                    return reader.ReadToEnd();
+                }
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryRegistrationClient.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryRegistrationClient.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using NuGet.Protocol.Registration;
+
+namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
+{
+    public class InMemoryRegistrationClient : IRegistrationClient
+    {
+        public ConcurrentDictionary<string, RegistrationIndex> Indexes { get; } = new ConcurrentDictionary<string, RegistrationIndex>();
+        public ConcurrentDictionary<string, RegistrationPage> Pages { get; } = new ConcurrentDictionary<string, RegistrationPage>();
+        public ConcurrentDictionary<string, RegistrationLeaf> Leaves { get; } = new ConcurrentDictionary<string, RegistrationLeaf>();
+
+        public Task<RegistrationIndex> GetIndexOrNullAsync(string indexUrl)
+        {
+            if (Indexes.TryGetValue(indexUrl, out var index))
+            {
+                return Task.FromResult(index);
+            }
+
+            return Task.FromResult<RegistrationIndex>(null);
+        }
+
+        public Task<RegistrationLeaf> GetLeafAsync(string leafUrl)
+        {
+            return Task.FromResult(Leaves[leafUrl]);
+        }
+
+        public Task<RegistrationPage> GetPageAsync(string pageUrl)
+        {
+            return Task.FromResult(Pages[pageUrl]);
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/HijackDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/HijackDocumentBuilderFacts.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuGet.Services.AzureSearch.Support;
 using Xunit;
@@ -63,11 +64,12 @@ namespace NuGet.Services.AzureSearch
                 Assert.Equal(_fullJson, json);
             }
 
-            [Fact]
-            public void UsesIdForNullTitleInHijackIndex()
+            [Theory]
+            [MemberData(nameof(MissingTitles))]
+            public void UsesIdWhenMissingForSortableTitle(string title)
             {
                 var package = Data.PackageEntity;
-                package.Title = null;
+                package.Title = title;
 
                 var document = _target.Full(Data.PackageId, _changes, package);
 
@@ -137,14 +139,27 @@ namespace NuGet.Services.AzureSearch
                 Assert.Equal(_fullJson, json);
             }
 
-            [Fact]
-            public void UsesIdForNullTitleInHijackIndex()
+            [Theory]
+            [MemberData(nameof(MissingTitles))]
+            public void UsesIdWhenMissingForSortableTitle(string title)
             {
                 var leaf = Data.Leaf;
-                leaf.Title = null;
+                leaf.Title = title;
+
                 var document = _target.Full(Data.NormalizedVersion, _changes, leaf);
 
                 Assert.Equal(Data.PackageId, document.SortableTitle);
+            }
+
+            [Fact]
+            public void DefaultsRequiresLicenseAcceptanceToFalse()
+            {
+                var leaf = Data.Leaf;
+                leaf.RequireLicenseAgreement = null;
+
+                var document = _target.Full(Data.NormalizedVersion, _changes, leaf);
+
+                Assert.False(document.RequiresLicenseAcceptance);
             }
         }
 
@@ -153,6 +168,14 @@ namespace NuGet.Services.AzureSearch
             protected readonly HijackDocumentChanges _changes;
             protected readonly string _fullJson;
             protected readonly HijackDocumentBuilder _target;
+
+            public static IEnumerable<object[]> MissingTitles = new[]
+            {
+                new object[] { null },
+                new object[] { string.Empty },
+                new object[] { " " },
+                new object[] { " \t"},
+            };
 
             public BaseFacts()
             {
@@ -167,9 +190,6 @@ namespace NuGet.Services.AzureSearch
   ""value"": [
     {
       ""@search.action"": ""upload"",
-      ""lastEdited"": ""2017-01-02T00:00:00+00:00"",
-      ""published"": ""2017-01-03T00:00:00+00:00"",
-      ""sortableTitle"": ""Windows Azure Storage"",
       ""isLatestStableSemVer1"": false,
       ""isLatestSemVer1"": true,
       ""isLatestStableSemVer2"": false,
@@ -185,6 +205,7 @@ namespace NuGet.Services.AzureSearch
       ""hashAlgorithm"": ""SHA512"",
       ""iconUrl"": ""http://go.microsoft.com/fwlink/?LinkID=288890"",
       ""language"": ""en-US"",
+      ""lastEdited"": ""2017-01-02T00:00:00+00:00"",
       ""licenseUrl"": ""http://go.microsoft.com/fwlink/?LinkId=331471"",
       ""minClientVersion"": ""2.12"",
       ""normalizedVersion"": ""7.1.2-alpha"",
@@ -192,8 +213,10 @@ namespace NuGet.Services.AzureSearch
       ""packageId"": ""WindowsAzure.Storage"",
       ""prerelease"": true,
       ""projectUrl"": ""https://github.com/Azure/azure-storage-net"",
+      ""published"": ""2017-01-03T00:00:00+00:00"",
       ""releaseNotes"": ""Release notes."",
       ""requiresLicenseAcceptance"": true,
+      ""sortableTitle"": ""Windows Azure Storage"",
       ""summary"": ""Summary."",
       ""tags"": [
         ""Microsoft"",

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -39,9 +39,15 @@
   <ItemGroup>
     <Compile Include="BatchPusherFacts.cs" />
     <Compile Include="Catalog2AzureSearch\AzureSearchCollectorLogicFacts.cs" />
+    <Compile Include="Catalog2AzureSearch\Integration\AzureSearchCollectorLogicIntegrationTests.cs" />
     <Compile Include="Catalog2AzureSearch\Catalog2AzureSearchCommandFacts.cs" />
     <Compile Include="Catalog2AzureSearch\CatalogIndexActionBuilderFacts.cs" />
     <Compile Include="Catalog2AzureSearch\CatalogLeafFetcherFacts.cs" />
+    <Compile Include="Catalog2AzureSearch\Integration\InMemoryCatalogClient.cs" />
+    <Compile Include="Catalog2AzureSearch\Integration\InMemoryCoreFileStorageService.cs" />
+    <Compile Include="Catalog2AzureSearch\Integration\InMemoryDocumentsOperations.cs" />
+    <Compile Include="Catalog2AzureSearch\Integration\InMemoryFileReference.cs" />
+    <Compile Include="Catalog2AzureSearch\Integration\InMemoryRegistrationClient.cs" />
     <Compile Include="Db2AzureSearch\Db2AzureSearchCommandFacts.cs" />
     <Compile Include="Db2AzureSearch\EnumerableExtensionsFacts.cs" />
     <Compile Include="Db2AzureSearch\NewPackageRegistrationProducerFacts.cs" />


### PR DESCRIPTION
This mocks out Azure Search, blob storage, registration, and catalog but leaves everything else as a concrete implementation.

This is a similar approach to the integration tests made for process signature job where we use Xunit and selective mocks to run some integration tests against some complex business logic.