### PR TITLE
[Search 1] Add debugging properties to documents submitted to Azure Search

### DIFF
--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/PackageEntityIndexActionBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/PackageEntityIndexActionBuilder.cs
@@ -141,7 +141,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
 
             VerifyConsistency(packageRegistration.PackageId, package);
 
-            return IndexAction.Upload<KeyedDocument>(_search.Full(
+            return IndexAction.Upload<KeyedDocument>(_search.FullFromDb(
                 packageRegistration.PackageId,
                 searchFilters,
                 latestFlags.LatestVersionInfo.ListedFullVersions,
@@ -167,7 +167,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
 
             VerifyConsistency(packageId, package);
 
-            return IndexAction.Upload<KeyedDocument>(_hijack.Full(
+            return IndexAction.Upload<KeyedDocument>(_hijack.FullFromDb(
                 packageId,
                 changes,
                 package));

--- a/src/NuGet.Services.AzureSearch/DocumentUtilities.cs
+++ b/src/NuGet.Services.AzureSearch/DocumentUtilities.cs
@@ -33,6 +33,44 @@ namespace NuGet.Services.AzureSearch
             return searchFilters.ToString();
         }
 
+        public static void PopulateCommitted(
+            ICommittedDocument document,
+            bool lastUpdatedFromCatalog,
+            DateTimeOffset? lastCommitTimestamp,
+            string lastCommitId)
+        {
+            if (lastUpdatedFromCatalog)
+            {
+                if (lastCommitTimestamp == null)
+                {
+                    throw new ArgumentNullException(nameof(lastCommitTimestamp));
+                }
+
+                if (lastCommitId == null)
+                {
+                    throw new ArgumentNullException(nameof(lastCommitId));
+                }
+            }
+            else
+            {
+                if (lastCommitTimestamp != null)
+                {
+                    throw new ArgumentException("The last commit timestamp must be null when not updated from the catalog", nameof(lastCommitTimestamp));
+                }
+
+                if (lastCommitId != null)
+                {
+                    throw new ArgumentException("The last commit ID must be null when not updated from the catalog", nameof(lastCommitId));
+                }
+            }
+
+            document.SetLastUpdatedDocumentOnNextRead();
+            document.LastDocumentType = document.GetType().FullName;
+            document.LastUpdatedFromCatalog = lastUpdatedFromCatalog;
+            document.LastCommitTimestamp = lastCommitTimestamp;
+            document.LastCommitId = lastCommitId;
+        }
+
         public static void PopulateMetadata(
             IBaseMetadataDocument document,
             string packageId,

--- a/src/NuGet.Services.AzureSearch/IHijackDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/IHijackDocumentBuilder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using NuGet.Protocol.Catalog;
 using NuGet.Services.Entities;
 
@@ -12,17 +13,19 @@ namespace NuGet.Services.AzureSearch
             string packageId,
             string normalizedVersion);
 
-        HijackDocument.Latest Latest(
+        HijackDocument.Latest LatestFromCatalog(
             string packageId,
             string normalizedVersion,
+            DateTimeOffset lastCommitTimestamp,
+            string lastCommitId,
             HijackDocumentChanges changes);
 
-        HijackDocument.Full Full(
+        HijackDocument.Full FullFromDb(
             string packageId,
             HijackDocumentChanges changes,
             Package package);
 
-        HijackDocument.Full Full(
+        HijackDocument.Full FullFromCatalog(
             string normalizedVersion,
             HijackDocumentChanges changes,
             PackageDetailsCatalogLeaf leaf);

--- a/src/NuGet.Services.AzureSearch/ISearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/ISearchDocumentBuilder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using NuGet.Protocol.Catalog;
 using NuGet.Services.Entities;
 
@@ -16,14 +17,16 @@ namespace NuGet.Services.AzureSearch
             string packageId,
             SearchFilters searchFilters);
 
-        SearchDocument.UpdateVersionList UpdateVersionList(
+        SearchDocument.UpdateVersionList UpdateVersionListFromCatalog(
             string packageId,
             SearchFilters searchFilters,
+            DateTimeOffset lastCommitTimestamp,
+            string lastCommitId,
             string[] versions,
             bool isLatestStable,
             bool isLatest);
 
-        SearchDocument.Full Full(
+        SearchDocument.Full FullFromDb(
             string packageId, 
             SearchFilters searchFilters,
             string[] versions,
@@ -34,7 +37,7 @@ namespace NuGet.Services.AzureSearch
             string[] owners,
             long totalDownloadCount);
 
-        SearchDocument.UpdateLatest UpdateLatest(
+        SearchDocument.UpdateLatest UpdateLatestFromCatalog(
             SearchFilters searchFilters,
             string[] versions,
             bool isLatestStable,

--- a/src/NuGet.Services.AzureSearch/Models/BaseMetadataDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/BaseMetadataDocument.cs
@@ -6,7 +6,7 @@ using Microsoft.Azure.Search;
 
 namespace NuGet.Services.AzureSearch
 {
-    public abstract class BaseMetadataDocument : KeyedDocument, IBaseMetadataDocument
+    public abstract class BaseMetadataDocument : CommittedDocument, IBaseMetadataDocument
     {
         [IsFilterable]
         public int? SemVerLevel { get; set; }

--- a/src/NuGet.Services.AzureSearch/Models/CommittedDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/CommittedDocument.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Newtonsoft.Json;
+
+namespace NuGet.Services.AzureSearch
+{
+    public abstract class CommittedDocument : KeyedDocument, ICommittedDocument
+    {
+        private readonly CurrentTimestamp _lastUpdatedDocument = new CurrentTimestamp();
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
+        public DateTimeOffset? LastUpdatedDocument
+        {
+            get => _lastUpdatedDocument.Value;
+            set => _lastUpdatedDocument.Value = value;
+        }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
+        public string LastDocumentType { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
+        public bool? LastUpdatedFromCatalog { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
+        public DateTimeOffset? LastCommitTimestamp { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
+        public string LastCommitId { get; set; }
+
+        public void SetLastUpdatedDocumentOnNextRead()
+        {
+            _lastUpdatedDocument.SetOnNextRead();
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Models/CurrentTimestamp.cs
+++ b/src/NuGet.Services.AzureSearch/Models/CurrentTimestamp.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+
+namespace NuGet.Services.AzureSearch
+{
+    /// <summary>
+    /// A "last updated" timestamp set on an Azure Search document is approximate since there is some undefined time
+    /// between when the document is initialized, then serialized, then pushed to Azure Search, then applied to the
+    /// index, then made available in a search result. The only period of time that we can mitigate is time between
+    /// initializing the document and when it is serialized to be sent to Azure Search. To do this, we introduce this
+    /// stateful type that can capture the current timestamp in <see cref="Value"/> when it is next read. This is so
+    /// the current timestamp is captured as we are serializing the document to JSON to be sent to the Azure Search
+    /// REST API.
+    /// </summary>
+    public class CurrentTimestamp
+    {
+        public const int FalseInt = 0;
+        public const int TrueInt = 1;
+
+        private int _setOnNextRead = FalseInt;
+        private DateTimeOffset? _value;
+
+        /// <summary>
+        /// Defaults to <c>null</c>. After <see cref="SetOnNextRead"/> is called, the next time the getter of
+        /// <see cref="Value"/> is the current timestamp is captured then returned. The setter can be used to set the
+        /// the value but does not undo any calls to <see cref="SetOnNextRead"/>. In other words, if <see cref="SetOnNextRead"/> is
+        /// called, then <see cref="Value"/> is set to an arbitrary timestamp, the the getter is called, the current
+        /// timestamp will still be captured.
+        /// </summary>
+        public DateTimeOffset? Value
+        {
+            get
+            {
+                var existingValue = Interlocked.CompareExchange(
+                    ref _setOnNextRead,
+                    FalseInt,
+                    TrueInt);
+                if (existingValue == TrueInt)
+                {
+                    _value = DateTimeOffset.UtcNow;
+                }
+
+                return _value;
+            }
+
+            set
+            {
+                _value = value;
+            }
+        }
+
+        public void SetOnNextRead()
+        {
+            _setOnNextRead = TrueInt;
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Models/HijackDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/HijackDocument.cs
@@ -28,7 +28,7 @@ namespace NuGet.Services.AzureSearch
         /// and <see cref="HijackDocumentChanges.Delete"/> is <c>false</c>.
         /// </summary>
         [SerializePropertyNamesAsCamelCase]
-        public class Latest : KeyedDocument, ILatest
+        public class Latest : CommittedDocument, ILatest
         {
             public bool? IsLatestStableSemVer1 { get; set; }
             public bool? IsLatestSemVer1 { get; set; }
@@ -39,7 +39,7 @@ namespace NuGet.Services.AzureSearch
         /// <summary>
         /// Allows index updating code to update the latest booleans.
         /// </summary>
-        public interface ILatest : IKeyedDocument
+        public interface ILatest : ICommittedDocument
         {
             bool? IsLatestStableSemVer1 { get; set; }
             bool? IsLatestSemVer1 { get; set; }

--- a/src/NuGet.Services.AzureSearch/Models/IBaseMetadataDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/IBaseMetadataDocument.cs
@@ -8,7 +8,7 @@ namespace NuGet.Services.AzureSearch
     /// <summary>
     /// The fields shared between the search index and hijack index.
     /// </summary>
-    public interface IBaseMetadataDocument
+    public interface IBaseMetadataDocument : ICommittedDocument
     {
         string Authors { get; set; }
         string Copyright { get; set; }

--- a/src/NuGet.Services.AzureSearch/Models/ICommittedDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/ICommittedDocument.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.AzureSearch
+{
+    /// <summary>
+    /// A document that has data committed from the catalog.
+    /// </summary>
+    public interface ICommittedDocument : IKeyedDocument
+    {
+        DateTimeOffset? LastUpdatedDocument { get; set; }
+        string LastDocumentType { get; set; }
+        bool? LastUpdatedFromCatalog { get; set; }
+        DateTimeOffset? LastCommitTimestamp { get; set; }
+        string LastCommitId { get; set; }
+        void SetLastUpdatedDocumentOnNextRead();
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.Azure.Search;
 using Microsoft.Azure.Search.Models;
 
@@ -53,7 +52,7 @@ namespace NuGet.Services.AzureSearch
         /// Used when processing <see cref="SearchIndexChangeType.UpdateVersionList"/>.
         /// </summary>
         [SerializePropertyNamesAsCamelCase]
-        public class UpdateVersionList : KeyedDocument, IVersions
+        public class UpdateVersionList : CommittedDocument, IVersions
         {
             public string[] Versions { get; set; }
             public bool? IsLatestStable { get; set; }
@@ -63,7 +62,7 @@ namespace NuGet.Services.AzureSearch
         /// <summary>
         /// Allows index updating code to apply a new version list to a document.
         /// </summary>
-        public interface IVersions : IKeyedDocument
+        public interface IVersions : ICommittedDocument
         {
             string[] Versions { get; set; }
             bool? IsLatestStable { get; set; }

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -77,7 +77,10 @@
     <Compile Include="Db2AzureSearch\IPackageEntityIndexActionBuilder.cs" />
     <Compile Include="IndexBuilder.cs" />
     <Compile Include="ISearchDocumentBuilder.cs" />
+    <Compile Include="Models\CommittedDocument.cs" />
+    <Compile Include="Models\CurrentTimestamp.cs" />
     <Compile Include="Models\IBaseMetadataDocument.cs" />
+    <Compile Include="Models\ICommittedDocument.cs" />
     <Compile Include="Models\KeyedDocument.cs" />
     <Compile Include="Models\BaseMetadataDocument.cs" />
     <Compile Include="Models\HijackDocument.cs" />
@@ -133,7 +136,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.Search">
-      <Version>5.0.2</Version>
+      <Version>5.0.3</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Common.Job">
       <Version>4.1.0-master-2197886</Version>

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/AzureSearchCollectorLogicIntegrationTests.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/AzureSearchCollectorLogicIntegrationTests.cs
@@ -100,17 +100,22 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
             // Step #1 - add a version
             {
                 // Arrange
+                var commitTimestamp = new DateTimeOffset(2018, 12, 10, 0, 0, 0, TimeSpan.Zero);
+                var commitId = "3998eda6-3931-4d0f-9975-d9893648d89c";
                 var leafUrl = "https://example/catalog/0/nuget.versioning.1.0.0-alpha.json";
-                _catalogClient.PackageDetailsLeaves[leafUrl] = CreateLeaf(leafUrl, identity1, listed: true);
+                _catalogClient.PackageDetailsLeaves[leafUrl] = CreatePackageDetailsLeaf(
+                    commitTimestamp,
+                    commitId,
+                    leafUrl,
+                    identity1,
+                    listed: true);
                 var items = new[]
                 {
-                    new CatalogCommitItem(
-                        uri: new Uri(leafUrl),
-                        commitId: null,
-                        commitTimeStamp: new DateTime(2018, 12, 10, 0, 0, 0),
-                        types: new List<string>(),
-                        typeUris: new List<Uri> { Schema.DataTypes.PackageDetails },
-                        packageIdentity: identity1)
+                    CreatePackageDetailsItem(
+                        commitTimestamp,
+                        commitId,
+                        leafUrl,
+                        identity1)
                 };
 
                 // Act
@@ -154,17 +159,22 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
             // Step #2 - add another version
             {
                 // Arrange
+                var commitTimestamp = new DateTimeOffset(2018, 12, 11, 0, 0, 0, TimeSpan.Zero);
+                var commitId = "00c01b51-ffd4-4f55-b212-0c10d2a06dbc";
                 var leafUrl = "https://example/catalog/0/nuget.versioning.2.0.0.json";
-                _catalogClient.PackageDetailsLeaves[leafUrl] = CreateLeaf(leafUrl, identity2, listed: true);
+                _catalogClient.PackageDetailsLeaves[leafUrl] = CreatePackageDetailsLeaf(
+                    commitTimestamp,
+                    commitId,
+                    leafUrl,
+                    identity2,
+                    listed: true);
                 var items = new[]
                 {
-                    new CatalogCommitItem(
-                        uri: new Uri(leafUrl),
-                        commitId: null,
-                        commitTimeStamp: new DateTime(2018, 12, 11, 0, 0, 0),
-                        types: new List<string>(),
-                        typeUris: new List<Uri> { Schema.DataTypes.PackageDetails },
-                        packageIdentity: identity2)
+                    CreatePackageDetailsItem(
+                        commitTimestamp,
+                        commitId,
+                        leafUrl,
+                        identity2)
                 };
 
                 // Act
@@ -218,17 +228,22 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
             // Step #3 - unlist the first version
             {
                 // Arrange
+                var commitTimestamp = new DateTimeOffset(2018, 12, 12, 0, 0, 0, TimeSpan.Zero);
+                var commitId = "bd9599c7-4512-4094-817e-dacef6674924";
                 var leafUrl = "https://example/catalog/2/nuget.versioning.1.0.0-alpha.json";
-                _catalogClient.PackageDetailsLeaves[leafUrl] = CreateLeaf(leafUrl, identity1, listed: false);
+                _catalogClient.PackageDetailsLeaves[leafUrl] = CreatePackageDetailsLeaf(
+                    commitTimestamp,
+                    commitId,
+                    leafUrl, 
+                    identity1, 
+                    listed: false);
                 var items = new[]
                 {
-                    new CatalogCommitItem(
-                        uri: new Uri(leafUrl),
-                        commitId: null,
-                        commitTimeStamp: new DateTime(2018, 12, 12, 0, 0, 0),
-                        types: new List<string>(),
-                        typeUris: new List<Uri> { Schema.DataTypes.PackageDetails },
-                        packageIdentity: identity1)
+                    CreatePackageDetailsItem(
+                        commitTimestamp,
+                        commitId,
+                        leafUrl,
+                        identity1),
                 };
 
                 // Act
@@ -292,25 +307,25 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
             // Step #1 - add two versions
             {
                 // Arrange
+                var commitTimestamp = new DateTimeOffset(2018, 12, 10, 0, 0, 0, TimeSpan.Zero);
+                var commitId = "76d0014c-60f8-427f-8eac-3dfbf8369296";
                 var leafUrl2 = "https://example/catalog/0/nuget.versioning.2.0.0-alpha.json";
-                _catalogClient.PackageDetailsLeaves[leafUrl1] = CreateLeaf(leafUrl1, identity1, listed: true);
-                _catalogClient.PackageDetailsLeaves[leafUrl2] = CreateLeaf(leafUrl2, identity2, listed: true);
+                _catalogClient.PackageDetailsLeaves[leafUrl1] = CreatePackageDetailsLeaf(
+                    commitTimestamp,
+                    commitId,
+                    leafUrl1, 
+                    identity1,
+                    listed: true);
+                _catalogClient.PackageDetailsLeaves[leafUrl2] = CreatePackageDetailsLeaf(
+                    commitTimestamp,
+                    commitId,
+                    leafUrl2,
+                    identity2,
+                    listed: true);
                 var items = new[]
                 {
-                    new CatalogCommitItem(
-                        uri: new Uri(leafUrl1),
-                        commitId: null,
-                        commitTimeStamp: new DateTime(2018, 12, 10, 0, 0, 0),
-                        types: new List<string>(),
-                        typeUris: new List<Uri> { Schema.DataTypes.PackageDetails },
-                        packageIdentity: identity1),
-                    new CatalogCommitItem(
-                        uri: new Uri(leafUrl2),
-                        commitId: null,
-                        commitTimeStamp: new DateTime(2018, 12, 10, 0, 0, 0),
-                        types: new List<string>(),
-                        typeUris: new List<Uri> { Schema.DataTypes.PackageDetails },
-                        packageIdentity: identity2),
+                    CreatePackageDetailsItem(commitTimestamp, commitId, leafUrl1, identity1),
+                    CreatePackageDetailsItem(commitTimestamp, commitId, leafUrl2, identity2),
                 };
 
                 // Act
@@ -363,16 +378,16 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
             // Step #2 - delete the latest version
             {
                 // Arrange
+                var commitTimestamp = new DateTimeOffset(2018, 12, 11, 0, 0, 0, TimeSpan.Zero);
+                var commitId = "68131297-699f-4d68-952e-c0a4eacbd6da";
                 var leafUrl = "https://example/catalog/1/nuget.versioning.2.0.0-alpha.json";
                 var items = new[]
                 {
-                    new CatalogCommitItem(
-                        uri: new Uri(leafUrl),
-                        commitId: null,
-                        commitTimeStamp: new DateTime(2018, 12, 11, 0, 0, 0),
-                        types: new List<string>(),
-                        typeUris: new List<Uri> { Schema.DataTypes.PackageDelete },
-                        packageIdentity: identity2),
+                    CreatePackageDeleteItem(
+                        commitTimestamp,
+                        commitId,
+                        leafUrl,
+                        identity2),
                 };
                 var registrationIndexUrl = "https://example/registrations/nuget.versioning/index.json";
                 var registrationPageUrl = "https://example/registrations/nuget.versioning/page/0.json";
@@ -446,10 +461,61 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
             }
         }
 
-        private static PackageDetailsCatalogLeaf CreateLeaf(string url, PackageIdentity identity, bool listed)
+        private static CatalogCommitItem CreatePackageDetailsItem(
+            DateTimeOffset commitTimestamp,
+            string commitId,
+            string leafUrl,
+            PackageIdentity identity)
+        {
+            return CreateItem(
+                commitTimestamp,
+                commitId,
+                leafUrl,
+                identity,
+                Schema.DataTypes.PackageDetails);
+        }
+
+        private static CatalogCommitItem CreatePackageDeleteItem(
+            DateTimeOffset commitTimestamp,
+            string commitId,
+            string leafUrl,
+            PackageIdentity identity)
+        {
+            return CreateItem(
+                commitTimestamp,
+                commitId,
+                leafUrl,
+                identity,
+                Schema.DataTypes.PackageDelete);
+        }
+
+        private static CatalogCommitItem CreateItem(
+            DateTimeOffset commitTimestamp,
+            string commitId,
+            string leafUrl,
+            PackageIdentity identity,
+            Uri type)
+        {
+            return new CatalogCommitItem(
+                uri: new Uri(leafUrl),
+                commitId: commitId,
+                commitTimeStamp: commitTimestamp.UtcDateTime,
+                types: new List<string>(),
+                typeUris: new List<Uri> { type },
+                packageIdentity: identity);
+        }
+
+        private static PackageDetailsCatalogLeaf CreatePackageDetailsLeaf(
+            DateTimeOffset commitTimestamp,
+            string commitId,
+            string url,
+            PackageIdentity identity,
+            bool listed)
         {
             return new PackageDetailsCatalogLeaf
             {
+                CommitTimestamp = commitTimestamp,
+                CommitId = commitId,
                 Url = url,
                 PackageId = identity.Id,
                 PackageVersion = identity.Version.ToFullString(),

--- a/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/PackageEntityIndexActionBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/PackageEntityIndexActionBuilderFacts.cs
@@ -44,7 +44,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                     x => x.Keyed(input.PackageId, SearchFilters.IncludeSemVer2),
                     Times.Once);
                 _search.Verify(
-                    x => x.Full(
+                    x => x.FullFromDb(
                         input.PackageId,
                         SearchFilters.IncludePrereleaseAndSemVer2,
                         It.IsAny<string[]>(),
@@ -61,7 +61,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
             public void UsesLatestVersionMetadataForSearchIndex()
             {
                 _search
-                    .Setup(x => x.Full(
+                    .Setup(x => x.FullFromDb(
                         It.IsAny<string>(),
                         It.IsAny<SearchFilters>(),
                         It.IsAny<string[]>(),
@@ -120,7 +120,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
             public void UsesSemVerLevelToIndicateSemVer2()
             {
                 _search
-                    .Setup(x => x.Full(
+                    .Setup(x => x.FullFromDb(
                         It.IsAny<string>(),
                         It.IsAny<SearchFilters>(),
                         It.IsAny<string[]>(),

--- a/tests/NuGet.Services.AzureSearch.Tests/HijackDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/HijackDocumentBuilderFacts.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuGet.Services.AzureSearch.Support;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuGet.Services.AzureSearch
 {
@@ -13,6 +14,10 @@ namespace NuGet.Services.AzureSearch
     {
         public class Keyed : BaseFacts
         {
+            public Keyed(ITestOutputHelper output) : base(output)
+            {
+            }
+
             [Fact]
             public async Task SetsExpectedProperties()
             {
@@ -30,13 +35,23 @@ namespace NuGet.Services.AzureSearch
             }
         }
 
-        public class Latest : BaseFacts
+        public class LatestFromCatalog : BaseFacts
         {
+            public LatestFromCatalog(ITestOutputHelper output) : base(output)
+            {
+            }
+
             [Fact]
             public async Task SetsExpectedProperties()
             {
-                var document = _target.Latest(Data.PackageId, Data.NormalizedVersion, _changes);
+                var document = _target.LatestFromCatalog(
+                    Data.PackageId,
+                    Data.NormalizedVersion,
+                    Data.CommitTimestamp,
+                    Data.CommitId,
+                    _changes);
 
+                SetDocumentLastUpdated(document);
                 var json = await SerializationUtilities.SerializeToJsonAsync(document);
                 Assert.Equal(@"{
   ""value"": [
@@ -46,6 +61,11 @@ namespace NuGet.Services.AzureSearch
       ""isLatestSemVer1"": true,
       ""isLatestStableSemVer2"": false,
       ""isLatestSemVer2"": true,
+      ""lastUpdatedDocument"": ""2018-12-14T09:30:00+00:00"",
+      ""lastDocumentType"": ""NuGet.Services.AzureSearch.HijackDocument+Latest"",
+      ""lastUpdatedFromCatalog"": true,
+      ""lastCommitTimestamp"": ""2018-12-13T12:30:00+00:00"",
+      ""lastCommitId"": ""6b9b24dd-7aec-48ae-afc1-2a117e3d50d1"",
       ""key"": ""windowsazure_storage_7_1_2-alpha-d2luZG93c2F6dXJlLnN0b3JhZ2UvNy4xLjItYWxwaGE1""
     }
   ]
@@ -53,140 +73,20 @@ namespace NuGet.Services.AzureSearch
             }
         }
 
-        public class FullFromPackageEntity : BaseFacts
+        public class FullFromDb : BaseFacts
         {
+            public FullFromDb(ITestOutputHelper output) : base(output)
+            {
+            }
+
             [Fact]
             public async Task SetsExpectedProperties()
             {
-                var document = _target.Full(Data.PackageId, _changes, Data.PackageEntity);
+                var document = _target.FullFromDb(Data.PackageId, _changes, Data.PackageEntity);
 
+                SetDocumentLastUpdated(document);
                 var json = await SerializationUtilities.SerializeToJsonAsync(document);
-                Assert.Equal(_fullJson, json);
-            }
-
-            [Theory]
-            [MemberData(nameof(MissingTitles))]
-            public void UsesIdWhenMissingForSortableTitle(string title)
-            {
-                var package = Data.PackageEntity;
-                package.Title = title;
-
-                var document = _target.Full(Data.PackageId, _changes, package);
-
-                Assert.Equal(Data.PackageId, document.SortableTitle);
-            }
-
-            [Fact]
-            public void Uses1900ForPublishedWhenUnlisted()
-            {
-                var package = Data.PackageEntity;
-                package.Listed = false;
-
-                var document = _target.Full(Data.PackageId, _changes, package);
-
-                Assert.Equal(DateTimeOffset.Parse("1900-01-01Z"), document.Published);
-            }
-
-            [Fact]
-            public void SplitsTags()
-            {
-                var package = Data.PackageEntity;
-                package.Tags = "foo; BAR |     Baz";
-
-                var document = _target.Full(Data.PackageId, _changes, package);
-
-                Assert.Equal(new[] { "foo", "BAR", "Baz" }, document.Tags);
-            }
-
-            [Theory]
-            [InlineData(null)]
-            [InlineData(2)]
-            public void UsesSemVerLevelToIndicateSemVer2(int? semVerLevelKey)
-            {
-                var package = Data.PackageEntity;
-                package.SemVerLevelKey = semVerLevelKey;
-
-                var document = _target.Full(Data.PackageId, _changes, package);
-
-                Assert.Equal(semVerLevelKey, document.SemVerLevel);
-            }
-
-            /// <summary>
-            /// The caller is expected to verify consistency.
-            /// </summary>
-            [Fact]
-            public void DoesNotUseVersionToIndicateIsPrerelease()
-            {
-                var package = Data.PackageEntity;
-                package.IsPrerelease = false;
-                package.Version = "2.0.0-alpha";
-                package.NormalizedVersion = "2.0.0-alpha";
-
-                var document = _target.Full(Data.PackageId, _changes, package);
-
-                Assert.False(document.Prerelease);
-            }
-        }
-
-        public class FullFromPackageDetailsCatalogLeaf : BaseFacts
-        {
-            [Fact]
-            public async Task SetsExpectedProperties()
-            {
-                var document = _target.Full(Data.NormalizedVersion, _changes, Data.Leaf);
-
-                var json = await SerializationUtilities.SerializeToJsonAsync(document);
-                Assert.Equal(_fullJson, json);
-            }
-
-            [Theory]
-            [MemberData(nameof(MissingTitles))]
-            public void UsesIdWhenMissingForSortableTitle(string title)
-            {
-                var leaf = Data.Leaf;
-                leaf.Title = title;
-
-                var document = _target.Full(Data.NormalizedVersion, _changes, leaf);
-
-                Assert.Equal(Data.PackageId, document.SortableTitle);
-            }
-
-            [Fact]
-            public void DefaultsRequiresLicenseAcceptanceToFalse()
-            {
-                var leaf = Data.Leaf;
-                leaf.RequireLicenseAgreement = null;
-
-                var document = _target.Full(Data.NormalizedVersion, _changes, leaf);
-
-                Assert.False(document.RequiresLicenseAcceptance);
-            }
-        }
-
-        public abstract class BaseFacts
-        {
-            protected readonly HijackDocumentChanges _changes;
-            protected readonly string _fullJson;
-            protected readonly HijackDocumentBuilder _target;
-
-            public static IEnumerable<object[]> MissingTitles = new[]
-            {
-                new object[] { null },
-                new object[] { string.Empty },
-                new object[] { " " },
-                new object[] { " \t"},
-            };
-
-            public BaseFacts()
-            {
-                _changes = new HijackDocumentChanges(
-                    delete: false,
-                    updateMetadata: true,
-                    latestStableSemVer1: false,
-                    latestSemVer1: true,
-                    latestStableSemVer2: false,
-                    latestSemVer2: true);
-                _fullJson = @"{
+                Assert.Equal(@"{
   ""value"": [
     {
       ""@search.action"": ""upload"",
@@ -230,10 +130,203 @@ namespace NuGet.Services.AzureSearch
         ""windowsazureofficial""
       ],
       ""title"": ""Windows Azure Storage"",
+      ""lastUpdatedDocument"": ""2018-12-14T09:30:00+00:00"",
+      ""lastDocumentType"": ""NuGet.Services.AzureSearch.HijackDocument+Full"",
+      ""lastUpdatedFromCatalog"": false,
+      ""lastCommitTimestamp"": null,
+      ""lastCommitId"": null,
       ""key"": ""windowsazure_storage_7_1_2-alpha-d2luZG93c2F6dXJlLnN0b3JhZ2UvNy4xLjItYWxwaGE1""
     }
   ]
-}";
+}", json);
+            }
+
+            [Theory]
+            [MemberData(nameof(MissingTitles))]
+            public void UsesIdWhenMissingForSortableTitle(string title)
+            {
+                var package = Data.PackageEntity;
+                package.Title = title;
+
+                var document = _target.FullFromDb(Data.PackageId, _changes, package);
+
+                Assert.Equal(Data.PackageId, document.SortableTitle);
+            }
+
+            [Fact]
+            public void Uses1900ForPublishedWhenUnlisted()
+            {
+                var package = Data.PackageEntity;
+                package.Listed = false;
+
+                var document = _target.FullFromDb(Data.PackageId, _changes, package);
+
+                Assert.Equal(DateTimeOffset.Parse("1900-01-01Z"), document.Published);
+            }
+
+            [Fact]
+            public void SplitsTags()
+            {
+                var package = Data.PackageEntity;
+                package.Tags = "foo; BAR |     Baz";
+
+                var document = _target.FullFromDb(Data.PackageId, _changes, package);
+
+                Assert.Equal(new[] { "foo", "BAR", "Baz" }, document.Tags);
+            }
+
+            [Theory]
+            [InlineData(null)]
+            [InlineData(2)]
+            public void UsesSemVerLevelToIndicateSemVer2(int? semVerLevelKey)
+            {
+                var package = Data.PackageEntity;
+                package.SemVerLevelKey = semVerLevelKey;
+
+                var document = _target.FullFromDb(Data.PackageId, _changes, package);
+
+                Assert.Equal(semVerLevelKey, document.SemVerLevel);
+            }
+
+            /// <summary>
+            /// The caller is expected to verify consistency.
+            /// </summary>
+            [Fact]
+            public void DoesNotUseVersionToIndicateIsPrerelease()
+            {
+                var package = Data.PackageEntity;
+                package.IsPrerelease = false;
+                package.Version = "2.0.0-alpha";
+                package.NormalizedVersion = "2.0.0-alpha";
+
+                var document = _target.FullFromDb(Data.PackageId, _changes, package);
+
+                Assert.False(document.Prerelease);
+            }
+        }
+
+        public class FullFromCatalog : BaseFacts
+        {
+            public FullFromCatalog(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task SetsExpectedProperties()
+            {
+                var document = _target.FullFromCatalog(Data.NormalizedVersion, _changes, Data.Leaf);
+
+                SetDocumentLastUpdated(document);
+                var json = await SerializationUtilities.SerializeToJsonAsync(document);
+                Assert.Equal(@"{
+  ""value"": [
+    {
+      ""@search.action"": ""upload"",
+      ""isLatestStableSemVer1"": false,
+      ""isLatestSemVer1"": true,
+      ""isLatestStableSemVer2"": false,
+      ""isLatestSemVer2"": true,
+      ""semVerLevel"": 2,
+      ""authors"": ""Microsoft"",
+      ""copyright"": ""© Microsoft Corporation. All rights reserved."",
+      ""created"": ""2017-01-01T00:00:00+00:00"",
+      ""description"": ""Description."",
+      ""fileSize"": 3039254,
+      ""flattenedDependencies"": ""Microsoft.Data.OData:5.6.4:net40-client|Newtonsoft.Json:6.0.8:net40-client"",
+      ""hash"": ""oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33+Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ=="",
+      ""hashAlgorithm"": ""SHA512"",
+      ""iconUrl"": ""http://go.microsoft.com/fwlink/?LinkID=288890"",
+      ""language"": ""en-US"",
+      ""lastEdited"": ""2017-01-02T00:00:00+00:00"",
+      ""licenseUrl"": ""http://go.microsoft.com/fwlink/?LinkId=331471"",
+      ""minClientVersion"": ""2.12"",
+      ""normalizedVersion"": ""7.1.2-alpha"",
+      ""originalVersion"": ""7.1.2.0-alpha+git"",
+      ""packageId"": ""WindowsAzure.Storage"",
+      ""prerelease"": true,
+      ""projectUrl"": ""https://github.com/Azure/azure-storage-net"",
+      ""published"": ""2017-01-03T00:00:00+00:00"",
+      ""releaseNotes"": ""Release notes."",
+      ""requiresLicenseAcceptance"": true,
+      ""sortableTitle"": ""Windows Azure Storage"",
+      ""summary"": ""Summary."",
+      ""tags"": [
+        ""Microsoft"",
+        ""Azure"",
+        ""Storage"",
+        ""Table"",
+        ""Blob"",
+        ""File"",
+        ""Queue"",
+        ""Scalable"",
+        ""windowsazureofficial""
+      ],
+      ""title"": ""Windows Azure Storage"",
+      ""lastUpdatedDocument"": ""2018-12-14T09:30:00+00:00"",
+      ""lastDocumentType"": ""NuGet.Services.AzureSearch.HijackDocument+Full"",
+      ""lastUpdatedFromCatalog"": true,
+      ""lastCommitTimestamp"": ""2018-12-13T12:30:00+00:00"",
+      ""lastCommitId"": ""6b9b24dd-7aec-48ae-afc1-2a117e3d50d1"",
+      ""key"": ""windowsazure_storage_7_1_2-alpha-d2luZG93c2F6dXJlLnN0b3JhZ2UvNy4xLjItYWxwaGE1""
+    }
+  ]
+}", json);
+            }
+
+            [Theory]
+            [MemberData(nameof(MissingTitles))]
+            public void UsesIdWhenMissingForSortableTitle(string title)
+            {
+                var leaf = Data.Leaf;
+                leaf.Title = title;
+
+                var document = _target.FullFromCatalog(Data.NormalizedVersion, _changes, leaf);
+
+                Assert.Equal(Data.PackageId, document.SortableTitle);
+            }
+
+            [Fact]
+            public void DefaultsRequiresLicenseAcceptanceToFalse()
+            {
+                var leaf = Data.Leaf;
+                leaf.RequireLicenseAgreement = null;
+
+                var document = _target.FullFromCatalog(Data.NormalizedVersion, _changes, leaf);
+
+                Assert.False(document.RequiresLicenseAcceptance);
+            }
+        }
+
+        public abstract class BaseFacts
+        {
+            protected readonly ITestOutputHelper _output;
+            protected readonly HijackDocumentChanges _changes;
+            protected readonly HijackDocumentBuilder _target;
+
+
+            public static IEnumerable<object[]> MissingTitles = new[]
+            {
+                new object[] { null },
+                new object[] { string.Empty },
+                new object[] { " " },
+                new object[] { " \t"},
+            };
+
+            public void SetDocumentLastUpdated(ICommittedDocument document)
+            {
+                Data.SetDocumentLastUpdated(document, _output);
+            }
+
+            public BaseFacts(ITestOutputHelper output)
+            {
+                _output = output;
+                _changes = new HijackDocumentChanges(
+                    delete: false,
+                    updateMetadata: true,
+                    latestStableSemVer1: false,
+                    latestSemVer1: true,
+                    latestStableSemVer2: false,
+                    latestSemVer2: true);
 
                 _target = new HijackDocumentBuilder();
             }

--- a/tests/NuGet.Services.AzureSearch.Tests/Models/CommittedDocumentFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Models/CommittedDocumentFacts.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class CurrentTimestampFacts
+    {
+        [Fact]
+        public void CapturesCurrentTimestampOnNextRead()
+        {
+            var target = new CurrentTimestamp();
+
+            target.SetOnNextRead();
+            var before = DateTimeOffset.UtcNow;
+            var actual = target.Value;
+            var after = DateTimeOffset.UtcNow;
+
+            Assert.NotNull(actual);
+            Assert.InRange(actual.Value, before, after);
+        }
+
+        [Fact]
+        public void RetainsValueAfterFirstRead()
+        {
+            var target = new CurrentTimestamp();
+            target.SetOnNextRead();
+            var initial = target.Value;
+
+            var actual = target.Value;
+
+            Assert.NotNull(actual);
+            Assert.Equal(initial, actual);
+        }
+
+        [Fact]
+        public void ReplacesSetValueWhenFlagIsSet()
+        {
+            var target = new CurrentTimestamp();
+            target.SetOnNextRead();
+            target.Value = DateTimeOffset.MaxValue;
+
+            var actual = target.Value;
+
+            Assert.NotNull(actual);
+            Assert.NotEqual(DateTimeOffset.MaxValue, actual);
+        }
+
+        [Fact]
+        public void DoesNotReplaceSetValueWhenFlagIsNotSet()
+        {
+            var target = new CurrentTimestamp();
+            target.Value = DateTimeOffset.MaxValue;
+
+            var actual = target.Value;
+
+            Assert.Equal(DateTimeOffset.MaxValue, actual);
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -55,9 +55,11 @@
     <Compile Include="DocumentUtilitiesFacts.cs" />
     <Compile Include="HijackDocumentBuilderFacts.cs" />
     <Compile Include="IndexBuilderFacts.cs" />
+    <Compile Include="Models\CommittedDocumentFacts.cs" />
     <Compile Include="SearchDocumentBuilderFacts.cs" />
     <Compile Include="Registration\RegistrationClientFacts.cs" />
     <Compile Include="Support\Cursor.cs" />
+    <Compile Include="Support\Data.cs" />
     <Compile Include="Support\SerializationUtilities.cs" />
     <Compile Include="Support\DbSetMockFactory.cs" />
     <Compile Include="Support\RecordingLogger.cs" />

--- a/tests/NuGet.Services.AzureSearch.Tests/Support/Data.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Support/Data.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Protocol.Catalog;
+using NuGet.Services.Entities;
+using Xunit.Abstractions;
+using PackageDependency = NuGet.Protocol.Catalog.PackageDependency;
+
+namespace NuGet.Services.AzureSearch.Support
+{
+    public static class Data
+    {
+        public const string PackageId = "WindowsAzure.Storage";
+        public const string NormalizedVersion = "7.1.2-alpha";
+        public const string FullVersion = "7.1.2-alpha+git";
+        public static readonly DateTimeOffset DocumentLastUpdated = new DateTimeOffset(2018, 12, 14, 9, 30, 0, TimeSpan.Zero);
+        public static readonly DateTimeOffset CommitTimestamp = new DateTimeOffset(2018, 12, 13, 12, 30, 0, TimeSpan.Zero);
+        public static readonly string CommitId = "6b9b24dd-7aec-48ae-afc1-2a117e3d50d1";
+
+        public static void SetDocumentLastUpdated(ICommittedDocument document, ITestOutputHelper output)
+        {
+            var currentTimestamp = document.LastUpdatedDocument;
+            output.WriteLine(
+                $"The commited document has a generated {nameof(document.LastUpdatedDocument)} value of " +
+                $"{currentTimestamp:O}. Replacing this value with {DocumentLastUpdated:O}.");
+            document.LastUpdatedDocument = DocumentLastUpdated;
+        }
+
+        public static Package PackageEntity => new Package
+        {
+            FlattenedAuthors = "Microsoft",
+            Copyright = "© Microsoft Corporation. All rights reserved.",
+            Created = new DateTime(2017, 1, 1),
+            Description = "Description.",
+            FlattenedDependencies = "Microsoft.Data.OData:5.6.4:net40-client|Newtonsoft.Json:6.0.8:net40-client",
+            Hash = "oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33+Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ==",
+            HashAlgorithm = "SHA512",
+            IconUrl = "http://go.microsoft.com/fwlink/?LinkID=288890",
+            IsPrerelease = true,
+            Language = "en-US",
+            LastEdited = new DateTime(2017, 1, 2),
+            LicenseUrl = "http://go.microsoft.com/fwlink/?LinkId=331471",
+            Listed = true,
+            MinClientVersion = "2.12",
+            NormalizedVersion = "7.1.2-alpha",
+            PackageFileSize = 3039254,
+            ProjectUrl = "https://github.com/Azure/azure-storage-net",
+            Published = new DateTime(2017, 1, 3),
+            ReleaseNotes = "Release notes.",
+            RequiresLicenseAcceptance = true,
+            SemVerLevelKey = 2,
+            Summary = "Summary.",
+            Tags = "Microsoft Azure Storage Table Blob File Queue Scalable windowsazureofficial",
+            Title = "Windows Azure Storage",
+            Version = "7.1.2.0-alpha+git",
+        };
+
+        public static PackageDetailsCatalogLeaf Leaf => new PackageDetailsCatalogLeaf
+        {
+            Authors = "Microsoft",
+            CommitId = CommitId,
+            CommitTimestamp = CommitTimestamp,
+            Copyright = "© Microsoft Corporation. All rights reserved.",
+            Created = new DateTimeOffset(new DateTime(2017, 1, 1), TimeSpan.Zero),
+            Description = "Description.",
+            DependencyGroups = new List<PackageDependencyGroup>
+            {
+                new PackageDependencyGroup
+                {
+                    TargetFramework = ".NETFramework4.0-Client",
+                    Dependencies = new List<PackageDependency>
+                    {
+                        new PackageDependency
+                        {
+                            Id = "Microsoft.Data.OData",
+                            Range = "[5.6.4, )",
+                        },
+                        new PackageDependency
+                        {
+                            Id = "Newtonsoft.Json",
+                            Range = "[6.0.8, )",
+                        },
+                    },
+                },
+            },
+            IconUrl = "http://go.microsoft.com/fwlink/?LinkID=288890",
+            IsPrerelease = true,
+            Language = "en-US",
+            LastEdited = new DateTimeOffset(new DateTime(2017, 1, 2), TimeSpan.Zero),
+            LicenseUrl = "http://go.microsoft.com/fwlink/?LinkId=331471",
+            Listed = true,
+            MinClientVersion = "2.12",
+            PackageHash = "oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33+Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ==",
+            PackageHashAlgorithm = "SHA512",
+            PackageId = PackageId,
+            PackageSize = 3039254,
+            PackageVersion = FullVersion,
+            ProjectUrl = "https://github.com/Azure/azure-storage-net",
+            Published = new DateTimeOffset(new DateTime(2017, 1, 3), TimeSpan.Zero),
+            ReleaseNotes = "Release notes.",
+            RequireLicenseAgreement = true,
+            Summary = "Summary.",
+            Tags = new List<string> { "Microsoft", "Azure", "Storage", "Table", "Blob", "File", "Queue", "Scalable", "windowsazureofficial" },
+            Title = "Windows Azure Storage",
+            VerbatimVersion = "7.1.2.0-alpha+git",
+        };
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/Support/SerializationUtilities.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Support/SerializationUtilities.cs
@@ -1,106 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Search;
 using Microsoft.Azure.Search.Models;
-using NuGet.Protocol.Catalog;
-using NuGet.Services.Entities;
-using PackageDependency = NuGet.Protocol.Catalog.PackageDependency;
 
 namespace NuGet.Services.AzureSearch.Support
 {
-    public static class Data
-    {
-        public const string PackageId = "WindowsAzure.Storage";
-        public const string NormalizedVersion = "7.1.2-alpha";
-        public const string FullVersion = "7.1.2-alpha+git";
-
-        public static Package PackageEntity => new Package
-        {
-            FlattenedAuthors = "Microsoft",
-            Copyright = "© Microsoft Corporation. All rights reserved.",
-            Created = new DateTime(2017, 1, 1),
-            Description = "Description.",
-            FlattenedDependencies = "Microsoft.Data.OData:5.6.4:net40-client|Newtonsoft.Json:6.0.8:net40-client",
-            Hash = "oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33+Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ==",
-            HashAlgorithm = "SHA512",
-            IconUrl = "http://go.microsoft.com/fwlink/?LinkID=288890",
-            IsPrerelease = true,
-            Language = "en-US",
-            LastEdited = new DateTime(2017, 1, 2),
-            LicenseUrl = "http://go.microsoft.com/fwlink/?LinkId=331471",
-            Listed = true,
-            MinClientVersion = "2.12",
-            NormalizedVersion = "7.1.2-alpha",
-            PackageFileSize = 3039254,
-            ProjectUrl = "https://github.com/Azure/azure-storage-net",
-            Published = new DateTime(2017, 1, 3),
-            ReleaseNotes = "Release notes.",
-            RequiresLicenseAcceptance = true,
-            SemVerLevelKey = 2,
-            Summary = "Summary.",
-            Tags = "Microsoft Azure Storage Table Blob File Queue Scalable windowsazureofficial",
-            Title = "Windows Azure Storage",
-            Version = "7.1.2.0-alpha+git",
-        };
-
-        public static PackageDetailsCatalogLeaf Leaf => new PackageDetailsCatalogLeaf
-        {
-            Authors = "Microsoft",
-            Copyright = "© Microsoft Corporation. All rights reserved.",
-            Created = new DateTimeOffset(new DateTime(2017, 1, 1), TimeSpan.Zero),
-            Description = "Description.",
-            DependencyGroups = new List<PackageDependencyGroup>
-            {
-                new PackageDependencyGroup
-                {
-                    TargetFramework = ".NETFramework4.0-Client",
-                    Dependencies = new List<PackageDependency>
-                    {
-                        new PackageDependency
-                        {
-                            Id = "Microsoft.Data.OData",
-                            Range = "[5.6.4, )",
-                        },
-                        new PackageDependency
-                        {
-                            Id = "Newtonsoft.Json",
-                            Range = "[6.0.8, )",
-                        },
-                    },
-                },
-            },
-            IconUrl = "http://go.microsoft.com/fwlink/?LinkID=288890",
-            IsPrerelease = true,
-            Language = "en-US",
-            LastEdited = new DateTimeOffset(new DateTime(2017, 1, 2), TimeSpan.Zero),
-            LicenseUrl = "http://go.microsoft.com/fwlink/?LinkId=331471",
-            Listed = true,
-            MinClientVersion = "2.12",
-            PackageHash = "oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33+Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ==",
-            PackageHashAlgorithm = "SHA512",
-            PackageId = PackageId,
-            PackageSize = 3039254,
-            PackageVersion = FullVersion,
-            ProjectUrl = "https://github.com/Azure/azure-storage-net",
-            Published = new DateTimeOffset(new DateTime(2017, 1, 3), TimeSpan.Zero),
-            ReleaseNotes = "Release notes.",
-            RequireLicenseAgreement = true,
-            Summary = "Summary.",
-            Tags = new List<string> { "Microsoft", "Azure", "Storage", "Table", "Blob", "File", "Queue", "Scalable", "windowsazureofficial" },
-            Title = "Windows Azure Storage",
-            VerbatimVersion = "7.1.2.0-alpha+git",
-        };
-    }
-
-
-
     public class SerializationUtilities
     {
         public static async Task<string> SerializeToJsonAsync<T>(T obj) where T : class


### PR DESCRIPTION
See `CommittedDocument` for the specific properties.

Since we have document batching, I made the `LastUpdatedDocument` property a little clever to capture the current timestamp as late as possible. I thought it was worth the trick to get a timestamp that is close to when the actual submission to Azure Search is (chronological). If I don't do this, the timestamp can be off by as much time as it takes to build up a full batch to Azure Search (1000 documents).