### PR TITLE
[Search 2] Trim/lowercase sortable title and perform less normalization on the document

### DIFF
--- a/src/NuGet.Services.AzureSearch/DocumentUtilities.cs
+++ b/src/NuGet.Services.AzureSearch/DocumentUtilities.cs
@@ -12,6 +12,7 @@ using NuGet.Protocol.Catalog;
 using NuGet.Services.Entities;
 using NuGet.Services.Metadata.Catalog;
 using NuGet.Versioning;
+using NuGetGallery;
 using PackageDependency = NuGet.Protocol.Catalog.PackageDependency;
 
 namespace NuGet.Services.AzureSearch
@@ -100,7 +101,7 @@ namespace NuGet.Services.AzureSearch
             document.SemVerLevel = package.SemVerLevelKey;
             document.SortableTitle = GetSortableTitle(package.Title, packageId);
             document.Summary = package.Summary;
-            document.Tags = Utils.SplitTags(package.Tags ?? string.Empty);
+            document.Tags = package.Tags == null ? null : Utils.SplitTags(package.Tags);
             document.Title = package.Title;
         }
 
@@ -123,14 +124,14 @@ namespace NuGet.Services.AzureSearch
             document.LicenseUrl = leaf.LicenseUrl;
             document.MinClientVersion = leaf.MinClientVersion;
             document.NormalizedVersion = normalizedVersion;
-            document.OriginalVersion = leaf.VerbatimVersion ?? leaf.PackageVersion;
+            document.OriginalVersion = leaf.VerbatimVersion;
             document.PackageId = leaf.PackageId;
             document.Prerelease = leaf.IsPrerelease;
             document.ProjectUrl = leaf.ProjectUrl;
             document.Published = leaf.Published;
             document.ReleaseNotes = leaf.ReleaseNotes;
-            document.RequiresLicenseAcceptance = leaf.RequireLicenseAgreement ?? false;
-            document.SemVerLevel = leaf.IsSemVer2() ? 2 : (int?)null;
+            document.RequiresLicenseAcceptance = leaf.RequireLicenseAgreement;
+            document.SemVerLevel = leaf.IsSemVer2() ? SemVerLevelKey.SemVer2 : SemVerLevelKey.Unknown;
             document.SortableTitle = GetSortableTitle(leaf.Title, leaf.PackageId);
             document.Summary = leaf.Summary;
             document.Tags = leaf.Tags == null ? null : leaf.Tags.ToArray();
@@ -139,12 +140,8 @@ namespace NuGet.Services.AzureSearch
 
         private static string GetSortableTitle(string title, string packageId)
         {
-            if (string.IsNullOrWhiteSpace(title))
-            {
-                return packageId;
-            }
-
-            return title;
+            var output = string.IsNullOrWhiteSpace(title) ? packageId : title;
+            return output.Trim().ToLowerInvariant();
         }
 
         public static string GetSearchDocumentKey(string packageId, SearchFilters searchFilters)

--- a/src/NuGet.Services.AzureSearch/Models/BaseMetadataDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/BaseMetadataDocument.cs
@@ -3,12 +3,14 @@
 
 using System;
 using Microsoft.Azure.Search;
+using Newtonsoft.Json;
 
 namespace NuGet.Services.AzureSearch
 {
     public abstract class BaseMetadataDocument : CommittedDocument, IBaseMetadataDocument
     {
         [IsFilterable]
+        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
         public int? SemVerLevel { get; set; }
 
         [IsSearchable]

--- a/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/PackageEntityIndexActionBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/PackageEntityIndexActionBuilderFacts.cs
@@ -6,6 +6,7 @@ using Moq;
 using NuGet.Services.AzureSearch.Support;
 using NuGet.Services.Entities;
 using NuGet.Versioning;
+using NuGetGallery;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -30,7 +31,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                     "NuGet.Versioning",
                     1001,
                     new string[0],
-                    new[] { new TestPackage(version) { SemVerLevelKey = 2 } });
+                    new[] { new TestPackage(version) { SemVerLevelKey = SemVerLevelKey.SemVer2 } });
 
                 var actions = _target.AddNewPackageRegistration(input);
 
@@ -135,7 +136,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                     "NuGet.Versioning",
                     1001,
                     new string[0],
-                    new[] { new TestPackage("1.0.0") { SemVerLevelKey = 2 } });
+                    new[] { new TestPackage("1.0.0") { SemVerLevelKey = SemVerLevelKey.SemVer2 } });
 
                 var actions = _target.AddNewPackageRegistration(input);
 

--- a/tests/NuGet.Services.AzureSearch.Tests/DocumentUtilitiesFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/DocumentUtilitiesFacts.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.Protocol.Catalog;
+using NuGet.Services.AzureSearch.Support;
 using Xunit;
 
 namespace NuGet.Services.AzureSearch
@@ -75,6 +76,7 @@ namespace NuGet.Services.AzureSearch
             {
                 var leaf = new PackageDetailsCatalogLeaf
                 {
+                    PackageId = Data.PackageId,
                     PackageVersion = NormalizedVersion,
                     DependencyGroups = new List<PackageDependencyGroup>
                     {
@@ -113,6 +115,7 @@ namespace NuGet.Services.AzureSearch
             {
                 var leaf = new PackageDetailsCatalogLeaf
                 {
+                    PackageId = Data.PackageId,
                     PackageVersion = NormalizedVersion,
                     DependencyGroups = new List<PackageDependencyGroup>
                     {
@@ -134,6 +137,7 @@ namespace NuGet.Services.AzureSearch
             {
                 var leaf = new PackageDetailsCatalogLeaf
                 {
+                    PackageId = Data.PackageId,
                     PackageVersion = NormalizedVersion,
                     DependencyGroups = new List<PackageDependencyGroup>
                     {
@@ -169,6 +173,7 @@ namespace NuGet.Services.AzureSearch
             {
                 var leaf = new PackageDetailsCatalogLeaf
                 {
+                    PackageId = Data.PackageId,
                     PackageVersion = NormalizedVersion,
                     DependencyGroups = new List<PackageDependencyGroup>
                     {
@@ -198,6 +203,7 @@ namespace NuGet.Services.AzureSearch
             {
                 var leaf = new PackageDetailsCatalogLeaf
                 {
+                    PackageId = Data.PackageId,
                     PackageVersion = NormalizedVersion,
                     DependencyGroups = null
                 };

--- a/tests/NuGet.Services.AzureSearch.Tests/Support/Data.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Support/Data.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using NuGet.Protocol.Catalog;
 using NuGet.Services.Entities;
+using NuGetGallery;
 using Xunit.Abstractions;
 using PackageDependency = NuGet.Protocol.Catalog.PackageDependency;
 
@@ -50,7 +51,7 @@ namespace NuGet.Services.AzureSearch.Support
             Published = new DateTime(2017, 1, 3),
             ReleaseNotes = "Release notes.",
             RequiresLicenseAcceptance = true,
-            SemVerLevelKey = 2,
+            SemVerLevelKey = SemVerLevelKey.SemVer2,
             Summary = "Summary.",
             Tags = "Microsoft Azure Storage Table Blob File Queue Scalable windowsazureofficial",
             Title = "Windows Azure Storage",


### PR DESCRIPTION
Depends on https://github.com/NuGet/NuGet.Services.Metadata/pull/449.

We should minimize normalization on the document where possible. This allows the search service to make this decision as late in the game as possible. Search service can be changed a lot easier than every document in the index.

Ensured that `semVerLevelKey` field is always serialized. This is used for filtering so it needs to have excellent reflow-ability. See https://github.com/NuGet/NuGetGallery/issues/6757.

Also, use `SemVerLevelKey.SemVer2` and `SemVerLevelKey.Unknown`.