### PR TITLE
[Search 2] Add auxiliary file loading infrastructure

### DIFF
--- a/src/NuGet.Indexing/VerifiedPackages.cs
+++ b/src/NuGet.Indexing/VerifiedPackages.cs
@@ -10,7 +10,7 @@ using FrameworkLogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace NuGet.Indexing
 {
-    internal static class VerifiedPackages
+    public static class VerifiedPackages
     {
         /// <summary>
         /// Load the verified packages auxiliary data.

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -43,6 +43,9 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SearchService\AuxiliaryDataCache.cs" />
+    <Compile Include="SearchService\AuxiliaryFileClient.cs" />
+    <Compile Include="SearchService\AuxiliaryFileReloader.cs" />
     <Compile Include="AzureSearchConfiguration.cs" />
     <Compile Include="AzureSearchJobConfiguration.cs" />
     <Compile Include="Catalog2AzureSearch\AzureSearchCollector.cs" />
@@ -96,6 +99,14 @@
     <Compile Include="Registration\Models\RegistrationLeaf.cs" />
     <Compile Include="Registration\RegistrationUrlBuilder.cs" />
     <Compile Include="SearchDocumentBuilder.cs" />
+    <Compile Include="SearchService\AuxiliaryData.cs" />
+    <Compile Include="SearchService\AuxiliaryFileResult.cs" />
+    <Compile Include="SearchService\IAuxiliaryDataCache.cs" />
+    <Compile Include="SearchService\IAuxiliaryFileClient.cs" />
+    <Compile Include="SearchService\IAuxiliaryFileReloader.cs" />
+    <Compile Include="SearchService\Models\AuxiliaryFileMetadata.cs" />
+    <Compile Include="SearchService\Models\AuxiliaryFilesMetadata.cs" />
+    <Compile Include="SearchService\IAuxiliaryData.cs" />
     <Compile Include="SearchService\Models\DebugInformation.cs" />
     <Compile Include="SearchService\Models\SearchRequest.cs" />
     <Compile Include="SearchService\Models\V2SearchDependency.cs" />
@@ -142,6 +153,7 @@
     <Compile Include="Wrappers\ISearchServiceClientWrapper.cs" />
     <Compile Include="Wrappers\SearchIndexClientWrapper.cs" />
     <Compile Include="Wrappers\SearchServiceClientWrapper.cs" />
+    <Compile Include="SearchService\SearchServiceConfiguration.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core">
@@ -165,6 +177,10 @@
     <ProjectReference Include="..\Catalog\NuGet.Services.Metadata.Catalog.csproj">
       <Project>{e97f23b8-ecb0-4afa-b00c-015c39395fef}</Project>
       <Name>NuGet.Services.Metadata.Catalog</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\NuGet.Indexing\NuGet.Indexing.csproj">
+      <Project>{DDB34145-870F-42C3-9663-A9390CEE1E35}</Project>
+      <Name>NuGet.Indexing</Name>
     </ProjectReference>
     <ProjectReference Include="..\NuGet.Protocol.Catalog\NuGet.Protocol.Catalog.csproj">
       <Project>{D44C2E89-2D98-44BD-8712-8CCBE4E67C9C}</Project>

--- a/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryData.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryData.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Indexing;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class AuxiliaryData : IAuxiliaryData
+    {
+        public AuxiliaryData(
+            AuxiliaryFileResult<Downloads> downloads,
+            AuxiliaryFileResult<HashSet<string>> verifiedPackages)
+        {
+            Downloads = downloads ?? throw new ArgumentNullException(nameof(downloads));
+            VerifiedPackages = verifiedPackages ?? throw new ArgumentNullException(nameof(verifiedPackages));
+            Metadata = new AuxiliaryFilesMetadata(
+                Downloads.Metadata,
+                VerifiedPackages.Metadata);
+        }
+
+        internal AuxiliaryFileResult<Downloads> Downloads { get; }
+        internal AuxiliaryFileResult<HashSet<string>> VerifiedPackages { get; }
+        public AuxiliaryFilesMetadata Metadata { get; }
+
+        public bool IsVerified(string id)
+        {
+            return VerifiedPackages.Data.Contains(id);
+        }
+
+        public int GetTotalDownloadCount(string id)
+        {
+            return Downloads.Data[id]?.Total ?? 0;
+        }
+
+        public int GetDownloadCount(string id, string normalizedVersion)
+        {
+            return Downloads.Data[id]?[normalizedVersion] ?? 0;
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryDataCache.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryDataCache.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class AuxiliaryDataCache : IAuxiliaryDataCache
+    {
+        private readonly SemaphoreSlim _lock = new SemaphoreSlim(1);
+        private readonly IAuxiliaryFileClient _client;
+        private readonly ILogger<AuxiliaryDataCache> _logger;
+        private AuxiliaryData _data;
+
+        public AuxiliaryDataCache(
+            IAuxiliaryFileClient client,
+            ILogger<AuxiliaryDataCache> logger)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public bool Initialized => _data != null;
+
+        public async Task InitializeAsync()
+        {
+            if (!Initialized)
+            {
+                await LoadAsync(Timeout.InfiniteTimeSpan, CancellationToken.None);
+            }
+        }
+
+        public async Task TryLoadAsync(CancellationToken token)
+        {
+            await LoadAsync(TimeSpan.Zero, token);
+        }
+
+        private async Task LoadAsync(TimeSpan timeout, CancellationToken token)
+        {
+            var acquired = false;
+            try
+            {
+                acquired = await _lock.WaitAsync(timeout, token);
+                if (!acquired)
+                {
+                    _logger.LogInformation("Another thread is already reloading the auxiliary data.");
+                }
+                else
+                {
+                    _logger.LogInformation("Starting the reload of auxiliary data.");
+
+                    var stopwatch = Stopwatch.StartNew();
+
+                    // Load the auxiliary files in parallel.
+                    var downloadsTask = LoadAsync(_data?.Downloads, _client.LoadDownloadsAsync);
+                    var verifiedPackagesTask = LoadAsync(_data?.VerifiedPackages, _client.LoadVerifiedPackagesAsync);
+                    await Task.WhenAll(downloadsTask, verifiedPackagesTask);
+                    var downloads = await downloadsTask;
+                    var verifiedPackages = await verifiedPackagesTask;
+
+                    // Keep track of what was actually reloaded and what didn't change.
+                    var reloadedNames = new List<string>();
+                    var notModifiedNames = new List<string>();
+                    (ReferenceEquals(_data?.Downloads, downloads) ? notModifiedNames : reloadedNames).Add(nameof(_data.Downloads));
+                    (ReferenceEquals(_data?.VerifiedPackages, verifiedPackages) ? notModifiedNames : reloadedNames).Add(nameof(_data.VerifiedPackages));
+
+                    // Reference assignment is atomic, so this is what makes the data available for readers.
+                    _data = new AuxiliaryData(downloads, verifiedPackages);
+
+                    stopwatch.Stop();
+
+                    _logger.LogInformation(
+                        "Done reloading auxiliary data. Took {Duration}. Reloaded: {Reloaded}. Not modified: {NotModified}",
+                        stopwatch.Elapsed,
+                        reloadedNames,
+                        notModifiedNames);
+                }
+            }
+            finally
+            {
+                if (acquired)
+                {
+                    _lock.Release();
+                }
+            }
+        }
+
+        private async Task<AuxiliaryFileResult<T>> LoadAsync<T>(
+            AuxiliaryFileResult<T> previousResult,
+            Func<string, Task<AuxiliaryFileResult<T>>> getResult) where T : class
+        {
+            await Task.Yield();
+            var inputETag = previousResult?.Metadata.ETag;
+            var newResult = await getResult(inputETag);
+            if (newResult.NotModified)
+            {
+                return previousResult;
+            }
+            else
+            {
+                return newResult;
+            }
+        }
+
+        public IAuxiliaryData Get()
+        {
+            if (_data == null)
+            {
+                throw new InvalidOperationException(
+                    $"The auxiliary data has not been loaded yet. Call {nameof(LoadAsync)}.");
+            }
+
+            return _data;
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryFileClient.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryFileClient.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.WindowsAzure.Storage;
+using Newtonsoft.Json;
+using NuGet.Indexing;
+using NuGetGallery;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class AuxiliaryFileClient : IAuxiliaryFileClient
+    {
+        private readonly ICloudBlobClient _cloudBlobClient;
+        private readonly IOptionsSnapshot<SearchServiceConfiguration> _options;
+        private readonly ILogger<AuxiliaryFileClient> _logger;
+        private readonly Lazy<ICloudBlobContainer> _lazyContainer;
+
+        public AuxiliaryFileClient(
+            ICloudBlobClient cloudBlobClient,
+            IOptionsSnapshot<SearchServiceConfiguration> options,
+            ILogger<AuxiliaryFileClient> logger)
+        {
+            _cloudBlobClient = cloudBlobClient ?? throw new ArgumentNullException(nameof(cloudBlobClient));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            _lazyContainer = new Lazy<ICloudBlobContainer>(
+                () => _cloudBlobClient.GetContainerReference(_options.Value.AuxiliaryDataStorageContainer));
+        }
+
+        private ICloudBlobContainer Container => _lazyContainer.Value;
+
+        public async Task<AuxiliaryFileResult<Downloads>> LoadDownloadsAsync(string etag)
+        {
+            return await LoadAuxiliaryFileAsync(
+                _options.Value.AuxiliaryDataStorageDownloadsPath,
+                etag,
+                loader =>
+                {
+                    var downloads = new Downloads();
+                    downloads.Load(
+                        name: null,
+                        loader: loader,
+                        logger: _logger);
+                    return downloads;
+                });
+        }
+
+        public async Task<AuxiliaryFileResult<HashSet<string>>> LoadVerifiedPackagesAsync(string etag)
+        {
+            return await LoadAuxiliaryFileAsync(
+                _options.Value.AuxiliaryDataStorageVerifiedPackagesPath,
+                etag,
+                loader => VerifiedPackages.Load(
+                    fileName: null,
+                    loader: loader,
+                    logger: _logger));
+        }
+
+        private async Task<AuxiliaryFileResult<T>> LoadAuxiliaryFileAsync<T>(
+            string blobName,
+            string etag,
+            Func<ILoader, T> loadData) where T : class
+        {
+            _logger.LogInformation("Attempted to load blob {BlobName} with etag {ETag}.", blobName, etag);
+
+            var stopwatch = Stopwatch.StartNew();
+            var blob = Container.GetBlobReference(blobName);
+            var condition = etag != null ? AccessCondition.GenerateIfNoneMatchCondition(etag) : null;
+            try
+            {
+                using (var stream = await blob.OpenReadAsync(condition))
+                using (var textReader = new StreamReader(stream))
+                using (var jsonReader = new JsonTextReader(textReader))
+                {
+                    var loader = new LoaderAdapter(jsonReader);
+                    var data = loadData(loader);
+                    stopwatch.Stop();
+
+                    _logger.LogInformation(
+                        "Loaded blob {BlobName} with etag {OldETag}. New etag is {NewETag}. Took {Duration}.",
+                        blobName,
+                        etag,
+                        blob.ETag,
+                        stopwatch.Elapsed);
+
+                    return new AuxiliaryFileResult<T>(
+                        notModified: false,
+                        data: data,
+                        metadata: new AuxiliaryFileMetadata(
+                            lastModified: new DateTimeOffset(blob.LastModifiedUtc),
+                            loaded: DateTimeOffset.UtcNow,
+                            loadDuration: stopwatch.Elapsed,
+                            fileSize: blob.Properties.Length,
+                            etag: blob.ETag));
+                };
+            }
+            catch (StorageException ex) when (ex.RequestInformation?.HttpStatusCode == (int)HttpStatusCode.NotModified)
+            {
+                stopwatch.Stop();
+                _logger.LogInformation(
+                    "Blob {BlobName} has not changed from the previous etag {ETag}. Took {Duration}.",
+                    blobName,
+                    etag,
+                    stopwatch.Elapsed);
+
+                return new AuxiliaryFileResult<T>(
+                    notModified: true,
+                    data: null,
+                    metadata: null);
+            }
+        }
+
+        /// <summary>
+        /// This is an adapter implementation so that we can use the pre-existing auxiliary file reading code. It simply
+        /// returns a <see cref="JsonReader"/> provided to the constructor and performs no additional network requests.
+        /// </summary>
+        private class LoaderAdapter : ILoader
+        {
+            private readonly JsonReader _jsonReader;
+
+            public LoaderAdapter(JsonReader jsonReader)
+            {
+                _jsonReader = jsonReader ?? throw new ArgumentNullException(nameof(jsonReader));
+            }
+
+            public DateTime? GetLastUpdateTime(string name) => throw new NotImplementedException();
+            public bool Reload(IndexingConfiguration config) => throw new NotImplementedException();
+
+            public JsonReader GetReader(string name)
+            {
+                if (name != null)
+                {
+                    throw new ArgumentException("The provided blob name should be null.", nameof(name));
+                }
+
+                return _jsonReader;
+            }
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryFileReloader.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryFileReloader.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class AuxiliaryFileReloader : IAuxiliaryFileReloader
+    {
+        private readonly IAuxiliaryDataCache _cache;
+        private readonly IOptionsSnapshot<SearchServiceConfiguration> _options;
+        private readonly ILogger<AuxiliaryFileReloader> _logger;
+
+        public AuxiliaryFileReloader(
+            IAuxiliaryDataCache cache,
+            IOptionsSnapshot<SearchServiceConfiguration> options,
+            ILogger<AuxiliaryFileReloader> logger)
+        {
+            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task ReloadContinuouslyAsync(CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                _logger.LogInformation("Trying to reload the auxiliary data.");
+
+                TimeSpan delay;
+                try
+                {
+                    await _cache.TryLoadAsync(token);
+                    delay = _options.Value.AuxiliaryDataReloadFrequency;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError((EventId)0, ex, "An exception was thrown while reloading the auxiliary data.");
+
+                    delay = _options.Value.AuxiliaryDataReloadFailureRetryFrequency;
+                }
+                
+                if (token.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                _logger.LogInformation(
+                    "Waiting {Duration} before attempting to reload the auxiliary data again.",
+                    delay);
+                await Task.Delay(delay, token);
+            }
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryFileResult.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryFileResult.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class AuxiliaryFileResult<T> where T : class
+    {
+        public AuxiliaryFileResult(
+            bool notModified,
+            T data,
+            AuxiliaryFileMetadata metadata)
+        {
+            NotModified = notModified;
+            if (notModified)
+            {
+                if (data != null)
+                {
+                    throw new ArgumentException("The fetched data must be null if it was not modified.", nameof(data));
+                }
+
+                if (metadata != null)
+                {
+                    throw new ArgumentException("The file metadata must be null if it was not modified.", nameof(data));
+                }
+            }
+            else
+            {
+                Data = data ?? throw new ArgumentNullException(nameof(data));
+                Metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
+            }
+        }
+
+        public bool NotModified { get; }
+        public T Data { get; }
+        public AuxiliaryFileMetadata Metadata { get; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/IAuxiliaryData.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IAuxiliaryData.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public interface IAuxiliaryData
+    {
+        AuxiliaryFilesMetadata Metadata { get; }
+        int GetDownloadCount(string id, string normalizedVersion);
+        int GetTotalDownloadCount(string id);
+        bool IsVerified(string id);
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/IAuxiliaryDataCache.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IAuxiliaryDataCache.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public interface IAuxiliaryDataCache
+    {
+        /// <summary>
+        /// Returns true if there is auxiliary data available. False, otherwise. If there is data available, it can be
+        /// retrieved using <see cref="Get"/>.
+        /// </summary>
+        bool Initialized { get; }
+
+        /// <summary>
+        /// Returns the cached loaded auxiliary data.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if there is not data available. <see cref="InitializeAsync"/> should be called if this is
+        /// thrown. <see cref="Initialized"/> can be used to check whether data is available.
+        /// </exception>
+        IAuxiliaryData Get();
+
+        /// <summary>
+        /// Load the latest version of the auxiliary data if it is not already loaded. If the data is already being
+        /// loaded by another caller, this method waits until that other reload finishes and then performs its own load
+        /// operation. If the data is already loaded, this method completes immediately without reloading the data.
+        /// </summary>
+        Task InitializeAsync();
+
+        /// <summary>
+        /// Tries to load the latest version of the auxiliary data. If the data is already being loaded by another
+        /// caller, this method does not reload the data but does wait until some data is available.
+        /// </summary>
+        Task TryLoadAsync(CancellationToken token);
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/IAuxiliaryFileClient.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IAuxiliaryFileClient.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NuGet.Indexing;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public interface IAuxiliaryFileClient
+    {
+        Task<AuxiliaryFileResult<Downloads>> LoadDownloadsAsync(string etag);
+        Task<AuxiliaryFileResult<HashSet<string>>> LoadVerifiedPackagesAsync(string etag);
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/IAuxiliaryFileReloader.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IAuxiliaryFileReloader.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public interface IAuxiliaryFileReloader
+    {
+        Task ReloadContinuouslyAsync(CancellationToken token);
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/AuxiliaryFileMetadata.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/AuxiliaryFileMetadata.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Newtonsoft.Json;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class AuxiliaryFileMetadata
+    {
+        [JsonConstructor]
+        public AuxiliaryFileMetadata(
+            DateTimeOffset lastModified,
+            DateTimeOffset loaded,
+            TimeSpan loadDuration,
+            long fileSize,
+            string etag)
+        {
+            Loaded = loaded;
+            LastModified = lastModified;
+            LoadDuration = loadDuration;
+            FileSize = fileSize;
+            ETag = etag ?? throw new ArgumentNullException(nameof(etag));
+        }
+
+        public DateTimeOffset LastModified { get; }
+        public DateTimeOffset Loaded { get; }
+        public TimeSpan LoadDuration { get; }
+        public long FileSize { get; }
+        public string ETag { get; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/AuxiliaryFilesMetadata.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/AuxiliaryFilesMetadata.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Newtonsoft.Json;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class AuxiliaryFilesMetadata
+    {
+        [JsonConstructor]
+        public AuxiliaryFilesMetadata(AuxiliaryFileMetadata downloads, AuxiliaryFileMetadata verifiedPackages)
+        {
+            Downloads = downloads ?? throw new ArgumentNullException(nameof(downloads));
+            VerifiedPackages = verifiedPackages ?? throw new ArgumentNullException(nameof(verifiedPackages));
+        }
+
+        public AuxiliaryFileMetadata Downloads { get; }
+        public AuxiliaryFileMetadata VerifiedPackages { get; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class SearchServiceConfiguration : AzureSearchConfiguration
+    {
+        public string SemVer1RegistrationsBaseUrl { get; set; }
+        public string SemVer2RegistrationsBaseUrl { get; set; }
+        public string AuxiliaryDataStorageConnectionString { get; set; }
+        public string AuxiliaryDataStorageContainer { get; set; }
+        public string AuxiliaryDataStorageDownloadsPath { get; set; }
+        public string AuxiliaryDataStorageVerifiedPackagesPath { get; set; }
+        public TimeSpan AuxiliaryDataReloadFrequency { get; set; }
+        public TimeSpan AuxiliaryDataReloadFailureRetryFrequency { get; set; }
+    }
+}

--- a/src/NuGet.Services.SearchService/NuGet.Services.SearchService.csproj
+++ b/src/NuGet.Services.SearchService/NuGet.Services.SearchService.csproj
@@ -81,6 +81,10 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\NuGet.Indexing\NuGet.Indexing.csproj">
+      <Project>{ddb34145-870f-42c3-9663-a9390cee1e35}</Project>
+      <Name>NuGet.Indexing</Name>
+    </ProjectReference>
     <ProjectReference Include="..\NuGet.Services.AzureSearch\NuGet.Services.AzureSearch.csproj">
       <Project>{1a53fe3d-8041-4773-942f-d73aef5b82b2}</Project>
       <Name>NuGet.Services.AzureSearch</Name>

--- a/src/NuGet.Services.SearchService/Settings/dev.json
+++ b/src/NuGet.Services.SearchService/Settings/dev.json
@@ -3,7 +3,15 @@
     "SearchServiceName": "",
     "SearchServiceApiKey": "",
     "SearchIndexName": "",
-    "HijackIndexName": ""
+    "HijackIndexName": "",
+    "SemVer1RegistrationsBaseUrl": "",
+    "SemVer2RegistrationsBaseUrl": "",
+    "AuxiliaryDataStorageConnectionString": "",
+    "AuxiliaryDataStorageContainer": "",
+    "AuxiliaryDataStorageDownloadsPath": "downloads.v1.json",
+    "AuxiliaryDataStorageVerifiedPackagesPath": "verifiedPackages.json",
+    "AuxiliaryDataReloadFrequency": "01:00:00",
+    "AuxiliaryDataReloadFailureRetryFrequency": "00:00:30"
   },
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryDocumentsOperations.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryDocumentsOperations.cs
@@ -33,5 +33,10 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
 
             return Task.FromResult(new DocumentIndexResult(new List<IndexingResult>()));
         }
+
+        public Task<DocumentSearchResult<T>> SearchAsync<T>(string searchText, SearchParameters searchParameters) where T : class
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -59,6 +59,10 @@
     <Compile Include="Registration\RegistrationUrlBuilderFacts.cs" />
     <Compile Include="SearchDocumentBuilderFacts.cs" />
     <Compile Include="Registration\RegistrationClientFacts.cs" />
+    <Compile Include="SearchService\AuxiliaryDataCacheFacts.cs" />
+    <Compile Include="SearchService\AuxiliaryDataFacts.cs" />
+    <Compile Include="SearchService\AuxiliaryFileClientFacts.cs" />
+    <Compile Include="SearchService\AuxiliaryFileReloaderFacts.cs" />
     <Compile Include="Support\Cursor.cs" />
     <Compile Include="Support\Data.cs" />
     <Compile Include="Support\SerializationUtilities.cs" />
@@ -85,6 +89,10 @@
     <ProjectReference Include="..\..\src\Catalog\NuGet.Services.Metadata.Catalog.csproj">
       <Project>{E97F23B8-ECB0-4AFA-B00C-015C39395FEF}</Project>
       <Name>NuGet.Services.Metadata.Catalog</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\NuGet.Indexing\NuGet.Indexing.csproj">
+      <Project>{DDB34145-870F-42C3-9663-A9390CEE1E35}</Project>
+      <Name>NuGet.Indexing</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\NuGet.Protocol.Catalog\NuGet.Protocol.Catalog.csproj">
       <Project>{D44C2E89-2D98-44BD-8712-8CCBE4E67C9C}</Project>

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryDataCacheFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryDataCacheFacts.cs
@@ -1,0 +1,183 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Indexing;
+using NuGet.Services.AzureSearch.Support;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class AuxiliaryDataCacheFacts
+    {
+        public class Initialized : BaseFacts
+        {
+            public Initialized(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public void DefaultsToFalse()
+            {
+                Assert.False(_target.Initialized);
+            }
+        }
+
+        public class InitializeAsync : BaseFacts
+        {
+            public InitializeAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task InitializesWhenUninitialized()
+            {
+                await _target.InitializeAsync();
+
+                Assert.True(_target.Initialized);
+                _client.Verify(x => x.LoadDownloadsAsync(null), Times.Once);
+                _client.Verify(x => x.LoadDownloadsAsync(It.IsAny<string>()), Times.Once);
+                _client.Verify(x => x.LoadVerifiedPackagesAsync(null), Times.Once);
+                _client.Verify(x => x.LoadVerifiedPackagesAsync(It.IsAny<string>()), Times.Once);
+                var message = Assert.Single(_logger.Messages.Where(x => x.Contains("Done reloading auxiliary data.")));
+                Assert.EndsWith("Not modified: ", message);
+                Assert.Contains("Reloaded: Downloads, VerifiedPackages", message);
+            }
+
+            [Fact]
+            public async Task DoesNotInitializeAgainWhenAlreadyInitialized()
+            {
+                // Arrange
+                await _target.InitializeAsync();
+                _client.ResetCalls();
+
+                // Act
+                await _target.InitializeAsync();
+
+                // Assert
+                Assert.True(_target.Initialized);
+                _client.Verify(x => x.LoadDownloadsAsync(It.IsAny<string>()), Times.Never);
+                _client.Verify(x => x.LoadVerifiedPackagesAsync(It.IsAny<string>()), Times.Never);
+            }
+        }
+
+        public class TryLoadAsync : BaseFacts
+        {
+            public TryLoadAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task InitializesWhenUninitialized()
+            {
+                await _target.TryLoadAsync(_token);
+
+                Assert.True(_target.Initialized);
+                _client.Verify(x => x.LoadDownloadsAsync(null), Times.Once);
+                _client.Verify(x => x.LoadDownloadsAsync(It.IsAny<string>()), Times.Once);
+                _client.Verify(x => x.LoadVerifiedPackagesAsync(null), Times.Once);
+                _client.Verify(x => x.LoadVerifiedPackagesAsync(It.IsAny<string>()), Times.Once);
+            }
+
+            [Fact]
+            public async Task InitializesAgainWhenAlreadyInitialized()
+            {
+                // Arrange
+                await _target.TryLoadAsync(_token);
+                _client.ResetCalls();
+
+                // Act
+                await _target.TryLoadAsync(_token);
+
+                // Assert
+                Assert.True(_target.Initialized);
+                _client.Verify(x => x.LoadDownloadsAsync("downloads-etag"), Times.Once);
+                _client.Verify(x => x.LoadDownloadsAsync(It.IsAny<string>()), Times.Once);
+                _client.Verify(x => x.LoadVerifiedPackagesAsync("verified-packages-etag"), Times.Once);
+                _client.Verify(x => x.LoadVerifiedPackagesAsync(It.IsAny<string>()), Times.Once);
+            }
+        }
+
+        public class Get : BaseFacts
+        {
+            public Get(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public void ThrowsWhenNotInitialized()
+            {
+                var ex = Assert.Throws<InvalidOperationException>(() => _target.Get());
+                Assert.False(_target.Initialized);
+                Assert.Equal("The auxiliary data has not been loaded yet. Call LoadAsync.", ex.Message);
+            }
+
+            [Fact]
+            public async Task ReturnsDataWhenInitialized()
+            {
+                await _target.InitializeAsync();
+                
+                var value = _target.Get();
+
+                Assert.True(_target.Initialized);
+                Assert.NotNull(value);
+                Assert.Same(_downloads.Metadata, value.Metadata.Downloads);
+                Assert.Same(_verifiedPackages.Metadata, value.Metadata.VerifiedPackages);
+            }
+        }
+
+        public abstract class BaseFacts
+        {
+            protected readonly Mock<IAuxiliaryFileClient> _client;
+            protected readonly RecordingLogger<AuxiliaryDataCache> _logger;
+            protected readonly CancellationToken _token;
+            protected readonly AuxiliaryFileResult<Downloads> _downloads;
+            protected readonly AuxiliaryFileResult<HashSet<string>> _verifiedPackages;
+            protected readonly AuxiliaryDataCache _target;
+
+            public BaseFacts(ITestOutputHelper output)
+            {
+                _client = new Mock<IAuxiliaryFileClient>();
+                _logger = output.GetLogger<AuxiliaryDataCache>();
+
+                _token = CancellationToken.None;
+                _downloads = new AuxiliaryFileResult<Downloads>(
+                    notModified: false,
+                    data: new Downloads(),
+                    metadata: new AuxiliaryFileMetadata(
+                        lastModified: DateTimeOffset.MinValue,
+                        loaded: DateTimeOffset.MinValue,
+                        loadDuration: TimeSpan.Zero,
+                        fileSize: 0,
+                        etag: "downloads-etag"));
+                _verifiedPackages = new AuxiliaryFileResult<HashSet<string>>(
+                    notModified: false,
+                    data: new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                    metadata: new AuxiliaryFileMetadata(
+                        lastModified: DateTimeOffset.MinValue,
+                        loaded: DateTimeOffset.MinValue,
+                        loadDuration: TimeSpan.Zero,
+                        fileSize: 0,
+                        etag: "verified-packages-etag"));
+
+                _client
+                    .Setup(x => x.LoadDownloadsAsync(It.IsAny<string>()))
+                    .ReturnsAsync(() => _downloads);
+                _client
+                    .Setup(x => x.LoadVerifiedPackagesAsync(It.IsAny<string>()))
+                    .ReturnsAsync(() => _verifiedPackages);
+
+                _target = new AuxiliaryDataCache(
+                    _client.Object,
+                    _logger);
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryDataFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryDataFacts.cs
@@ -1,0 +1,155 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Indexing;
+using Xunit;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class AuxiliaryDataFacts
+    {
+        public class IsVerified : BaseFacts
+        {
+            [Fact]
+            public void VerifiedWhenInSet()
+            {
+                _target.VerifiedPackages.Data.Add("NuGet.Versioning");
+
+                var actual = _target.IsVerified("nuget.versioning");
+
+                Assert.True(actual);
+            }
+
+            [Fact]
+            public void NotVerifiedWhenNotInSet()
+            {
+                var actual = _target.IsVerified("nuget.versioning");
+
+                Assert.False(actual);
+            }
+        }
+
+        public class GetTotalDownloadCount : BaseFacts
+        {
+            [Fact]
+            public void ZeroWhenUnknownId()
+            {
+                var actual = _target.GetTotalDownloadCount("nuget.versioning");
+
+                Assert.Equal(0, actual);
+            }
+
+            [Fact]
+            public void ReturnsTotal()
+            {
+                var downloads = new DownloadsByVersion();
+                downloads["1.0.0"] = 2;
+                downloads["3.0.0-alpha"] = 23;
+                _target.Downloads.Data["NuGet.Versioning"] = downloads;
+
+                var actual = _target.GetTotalDownloadCount("nuget.versioning");
+
+                Assert.Equal(25, actual);
+            }
+        }
+
+        public class GetDownloadCount : BaseFacts
+        {
+            [Fact]
+            public void ZeroWhenUnknownId()
+            {
+                var actual = _target.GetDownloadCount("nuget.versioning", "1.0.0");
+
+                Assert.Equal(0, actual);
+            }
+
+            [Fact]
+            public void ZeroWhenUnknownVersion()
+            {
+                var downloads = new DownloadsByVersion();
+                downloads["1.0.0"] = 2;
+                _target.Downloads.Data["NuGet.Versioning"] = downloads;
+
+                var actual = _target.GetDownloadCount("nuget.versioning", "2.0.0");
+
+                Assert.Equal(0, actual);
+            }
+
+            [Fact]
+            public void ReturnsCount()
+            {
+                var downloads = new DownloadsByVersion();
+                downloads["1.0.0"] = 2;
+                downloads["3.0.0-alpha"] = 23;
+                _target.Downloads.Data["NuGet.Versioning"] = downloads;
+
+                var actual = _target.GetDownloadCount("nuget.versioning", "3.0.0-ALPHA");
+
+                Assert.Equal(23, actual);
+            }
+        }
+
+        public class Metadata
+        {
+            [Fact]
+            public void UsesSameMetadataInstances()
+            {
+                var downloadsMetadata = new AuxiliaryFileMetadata(
+                    DateTimeOffset.MinValue,
+                    DateTimeOffset.MinValue,
+                    TimeSpan.Zero,
+                    fileSize: 0,
+                    etag: string.Empty);
+                var verifiedPackagesMetadata = new AuxiliaryFileMetadata(
+                    DateTimeOffset.MinValue,
+                    DateTimeOffset.MinValue,
+                    TimeSpan.Zero,
+                    fileSize: 0,
+                    etag: string.Empty);
+
+                var target = new AuxiliaryData(
+                    new AuxiliaryFileResult<Downloads>(
+                        notModified: false,
+                        data: new Downloads(),
+                        metadata: downloadsMetadata),
+                    new AuxiliaryFileResult<HashSet<string>>(
+                        notModified: false,
+                        data: new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                        metadata: verifiedPackagesMetadata));
+
+                Assert.Same(downloadsMetadata, target.Metadata.Downloads);
+                Assert.Same(verifiedPackagesMetadata, target.Metadata.VerifiedPackages);
+            }
+        }
+
+        public abstract class BaseFacts
+        {
+            protected readonly AuxiliaryData _target;
+
+            public BaseFacts()
+            {
+                _target = new AuxiliaryData(
+                    new AuxiliaryFileResult<Downloads>(
+                        notModified: false,
+                        data: new Downloads(),
+                        metadata: new AuxiliaryFileMetadata(
+                            DateTimeOffset.MinValue,
+                            DateTimeOffset.MinValue,
+                            TimeSpan.Zero,
+                            fileSize: 0,
+                            etag: string.Empty)),
+                    new AuxiliaryFileResult<HashSet<string>>(
+                        notModified: false,
+                        data: new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                        metadata: new AuxiliaryFileMetadata(
+                            DateTimeOffset.MinValue,
+                            DateTimeOffset.MinValue,
+                            TimeSpan.Zero,
+                            fileSize: 0,
+                            etag: string.Empty)));
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryFileClientFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryFileClientFacts.cs
@@ -1,0 +1,205 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Moq;
+using NuGet.Services.AzureSearch.Support;
+using NuGetGallery;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class AuxiliaryFileClientFacts
+    {
+        public class LoadDownloadsAsync : BaseFacts
+        {
+            public LoadDownloadsAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task ReadsContent()
+            {
+                var json = @"
+[
+    [
+        ""NuGet.Frameworks"",
+        [ ""1.0.0"", 406],
+        [ ""2.0.0-ALPHA"", 137]
+    ],
+    [
+        ""NuGet.Versioning"",
+        [""3.0.0"", 138]
+    ]
+]
+";
+                _blob
+                    .Setup(x => x.OpenReadAsync(It.IsAny<AccessCondition>()))
+                    .ReturnsAsync(() => new MemoryStream(Encoding.UTF8.GetBytes(json)));
+
+                var actual = await _target.LoadDownloadsAsync(etag: null);
+
+                Assert.False(actual.NotModified);
+                Assert.Equal(406, actual.Data["NuGet.Frameworks"]["1.0.0"]);
+                Assert.Equal(137, actual.Data["NuGet.Frameworks"]["2.0.0-alpha"]);
+                Assert.Equal(138, actual.Data["nuget.versioning"]["3.0.0"]);
+                Assert.Equal(0, actual.Data["nuget.versioning"]["4.0.0"]);
+                Assert.Null(actual.Data["something.else"]);
+                Assert.Equal(_etag, actual.Metadata.ETag);
+                Assert.NotEqual(TimeSpan.Zero, actual.Metadata.LoadDuration);
+                Assert.NotEqual(default(DateTimeOffset), actual.Metadata.Loaded);
+                _blobClient.Verify(x => x.GetContainerReference("my-container"), Times.Once);
+                _blobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
+                _container.Verify(x => x.GetBlobReference("my-downloads.json"), Times.Once);
+                _container.Verify(x => x.GetBlobReference(It.IsAny<string>()), Times.Once);
+                _blob.Verify(x => x.OpenReadAsync(null), Times.Once);
+                _blob.Verify(x => x.OpenReadAsync(It.IsAny<AccessCondition>()), Times.Once);
+            }
+
+            [Fact]
+            public async Task HandlesNotModified()
+            {
+                _blob
+                    .Setup(x => x.OpenReadAsync(It.IsAny<AccessCondition>()))
+                    .ThrowsAsync(new StorageException(
+                        res: new RequestResult()
+                        {
+                            HttpStatusCode = (int)HttpStatusCode.NotModified,
+                        },
+                        message: "Not so fast, buddy!",
+                        inner: null));
+
+                var actual = await _target.LoadDownloadsAsync(etag: "old-etag");
+
+                Assert.True(actual.NotModified);
+                Assert.Null(actual.Data);
+                Assert.Null(actual.Metadata);
+                _blobClient.Verify(x => x.GetContainerReference("my-container"), Times.Once);
+                _blobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
+                _container.Verify(x => x.GetBlobReference("my-downloads.json"), Times.Once);
+                _container.Verify(x => x.GetBlobReference(It.IsAny<string>()), Times.Once);
+                _blob.Verify(x => x.OpenReadAsync(It.Is<AccessCondition>(a => a.IfNoneMatchETag == "old-etag")), Times.Once);
+                _blob.Verify(x => x.OpenReadAsync(It.IsAny<AccessCondition>()), Times.Once);
+            }
+        }
+
+        public class LoadVerifiedPackagesAsync : BaseFacts
+        {
+            public LoadVerifiedPackagesAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task ReadsContent()
+            {
+                var json = @"
+[
+    ""NuGet.Frameworks"",
+    ""NuGet.Versioning""
+]
+";
+                _blob
+                    .Setup(x => x.OpenReadAsync(It.IsAny<AccessCondition>()))
+                    .ReturnsAsync(() => new MemoryStream(Encoding.UTF8.GetBytes(json)));
+
+                var actual = await _target.LoadVerifiedPackagesAsync(etag: null);
+
+                Assert.False(actual.NotModified);
+                Assert.Contains("NuGet.Frameworks", actual.Data);
+                Assert.Contains("nuget.versioning", actual.Data);
+                Assert.DoesNotContain("something.else", actual.Data);
+                Assert.Equal(_etag, actual.Metadata.ETag);
+                Assert.NotEqual(TimeSpan.Zero, actual.Metadata.LoadDuration);
+                Assert.NotEqual(default(DateTimeOffset), actual.Metadata.Loaded);
+                _blobClient.Verify(x => x.GetContainerReference("my-container"), Times.Once);
+                _blobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
+                _container.Verify(x => x.GetBlobReference("my-verified-packages.json"), Times.Once);
+                _container.Verify(x => x.GetBlobReference(It.IsAny<string>()), Times.Once);
+                _blob.Verify(x => x.OpenReadAsync(null), Times.Once);
+                _blob.Verify(x => x.OpenReadAsync(It.IsAny<AccessCondition>()), Times.Once);
+            }
+
+            [Fact]
+            public async Task HandlesNotModified()
+            {
+                _blob
+                    .Setup(x => x.OpenReadAsync(It.IsAny<AccessCondition>()))
+                    .ThrowsAsync(new StorageException(
+                        res: new RequestResult()
+                        {
+                            HttpStatusCode = (int)HttpStatusCode.NotModified,
+                        },
+                        message: "Not so fast, buddy!",
+                        inner: null));
+
+                var downloads = await _target.LoadVerifiedPackagesAsync(etag: "old-etag");
+
+                Assert.True(downloads.NotModified);
+                Assert.Null(downloads.Data);
+                Assert.Null(downloads.Metadata);
+                _blobClient.Verify(x => x.GetContainerReference("my-container"), Times.Once);
+                _blobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
+                _container.Verify(x => x.GetBlobReference("my-verified-packages.json"), Times.Once);
+                _container.Verify(x => x.GetBlobReference(It.IsAny<string>()), Times.Once);
+                _blob.Verify(x => x.OpenReadAsync(It.Is<AccessCondition>(a => a.IfNoneMatchETag == "old-etag")), Times.Once);
+                _blob.Verify(x => x.OpenReadAsync(It.IsAny<AccessCondition>()), Times.Once);
+            }
+        }
+
+        public abstract class BaseFacts
+        {
+            protected readonly Mock<ICloudBlobClient> _blobClient;
+            protected readonly SearchServiceConfiguration _config;
+            protected readonly Mock<IOptionsSnapshot<SearchServiceConfiguration>> _options;
+            protected readonly RecordingLogger<AuxiliaryFileClient> _logger;
+            protected readonly Mock<ICloudBlobContainer> _container;
+            protected readonly Mock<ISimpleCloudBlob> _blob;
+            protected readonly string _etag;
+            protected readonly AuxiliaryFileClient _target;
+
+            public BaseFacts(ITestOutputHelper output)
+            {
+                _blobClient = new Mock<ICloudBlobClient>();
+                _config = new SearchServiceConfiguration();
+                _options = new Mock<IOptionsSnapshot<SearchServiceConfiguration>>();
+                _logger = output.GetLogger<AuxiliaryFileClient>();
+                _container = new Mock<ICloudBlobContainer>();
+                _blob = new Mock<ISimpleCloudBlob>();
+                _etag = "\"something\"";
+
+                _config.AuxiliaryDataStorageContainer = "my-container";
+                _config.AuxiliaryDataStorageDownloadsPath = "my-downloads.json";
+                _config.AuxiliaryDataStorageVerifiedPackagesPath = "my-verified-packages.json";
+                _options.Setup(x => x.Value).Returns(() => _config);
+                _blobClient
+                    .Setup(x => x.GetContainerReference(It.IsAny<string>()))
+                    .Returns(() => _container.Object);
+                _container
+                    .Setup(x => x.GetBlobReference(It.IsAny<string>()))
+                    .Returns(() => _blob.Object);
+                _blob
+                    .Setup(x => x.OpenReadAsync(It.IsAny<AccessCondition>()))
+                    .ReturnsAsync(() => new MemoryStream(Encoding.UTF8.GetBytes("[]")));
+                _blob
+                    .Setup(x => x.ETag)
+                    .Returns(() => _etag);
+                _blob
+                    .Setup(x => x.Properties)
+                    .Returns(new BlobProperties());
+
+                _target = new AuxiliaryFileClient(
+                    _blobClient.Object,
+                    _options.Object,
+                    _logger);
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryFileReloaderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryFileReloaderFacts.cs
@@ -1,0 +1,138 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Moq;
+using NuGet.Services.AzureSearch.Support;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class AuxiliaryFileReloaderFacts
+    {
+        public class ReloadContinuouslyAsync : BaseFacts
+        {
+            public ReloadContinuouslyAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task CanBeCancelledImmediately()
+            {
+                _cts.Cancel();
+
+                await _target.ReloadContinuouslyAsync(_cts.Token);
+
+                _cache.Verify(x => x.TryLoadAsync(It.IsAny<CancellationToken>()), Times.Never);
+            }
+
+            [Fact]
+            public async Task ReloadsUntilCancelled()
+            {
+                CancelAfter(reloads: 5);
+                _config.AuxiliaryDataReloadFrequency = TimeSpan.Zero;
+
+                await _target.ReloadContinuouslyAsync(_cts.Token);
+
+                _cache.Verify(x => x.TryLoadAsync(_cts.Token), Times.Exactly(5));
+                _cache.Verify(x => x.TryLoadAsync(It.IsAny<CancellationToken>()), Times.Exactly(5));
+            }
+
+            [Fact]
+            public async Task UsesReloadFrequencyOnSuccess()
+            {
+                CancelAfter(reloads: 2);
+                _config.AuxiliaryDataReloadFrequency = TimeSpan.FromMilliseconds(100);
+                _config.AuxiliaryDataReloadFailureRetryFrequency = TimeSpan.Zero;
+
+                var stopwatch = Stopwatch.StartNew();
+                await _target.ReloadContinuouslyAsync(_cts.Token);
+                stopwatch.Stop();
+
+                _cache.Verify(x => x.TryLoadAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+                Assert.InRange(stopwatch.Elapsed, _config.AuxiliaryDataReloadFrequency, TimeSpan.FromHours(1));
+            }
+
+            [Fact]
+            public async Task UsesReloadFailureRetryFrequencyOnSuccess()
+            {
+                int count = 0;
+                _cache
+                    .Setup(x => x.TryLoadAsync(It.IsAny<CancellationToken>()))
+                    .Returns(() =>
+                    {
+                        count++;
+                        if (count >= 2)
+                        {
+                            _cts.Cancel();
+                        }
+
+                        throw new InvalidOperationException("Please retry later.");
+                    });
+                _config.AuxiliaryDataReloadFrequency = TimeSpan.Zero;
+                _config.AuxiliaryDataReloadFailureRetryFrequency = TimeSpan.FromMilliseconds(100);
+
+                var stopwatch = Stopwatch.StartNew();
+                await _target.ReloadContinuouslyAsync(_cts.Token);
+                stopwatch.Stop();
+
+                _cache.Verify(x => x.TryLoadAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+                Assert.InRange(stopwatch.Elapsed, _config.AuxiliaryDataReloadFailureRetryFrequency, TimeSpan.FromHours(1));
+            }
+        }
+
+        public abstract class BaseFacts
+        {
+            protected readonly Mock<IAuxiliaryDataCache> _cache;
+            protected readonly SearchServiceConfiguration _config;
+            protected readonly Mock<IOptionsSnapshot<SearchServiceConfiguration>> _options;
+            protected readonly RecordingLogger<AuxiliaryFileReloader> _logger;
+            protected readonly CancellationTokenSource _cts;
+            protected readonly AuxiliaryFileReloader _target;
+
+            public BaseFacts(ITestOutputHelper output)
+            {
+                _cache = new Mock<IAuxiliaryDataCache>();
+                _config = new SearchServiceConfiguration();
+                _options = new Mock<IOptionsSnapshot<SearchServiceConfiguration>>();
+                _logger = output.GetLogger<AuxiliaryFileReloader>();
+
+                _cts = new CancellationTokenSource();
+
+                // Default test behavior is to cancel after the first invocation otherwise it is very easy to loop
+                // forever, which is annoying for the person writing the tests.
+                CancelAfter(reloads: 1);
+
+                _config.AuxiliaryDataReloadFrequency = TimeSpan.FromMilliseconds(100);
+                _config.AuxiliaryDataReloadFailureRetryFrequency = TimeSpan.FromMilliseconds(20);
+                _options.Setup(x => x.Value).Returns(() => _config);
+
+                _target = new AuxiliaryFileReloader(
+                    _cache.Object,
+                    _options.Object,
+                    _logger);
+            }
+
+            protected void CancelAfter(int reloads)
+            {
+                int count = 0;
+                _cache
+                    .Setup(x => x.TryLoadAsync(It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask)
+                    .Callback(() =>
+                    {
+                        count++;
+                        if (count >= reloads)
+                        {
+                            _cts.Cancel();
+                        }
+                    });
+            }
+        }
+    }
+}


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/6449

1. Load the downloads and verified packages auxiliary files using existing parsers
1. No-op loading the auxiliary files using etags
1. Introduce a simple, synchronous interface `IAuxiliaryData` which can be used in a non-async context. This is ideal for code-paths that should be fast-ish, like building response bodies.

`AuxiliaryFileReloader` is the guy that will be launched on app start to reload the auxiliary files in the background.

`AuxiliaryDataCache.InitializeAsync` must be called in an async context before `AuxiliaryDataCache.Get` is called.