### PR TITLE
Add initial field attributes for Azure Search and SortableTitle to search index

### DIFF
--- a/src/NuGet.Services.AzureSearch/HijackDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/HijackDocumentBuilder.cs
@@ -38,7 +38,7 @@ namespace NuGet.Services.AzureSearch
         {
             var document = new HijackDocument.Full();
 
-            PopulateFull(document, leaf.PackageId, normalizedVersion, changes, leaf.Title);
+            PopulateLatest(document, leaf.PackageId, normalizedVersion, changes);
             DocumentUtilities.PopulateMetadata(document, normalizedVersion, leaf);
 
             return document;
@@ -51,21 +51,10 @@ namespace NuGet.Services.AzureSearch
         {
             var document = new HijackDocument.Full();
 
-            PopulateFull(document, packageId, package.NormalizedVersion, changes, package.Title);
+            PopulateLatest(document, packageId, package.NormalizedVersion, changes);
             DocumentUtilities.PopulateMetadata(document, packageId, package);
 
             return document;
-        }
-
-        private static void PopulateFull(
-            HijackDocument.Full document,
-            string packageId,
-            string normalizedVersion,
-            HijackDocumentChanges changes,
-            string title)
-        {
-            PopulateLatest(document, packageId, normalizedVersion, changes);
-            document.SortableTitle = title ?? packageId;
         }
 
         private static void PopulateLatest<T>(

--- a/src/NuGet.Services.AzureSearch/Models/BaseMetadataDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/BaseMetadataDocument.cs
@@ -3,39 +3,64 @@
 
 using System;
 using Microsoft.Azure.Search;
+using Microsoft.Azure.Search.Models;
 
 namespace NuGet.Services.AzureSearch
 {
-    /// <summary>
-    /// Implements most of <see cref="IBaseMetadataDocument"/>. Some fields are not defined here since they have
-    /// different Azure Search attributes.
-    /// </summary>
-    public abstract class BaseMetadataDocument : KeyedDocument
+    public abstract class BaseMetadataDocument : KeyedDocument, IBaseMetadataDocument
     {
         [IsFilterable]
         public int? SemVerLevel { get; set; }
 
+        [IsSearchable]
         public string Authors { get; set; }
+
         public string Copyright { get; set; }
         public DateTimeOffset? Created { get; set; }
+
+        [IsSearchable]
         public string Description { get; set; }
+
         public long? FileSize { get; set; }
         public string FlattenedDependencies { get; set; }
         public string Hash { get; set; }
         public string HashAlgorithm { get; set; }
         public string IconUrl { get; set; }
         public string Language { get; set; }
+
+        [IsSortable]
+        public DateTimeOffset? LastEdited { get; set; }
+
         public string LicenseUrl { get; set; }
         public string MinClientVersion { get; set; }
+
+        [IsSearchable]
         public string NormalizedVersion { get; set; }
+
         public string OriginalVersion { get; set; }
+
+        [IsSearchable]
         public string PackageId { get; set; }
+
         public bool? Prerelease { get; set; }
         public string ProjectUrl { get; set; }
+
+        [IsSortable]
+        public DateTimeOffset? Published { get; set; }
+
         public string ReleaseNotes { get; set; }
         public bool? RequiresLicenseAcceptance { get; set; }
+
+        [IsSortable]
+        public string SortableTitle { get; set; }
+
+        [IsSearchable]
         public string Summary { get; set; }
+
+        [IsSearchable]
         public string[] Tags { get; set; }
+
+        [IsSearchable]
         public string Title { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/Models/HijackDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/HijackDocument.cs
@@ -19,13 +19,6 @@ namespace NuGet.Services.AzureSearch
         [SerializePropertyNamesAsCamelCase]
         public class Full : BaseMetadataDocument, ILatest, IBaseMetadataDocument
         {
-            [IsSortable]
-            public DateTimeOffset? LastEdited { get; set; }
-            [IsSortable]
-            public DateTimeOffset? Published { get; set; }
-            [IsSortable]
-            public string SortableTitle { get; set; }
-
             public bool? IsLatestStableSemVer1 { get; set; }
             public bool? IsLatestSemVer1 { get; set; }
             public bool? IsLatestStableSemVer2 { get; set; }

--- a/src/NuGet.Services.AzureSearch/Models/IBaseMetadataDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/IBaseMetadataDocument.cs
@@ -27,11 +27,12 @@ namespace NuGet.Services.AzureSearch
         string OriginalVersion { get; set; }
         string PackageId { get; set; }
         bool? Prerelease { get; set; }
-        DateTimeOffset? Published { get; set; }
         string ProjectUrl { get; set; }
+        DateTimeOffset? Published { get; set; }
         string ReleaseNotes { get; set; }
         bool? RequiresLicenseAcceptance { get; set; }
         int? SemVerLevel { get; set; }
+        string SortableTitle { get; set; }
         string Summary { get; set; }
         string[] Tags { get; set; }
         string Title { get; set; }

--- a/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
@@ -29,6 +29,7 @@ namespace NuGet.Services.AzureSearch
         [SerializePropertyNamesAsCamelCase]
         public class AddFirst : UpdateLatest
         {
+            [IsSearchable]
             public string[] Owners { get; set; }
         }
 
@@ -37,14 +38,12 @@ namespace NuGet.Services.AzureSearch
         /// <see cref="SearchIndexChangeType.DowngradeLatest"/>.
         /// </summary>
         [SerializePropertyNamesAsCamelCase]
-        public class UpdateLatest : BaseMetadataDocument, IVersions, IBaseMetadataDocument
+        public class UpdateLatest : BaseMetadataDocument, IVersions
         {
             [IsFilterable]
             public string SearchFilters { get; set; }
 
             public string FullVersion { get; set; }
-            public DateTimeOffset? LastEdited { get; set; }
-            public DateTimeOffset? Published { get; set; }
             public string[] Versions { get; set; }
             public bool? IsLatestStable { get; set; }
             public bool? IsLatest { get; set; }

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -170,7 +170,7 @@ namespace NuGet.Services.AzureSearch
             string fullVersion)
         {
             PopulateVersions(document, packageId, searchFilters, versions, isLatestStable, isLatest);
-            document.SearchFilters = searchFilters.ToString();
+            document.SearchFilters = DocumentUtilities.GetSearchFilterString(searchFilters);
             document.FullVersion = fullVersion;
         }
 

--- a/tests/NuGet.Services.AzureSearch.Tests/HijackDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/HijackDocumentBuilderFacts.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuGet.Services.AzureSearch.Support;
 using Xunit;
@@ -63,11 +64,12 @@ namespace NuGet.Services.AzureSearch
                 Assert.Equal(_fullJson, json);
             }
 
-            [Fact]
-            public void UsesIdForNullTitleInHijackIndex()
+            [Theory]
+            [MemberData(nameof(MissingTitles))]
+            public void UsesIdWhenMissingForSortableTitle(string title)
             {
                 var package = Data.PackageEntity;
-                package.Title = null;
+                package.Title = title;
 
                 var document = _target.Full(Data.PackageId, _changes, package);
 
@@ -137,14 +139,27 @@ namespace NuGet.Services.AzureSearch
                 Assert.Equal(_fullJson, json);
             }
 
-            [Fact]
-            public void UsesIdForNullTitleInHijackIndex()
+            [Theory]
+            [MemberData(nameof(MissingTitles))]
+            public void UsesIdWhenMissingForSortableTitle(string title)
             {
                 var leaf = Data.Leaf;
-                leaf.Title = null;
+                leaf.Title = title;
+
                 var document = _target.Full(Data.NormalizedVersion, _changes, leaf);
 
                 Assert.Equal(Data.PackageId, document.SortableTitle);
+            }
+
+            [Fact]
+            public void DefaultsRequiresLicenseAcceptanceToFalse()
+            {
+                var leaf = Data.Leaf;
+                leaf.RequireLicenseAgreement = null;
+
+                var document = _target.Full(Data.NormalizedVersion, _changes, leaf);
+
+                Assert.False(document.RequiresLicenseAcceptance);
             }
         }
 
@@ -153,6 +168,14 @@ namespace NuGet.Services.AzureSearch
             protected readonly HijackDocumentChanges _changes;
             protected readonly string _fullJson;
             protected readonly HijackDocumentBuilder _target;
+
+            public static IEnumerable<object[]> MissingTitles = new[]
+            {
+                new object[] { null },
+                new object[] { string.Empty },
+                new object[] { " " },
+                new object[] { " \t"},
+            };
 
             public BaseFacts()
             {
@@ -167,9 +190,6 @@ namespace NuGet.Services.AzureSearch
   ""value"": [
     {
       ""@search.action"": ""upload"",
-      ""lastEdited"": ""2017-01-02T00:00:00+00:00"",
-      ""published"": ""2017-01-03T00:00:00+00:00"",
-      ""sortableTitle"": ""Windows Azure Storage"",
       ""isLatestStableSemVer1"": false,
       ""isLatestSemVer1"": true,
       ""isLatestStableSemVer2"": false,
@@ -185,6 +205,7 @@ namespace NuGet.Services.AzureSearch
       ""hashAlgorithm"": ""SHA512"",
       ""iconUrl"": ""http://go.microsoft.com/fwlink/?LinkID=288890"",
       ""language"": ""en-US"",
+      ""lastEdited"": ""2017-01-02T00:00:00+00:00"",
       ""licenseUrl"": ""http://go.microsoft.com/fwlink/?LinkId=331471"",
       ""minClientVersion"": ""2.12"",
       ""normalizedVersion"": ""7.1.2-alpha"",
@@ -192,8 +213,10 @@ namespace NuGet.Services.AzureSearch
       ""packageId"": ""WindowsAzure.Storage"",
       ""prerelease"": true,
       ""projectUrl"": ""https://github.com/Azure/azure-storage-net"",
+      ""published"": ""2017-01-03T00:00:00+00:00"",
       ""releaseNotes"": ""Release notes."",
       ""requiresLicenseAcceptance"": true,
+      ""sortableTitle"": ""Windows Azure Storage"",
       ""summary"": ""Summary."",
       ""tags"": [
         ""Microsoft"",


### PR DESCRIPTION
Existing search service treats an empty string title as missing so package ID is used instead of title for the sortable title field.

This moves our documents a little closer to what they need to be.