### PR TITLE
[Search 1] Add SearchResponseBuilder for constructing V2 and V3 search responses

### DIFF
--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -109,6 +109,7 @@
     <Compile Include="SearchService\IAuxiliaryData.cs" />
     <Compile Include="SearchService\IndexFields.cs" />
     <Compile Include="SearchService\ISearchParametersBuilder.cs" />
+    <Compile Include="SearchService\ISearchResponseBuilder.cs" />
     <Compile Include="SearchService\Models\DebugInformation.cs" />
     <Compile Include="SearchService\Models\SearchRequest.cs" />
     <Compile Include="SearchService\Models\V2SearchDependency.cs" />
@@ -123,6 +124,7 @@
     <Compile Include="SearchService\Models\V3SearchVersion.cs" />
     <Compile Include="SearchService\SearchParametersBuilder.cs" />
     <Compile Include="SearchService\Models\V2SortBy.cs" />
+    <Compile Include="SearchService\SearchResponseBuilder.cs" />
     <Compile Include="VersionList\Guard.cs" />
     <Compile Include="VersionList\HijackIndexChange.cs" />
     <Compile Include="VersionList\HijackIndexChangeType.cs" />

--- a/src/NuGet.Services.AzureSearch/SearchService/ISearchResponseBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/ISearchResponseBuilder.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.Search.Models;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public interface ISearchResponseBuilder
+    {
+        V2SearchResponse V2FromHijack(
+            V2SearchRequest request,
+            SearchParameters parameters,
+            string text,
+            DocumentSearchResult<HijackDocument.Full> result,
+            TimeSpan duration);
+        V2SearchResponse V2FromSearch(
+            V2SearchRequest request,
+            SearchParameters parameters,
+            string text,
+            DocumentSearchResult<SearchDocument.Full> result,
+            TimeSpan duration);
+        V3SearchResponse V3FromSearch(
+            V3SearchRequest request,
+            SearchParameters parameters,
+            string text,
+            DocumentSearchResult<SearchDocument.Full> result,
+            TimeSpan duration);
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/DebugInformation.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/DebugInformation.cs
@@ -14,6 +14,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         public string SearchText { get; set; }
         public object DocumentSearchResult { get; set; }
         public TimeSpan QueryDuration { get; set; }
+        public AuxiliaryFilesMetadata AuxiliaryFilesMetadata { get; set; }
 
         public static DebugInformation CreateOrNull<T>(
             SearchRequest request,
@@ -21,7 +22,8 @@ namespace NuGet.Services.AzureSearch.SearchService
             SearchParameters parameters,
             string text,
             DocumentSearchResult<T> result,
-            TimeSpan duration) where T : class
+            TimeSpan duration,
+            AuxiliaryFilesMetadata auxiliaryFilesMetadata) where T : class
         {
             if (!request.ShowDebug)
             {
@@ -36,6 +38,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 IndexName = indexName,
                 DocumentSearchResult = result,
                 QueryDuration = duration,
+                AuxiliaryFilesMetadata = auxiliaryFilesMetadata,
             };
         }
     }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
@@ -1,0 +1,285 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Azure.Search.Models;
+using Microsoft.Extensions.Options;
+using NuGet.Protocol.Registration;
+using NuGet.Versioning;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class SearchResponseBuilder : ISearchResponseBuilder
+    {
+        private static readonly string[] EmptyStringArray = new string[0];
+        private static readonly V2SearchDependency[] EmptyDependencies = new V2SearchDependency[0];
+        private readonly Lazy<IAuxiliaryData> _lazyAuxiliaryData;
+        private readonly IOptionsSnapshot<SearchServiceConfiguration> _options;
+
+        public SearchResponseBuilder(
+            Lazy<IAuxiliaryData> auxiliaryData,
+            IOptionsSnapshot<SearchServiceConfiguration> options)
+        {
+            _lazyAuxiliaryData = auxiliaryData ?? throw new ArgumentNullException(nameof(auxiliaryData));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+
+            if (_options.Value.SemVer1RegistrationsBaseUrl == null)
+            {
+                throw new ArgumentException($"The {nameof(SearchServiceConfiguration.SemVer1RegistrationsBaseUrl)} need to be set.", nameof(options));
+            }
+
+            if (_options.Value.SemVer2RegistrationsBaseUrl == null)
+            {
+                throw new ArgumentException($"The {nameof(SearchServiceConfiguration.SemVer2RegistrationsBaseUrl)} need to be set.", nameof(options));
+            }
+        }
+
+        private IAuxiliaryData AuxiliaryData => _lazyAuxiliaryData.Value;
+
+        public V2SearchResponse V2FromHijack(
+            V2SearchRequest request,
+            SearchParameters searchParameters,
+            string text,
+            DocumentSearchResult<HijackDocument.Full> result,
+            TimeSpan duration)
+        {
+            return ToResponse(
+                request,
+                searchParameters,
+                text,
+                _options.Value.HijackIndexName,
+                result,
+                duration,
+                p => ToV2SearchPackage(p, request.IncludeSemVer2));
+        }
+
+        public V2SearchResponse V2FromSearch(
+            V2SearchRequest request,
+            SearchParameters parameters,
+            string text,
+            DocumentSearchResult<SearchDocument.Full> result,
+            TimeSpan duration)
+        {
+            return ToResponse(
+                request,
+                parameters,
+                text,
+                _options.Value.SearchIndexName,
+                result,
+                duration,
+                p => ToV2SearchPackage(p));
+        }
+
+        public V3SearchResponse V3FromSearch(
+            V3SearchRequest request,
+            SearchParameters parameters,
+            string text,
+            DocumentSearchResult<SearchDocument.Full> result,
+            TimeSpan duration)
+        {
+            var results = result.Results;
+            result.Results = null;
+
+            var registrationsBaseUrl = GetRegistrationsBaseUrl(request.IncludeSemVer2);
+
+            return new V3SearchResponse
+            {
+                Context = new V3SearchContext
+                {
+                    Vocab = "http://schema.nuget.org/schema#",
+                    Base = registrationsBaseUrl,
+                },
+                TotalHits = result.Count.Value,
+                Data = results
+                    .Select(x =>
+                    {
+                        var package = ToV3SearchPackage(x.Document, registrationsBaseUrl);
+                        package.Debug = request.ShowDebug ? x : null;
+                        return package;
+                    })
+                    .ToList(),
+                Debug = DebugInformation.CreateOrNull(
+                    request,
+                    _options.Value.SearchIndexName,
+                    parameters,
+                    text,
+                    result,
+                    duration,
+                    AuxiliaryData.Metadata),
+            };
+        }
+
+        private static string TitleThenId(IBaseMetadataDocument document)
+        {
+            if (!string.IsNullOrWhiteSpace(document.Title))
+            {
+                return document.Title;
+            }
+
+            return document.PackageId;
+        }
+
+        private V2SearchResponse ToResponse<T>(
+            V2SearchRequest request,
+            SearchParameters parameters,
+            string text,
+            string indexName,
+            DocumentSearchResult<T> result,
+            TimeSpan duration,
+            Func<T, V2SearchPackage> toPackage)
+            where T : class
+        {
+            var results = result.Results;
+            result.Results = null;
+
+            if (request.CountOnly)
+            {
+                return new V2SearchResponse
+                {
+                    TotalHits = result.Count.Value,
+                    Debug = DebugInformation.CreateOrNull(
+                        request,
+                        indexName,
+                        parameters,
+                        text,
+                        result,
+                        duration,
+                        AuxiliaryData.Metadata),
+                };
+            }
+            else
+            {
+                return new V2SearchResponse
+                {
+                    TotalHits = result.Count.Value,
+                    Data = results
+                        .Select(x =>
+                        {
+                            var package = toPackage(x.Document);
+                            package.Debug = request.ShowDebug ? x : null;
+                            return package;
+                        })
+                        .ToList(),
+                    Debug = DebugInformation.CreateOrNull(
+                        request,
+                        indexName,
+                        parameters,
+                        text,
+                        result,
+                        duration,
+                        AuxiliaryData.Metadata),
+                };
+            }
+        }
+
+        private V3SearchPackage ToV3SearchPackage(SearchDocument.Full result, string registrationsBaseUrl)
+        {
+            var registrationIndexUrl = RegistrationUrlBuilder.GetIndexUrl(registrationsBaseUrl, result.PackageId);
+            return new V3SearchPackage
+            {
+                AtId = registrationIndexUrl,
+                Type = "Package",
+                Registration = registrationIndexUrl,
+                Id = result.PackageId,
+                Version = result.FullVersion,
+                Description = result.Description ?? string.Empty,
+                Summary = result.Summary ?? string.Empty,
+                Title = TitleThenId(result),
+                IconUrl = result.IconUrl,
+                LicenseUrl = result.LicenseUrl,
+                ProjectUrl = result.ProjectUrl,
+                Tags = result.Tags ?? EmptyStringArray,
+                Authors = new[] { result.Authors ?? string.Empty },
+                TotalDownloads = AuxiliaryData.GetTotalDownloadCount(result.PackageId),
+                Verified = AuxiliaryData.IsVerified(result.PackageId),
+                Versions = result
+                    .Versions
+                    .Select(x =>
+                    {
+                        // Each of these versions is the full version.
+                        var lowerVersion = NuGetVersion.Parse(x).ToNormalizedString().ToLowerInvariant();
+                        return new V3SearchVersion
+                        {
+                            Version = x,
+                            Downloads = AuxiliaryData.GetDownloadCount(result.PackageId, lowerVersion),
+                            AtId = RegistrationUrlBuilder.GetLeafUrl(registrationsBaseUrl, result.PackageId, x),
+                        };
+                    })
+                    .ToList(),
+            };
+        }
+
+        private V2SearchPackage ToV2SearchPackage(SearchDocument.Full result)
+        {
+            var package = BaseMetadataDocumentToPackage(result);
+
+            package.PackageRegistration.Owners = result.Owners ?? EmptyStringArray;
+            package.Listed = true;
+            package.IsLatestStable = result.IsLatestStable.Value;
+            package.IsLatest = result.IsLatest.Value;
+
+            return package;
+        }
+
+        private V2SearchPackage ToV2SearchPackage(HijackDocument.Full result, bool semVer2)
+        {
+            var package = BaseMetadataDocumentToPackage(result);
+
+            // The owners are not used in the hijack scenarios.
+            package.PackageRegistration.Owners = EmptyStringArray;
+
+            package.Listed = result.Listed.Value;
+            package.IsLatestStable = semVer2 ? result.IsLatestStableSemVer2.Value : result.IsLatestStableSemVer1.Value;
+            package.IsLatest = semVer2 ? result.IsLatestSemVer2.Value : result.IsLatestSemVer1.Value;
+
+            return package;
+        }
+
+        private V2SearchPackage BaseMetadataDocumentToPackage(IBaseMetadataDocument document)
+        {
+            return new V2SearchPackage
+            {
+                PackageRegistration = new V2SearchPackageRegistration
+                {
+                    Id = document.PackageId,
+                    DownloadCount = AuxiliaryData.GetTotalDownloadCount(document.PackageId),
+                    Verified = AuxiliaryData.IsVerified(document.PackageId),
+                },
+                Version = document.OriginalVersion ?? document.NormalizedVersion,
+                NormalizedVersion = document.NormalizedVersion,
+                Title = TitleThenId(document),
+                Description = document.Description ?? string.Empty,
+                Summary = document.Summary ?? string.Empty,
+                Authors = document.Authors ?? string.Empty,
+                Copyright = document.Copyright,
+                Language = document.Language,
+                Tags = document.Tags != null ? string.Join(" ", document.Tags) : string.Empty,
+                ReleaseNotes = document.ReleaseNotes,
+                ProjectUrl = document.ProjectUrl,
+                IconUrl = document.IconUrl,
+                Created = document.Created.Value,
+                Published = document.Published.Value,
+                LastUpdated = document.Published.Value,
+                LastEdited = document.LastEdited,
+                DownloadCount = AuxiliaryData.GetDownloadCount(document.PackageId, document.NormalizedVersion),
+                FlattenedDependencies = document.FlattenedDependencies,
+                Dependencies = EmptyDependencies,
+                SupportedFrameworks = EmptyStringArray,
+                MinClientVersion = document.MinClientVersion,
+                Hash = document.Hash,
+                HashAlgorithm = document.HashAlgorithm,
+                PackageFileSize = document.FileSize.Value,
+                LicenseUrl = document.LicenseUrl,
+                RequiresLicenseAcceptance = document.RequiresLicenseAcceptance ?? false,
+            };
+        }
+
+        public string GetRegistrationsBaseUrl(bool includeSemVer2)
+        {
+            var url = includeSemVer2 ? _options.Value.SemVer2RegistrationsBaseUrl : _options.Value.SemVer1RegistrationsBaseUrl;
+
+            return url.TrimEnd('/') + '/';
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/HijackDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/HijackDocumentBuilderFacts.cs
@@ -50,7 +50,7 @@ namespace NuGet.Services.AzureSearch
                     Data.NormalizedVersion,
                     Data.CommitTimestamp,
                     Data.CommitId,
-                    _changes);
+                    Data.HijackDocumentChanges);
 
                 SetDocumentLastUpdated(document);
                 var json = await SerializationUtilities.SerializeToJsonAsync(document);
@@ -86,7 +86,7 @@ namespace NuGet.Services.AzureSearch
                 var package = Data.PackageEntity;
                 package.Tags = null;
 
-                var document = _target.FullFromDb(Data.PackageId, _changes, package);
+                var document = _target.FullFromDb(Data.PackageId, Data.HijackDocumentChanges, package);
 
                 Assert.Null(document.Tags);
             }
@@ -97,7 +97,7 @@ namespace NuGet.Services.AzureSearch
                 var package = Data.PackageEntity;
                 package.SemVerLevelKey = SemVerLevelKey.Unknown;
 
-                var document = _target.FullFromDb(Data.PackageId, _changes, package);
+                var document = _target.FullFromDb(Data.PackageId, Data.HijackDocumentChanges, package);
 
                 var json = await SerializationUtilities.SerializeToJsonAsync(document);
                 Assert.Contains("\"semVerLevel\": null,", json);
@@ -106,7 +106,7 @@ namespace NuGet.Services.AzureSearch
             [Fact]
             public async Task SetsExpectedProperties()
             {
-                var document = _target.FullFromDb(Data.PackageId, _changes, Data.PackageEntity);
+                var document = _target.FullFromDb(Data.PackageId, Data.HijackDocumentChanges, Data.PackageEntity);
 
                 SetDocumentLastUpdated(document);
                 var json = await SerializationUtilities.SerializeToJsonAsync(document);
@@ -173,7 +173,7 @@ namespace NuGet.Services.AzureSearch
                 var package = Data.PackageEntity;
                 package.Title = title;
 
-                var document = _target.FullFromDb(Data.PackageId, _changes, package);
+                var document = _target.FullFromDb(Data.PackageId, Data.HijackDocumentChanges, package);
 
                 Assert.Equal(Data.PackageId.ToLowerInvariant(), document.SortableTitle);
             }
@@ -184,7 +184,7 @@ namespace NuGet.Services.AzureSearch
                 var package = Data.PackageEntity;
                 package.Listed = false;
 
-                var document = _target.FullFromDb(Data.PackageId, _changes, package);
+                var document = _target.FullFromDb(Data.PackageId, Data.HijackDocumentChanges, package);
 
                 Assert.Equal(DateTimeOffset.Parse("1900-01-01Z"), document.Published);
             }
@@ -195,7 +195,7 @@ namespace NuGet.Services.AzureSearch
                 var package = Data.PackageEntity;
                 package.Tags = "foo; BAR |     Baz";
 
-                var document = _target.FullFromDb(Data.PackageId, _changes, package);
+                var document = _target.FullFromDb(Data.PackageId, Data.HijackDocumentChanges, package);
 
                 Assert.Equal(new[] { "foo", "BAR", "Baz" }, document.Tags);
             }
@@ -208,7 +208,7 @@ namespace NuGet.Services.AzureSearch
                 var package = Data.PackageEntity;
                 package.SemVerLevelKey = semVerLevelKey;
 
-                var document = _target.FullFromDb(Data.PackageId, _changes, package);
+                var document = _target.FullFromDb(Data.PackageId, Data.HijackDocumentChanges, package);
 
                 Assert.Equal(semVerLevelKey, document.SemVerLevel);
             }
@@ -224,7 +224,7 @@ namespace NuGet.Services.AzureSearch
                 package.Version = "2.0.0-alpha";
                 package.NormalizedVersion = "2.0.0-alpha";
 
-                var document = _target.FullFromDb(Data.PackageId, _changes, package);
+                var document = _target.FullFromDb(Data.PackageId, Data.HijackDocumentChanges, package);
 
                 Assert.False(document.Prerelease);
             }
@@ -239,7 +239,7 @@ namespace NuGet.Services.AzureSearch
             [Fact]
             public async Task SetsExpectedProperties()
             {
-                var document = _target.FullFromCatalog(Data.NormalizedVersion, _changes, Data.Leaf);
+                var document = _target.FullFromCatalog(Data.NormalizedVersion, Data.HijackDocumentChanges, Data.Leaf);
 
                 SetDocumentLastUpdated(document);
                 var json = await SerializationUtilities.SerializeToJsonAsync(document);
@@ -306,7 +306,7 @@ namespace NuGet.Services.AzureSearch
                 leaf.Listed = null;
                 leaf.Published = DateTimeOffset.Parse("1900-01-01Z");
 
-                var document = _target.FullFromCatalog(Data.NormalizedVersion, _changes, leaf);
+                var document = _target.FullFromCatalog(Data.NormalizedVersion, Data.HijackDocumentChanges, leaf);
 
                 Assert.False(document.Listed);
             }
@@ -318,7 +318,7 @@ namespace NuGet.Services.AzureSearch
                 var leaf = Data.Leaf;
                 leaf.Title = title;
 
-                var document = _target.FullFromCatalog(Data.NormalizedVersion, _changes, leaf);
+                var document = _target.FullFromCatalog(Data.NormalizedVersion, Data.HijackDocumentChanges, leaf);
 
                 Assert.Equal(Data.PackageId.ToLowerInvariant(), document.SortableTitle);
             }
@@ -329,7 +329,7 @@ namespace NuGet.Services.AzureSearch
                 var leaf = Data.Leaf;
                 leaf.RequireLicenseAgreement = null;
 
-                var document = _target.FullFromCatalog(Data.NormalizedVersion, _changes, leaf);
+                var document = _target.FullFromCatalog(Data.NormalizedVersion, Data.HijackDocumentChanges, leaf);
 
                 Assert.Null(document.RequiresLicenseAcceptance);
             }
@@ -340,7 +340,7 @@ namespace NuGet.Services.AzureSearch
                 var leaf = Data.Leaf;
                 leaf.VerbatimVersion = null;
 
-                var document = _target.FullFromCatalog(Data.NormalizedVersion, _changes, leaf);
+                var document = _target.FullFromCatalog(Data.NormalizedVersion, Data.HijackDocumentChanges, leaf);
 
                 Assert.Null(document.OriginalVersion);
             }
@@ -349,9 +349,7 @@ namespace NuGet.Services.AzureSearch
         public abstract class BaseFacts
         {
             protected readonly ITestOutputHelper _output;
-            protected readonly HijackDocumentChanges _changes;
             protected readonly HijackDocumentBuilder _target;
-
 
             public static IEnumerable<object[]> MissingTitles = new[]
             {
@@ -369,13 +367,6 @@ namespace NuGet.Services.AzureSearch
             public BaseFacts(ITestOutputHelper output)
             {
                 _output = output;
-                _changes = new HijackDocumentChanges(
-                    delete: false,
-                    updateMetadata: true,
-                    latestStableSemVer1: false,
-                    latestSemVer1: true,
-                    latestStableSemVer2: false,
-                    latestSemVer2: true);
 
                 _target = new HijackDocumentBuilder();
             }

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="SearchService\AuxiliaryFileClientFacts.cs" />
     <Compile Include="SearchService\AuxiliaryFileReloaderFacts.cs" />
     <Compile Include="SearchService\SearchParametersBuilderFacts.cs" />
+    <Compile Include="SearchService\SearchResponseBuilderFacts.cs" />
     <Compile Include="Support\Cursor.cs" />
     <Compile Include="Support\Data.cs" />
     <Compile Include="Support\SerializationUtilities.cs" />

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
@@ -124,7 +124,7 @@ namespace NuGet.Services.AzureSearch
             [Fact]
             public async Task SetsExpectedProperties()
             {
-                var document = _target.Keyed(Data.PackageId, _searchFilters);
+                var document = _target.Keyed(Data.PackageId, Data.SearchFilters);
 
                 var json = await SerializationUtilities.SerializeToJsonAsync(document);
                 Assert.Equal(@"{
@@ -153,10 +153,10 @@ namespace NuGet.Services.AzureSearch
             {
                 var document = _target.UpdateVersionListFromCatalog(
                     Data.PackageId,
-                    _searchFilters,
+                    Data.SearchFilters,
                     Data.CommitTimestamp,
                     Data.CommitId,
-                    _versions,
+                    Data.Versions,
                     isLatestStable,
                     isLatest);
 
@@ -200,8 +200,8 @@ namespace NuGet.Services.AzureSearch
                 leaf.Title = title;
 
                 var document = _target.UpdateLatestFromCatalog(
-                    _searchFilters,
-                    _versions,
+                    Data.SearchFilters,
+                    Data.Versions,
                     isLatestStable: false,
                     isLatest: true,
                     normalizedVersion: Data.NormalizedVersion,
@@ -217,7 +217,7 @@ namespace NuGet.Services.AzureSearch
             {
                 var document = _target.UpdateLatestFromCatalog(
                     searchFilters,
-                    _versions,
+                    Data.Versions,
                     isLatestStable: false,
                     isLatest: true,
                     normalizedVersion: Data.NormalizedVersion,
@@ -294,8 +294,8 @@ namespace NuGet.Services.AzureSearch
                 leaf.RequireLicenseAgreement = null;                
 
                 var document = _target.UpdateLatestFromCatalog(
-                    _searchFilters,
-                    _versions,
+                    Data.SearchFilters,
+                    Data.Versions,
                     isLatestStable: false,
                     isLatest: true,
                     normalizedVersion: Data.NormalizedVersion,
@@ -320,14 +320,14 @@ namespace NuGet.Services.AzureSearch
 
                 var document = _target.FullFromDb(
                     Data.PackageId,
-                    _searchFilters,
-                    _versions,
+                    Data.SearchFilters,
+                    Data.Versions,
                     isLatestStable: false,
                     isLatest: true,
                     fullVersion: Data.FullVersion,
                     package: package,
-                    owners: _owners,
-                    totalDownloadCount: _totalDownloadCount);
+                    owners: Data.Owners,
+                    totalDownloadCount: Data.TotalDownloadCount);
 
                 Assert.Equal("some title", document.SortableTitle);
             }
@@ -341,14 +341,14 @@ namespace NuGet.Services.AzureSearch
 
                 var document = _target.FullFromDb(
                     Data.PackageId,
-                    _searchFilters,
-                    _versions,
+                    Data.SearchFilters,
+                    Data.Versions,
                     isLatestStable: false,
                     isLatest: true,
                     fullVersion: Data.FullVersion,
                     package: package,
-                    owners: _owners,
-                    totalDownloadCount: _totalDownloadCount);
+                    owners: Data.Owners,
+                    totalDownloadCount: Data.TotalDownloadCount);
 
                 Assert.Equal(Data.PackageId.ToLowerInvariant(), document.SortableTitle);
             }
@@ -361,14 +361,14 @@ namespace NuGet.Services.AzureSearch
 
                 var document = _target.FullFromDb(
                     Data.PackageId,
-                    _searchFilters,
-                    _versions,
+                    Data.SearchFilters,
+                    Data.Versions,
                     isLatestStable: false,
                     isLatest: true,
                     fullVersion: Data.FullVersion,
                     package: package,
-                    owners: _owners,
-                    totalDownloadCount: _totalDownloadCount);
+                    owners: Data.Owners,
+                    totalDownloadCount: Data.TotalDownloadCount);
 
                 var json = await SerializationUtilities.SerializeToJsonAsync(document);
                 Assert.Contains("\"semVerLevel\": null,", json);
@@ -381,13 +381,13 @@ namespace NuGet.Services.AzureSearch
                 var document = _target.FullFromDb(
                     Data.PackageId,
                     searchFilters,
-                    _versions,
+                    Data.Versions,
                     isLatestStable: false,
                     isLatest: true,
                     fullVersion: Data.FullVersion,
                     package: Data.PackageEntity,
-                    owners: _owners,
-                    totalDownloadCount: _totalDownloadCount);
+                    owners: Data.Owners,
+                    totalDownloadCount: Data.TotalDownloadCount);
 
                 SetDocumentLastUpdated(document);
                 var json = await SerializationUtilities.SerializeToJsonAsync(document);
@@ -464,14 +464,14 @@ namespace NuGet.Services.AzureSearch
                 package.Tags = "foo; BAR |     Baz";
                 var document = _target.FullFromDb(
                     Data.PackageId,
-                    _searchFilters,
-                    _versions,
+                    Data.SearchFilters,
+                    Data.Versions,
                     isLatestStable: false,
                     isLatest: true,
                     fullVersion: Data.FullVersion,
                     package: package,
-                    owners: _owners,
-                    totalDownloadCount: _totalDownloadCount);
+                    owners: Data.Owners,
+                    totalDownloadCount: Data.TotalDownloadCount);
 
                 Assert.Equal(new[] { "foo", "BAR", "Baz" }, document.Tags);
             }
@@ -480,10 +480,6 @@ namespace NuGet.Services.AzureSearch
         public abstract class BaseFacts
         {
             protected readonly ITestOutputHelper _output;
-            protected readonly SearchFilters _searchFilters;
-            protected readonly string[] _versions;
-            protected readonly string[] _owners;
-            protected readonly int _totalDownloadCount;
             protected readonly SearchDocumentBuilder _target;
 
             public static IEnumerable<object[]> MissingTitles = new[]
@@ -520,10 +516,6 @@ namespace NuGet.Services.AzureSearch
             public BaseFacts(ITestOutputHelper output)
             {
                 _output = output;
-                _searchFilters = SearchFilters.IncludePrereleaseAndSemVer2;
-                _versions = new[] { "1.0.0", "2.0.0+git", "3.0.0-alpha.1", Data.FullVersion };
-                _owners = new[] { "Microsoft", "azure-sdk" };
-                _totalDownloadCount = 1001;
 
                 _target = new SearchDocumentBuilder();
             }

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -1,0 +1,747 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Azure.Search.Models;
+using Microsoft.Extensions.Options;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using NuGet.Services.AzureSearch.Support;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class SearchResponseBuilderFacts
+    {
+        public class V2FromHijack : BaseFacts
+        {
+            [Fact]
+            public void ShowsUnlisted()
+            {
+                _hijackResult.Results[0].Document.Listed = false;
+
+                var response = _target.V2FromHijack(
+                    _v2Request,
+                    _searchParameters,
+                    _text,
+                    _hijackResult,
+                    _duration);
+
+                Assert.False(response.Data[0].Listed);
+            }
+
+            [Theory]
+            [InlineData(false, true, true, false, false)]
+            [InlineData(true, false, false, true, true)]
+            public void UsesCorrectSetOfLatestBooleans(
+                bool includeSemVer2,
+                bool isLatestStableSemVer1,
+                bool isLatestSemVer1,
+                bool isLatestStableSemVer2,
+                bool isLatestSemVer2)
+            {
+                _v2Request.IncludeSemVer2 = includeSemVer2;
+                var doc = _hijackResult.Results[0].Document;
+                doc.IsLatestStableSemVer1 = isLatestStableSemVer1;
+                doc.IsLatestSemVer1 = isLatestSemVer1;
+                doc.IsLatestStableSemVer2 = isLatestStableSemVer2;
+                doc.IsLatestSemVer2 = isLatestSemVer2;
+
+                var response = _target.V2FromHijack(
+                    _v2Request,
+                    _searchParameters,
+                    _text,
+                    _hijackResult,
+                    _duration);
+
+                Assert.True(response.Data[0].IsLatestStable);
+                Assert.True(response.Data[0].IsLatest);
+            }
+
+            [Theory]
+            [MemberData(nameof(MissingTitles))]
+            public void UsesIdForMissingTitle(string title)
+            {
+                _hijackResult.Results[0].Document.Title = title;
+
+                var response = _target.V2FromHijack(
+                    _v2Request,
+                    _searchParameters,
+                    _text,
+                    _hijackResult,
+                    _duration);
+
+                Assert.Equal(Data.PackageId, response.Data[0].Title);
+            }
+
+            [Fact]
+            public void CoalescesSomeNullFields()
+            {
+                var doc = _hijackResult.Results[0].Document;
+                doc.OriginalVersion = null;
+                doc.Description = null;
+                doc.Summary = null;
+                doc.Authors = null;
+                doc.Tags = null;
+                doc.RequiresLicenseAcceptance = null;
+
+                var response = _target.V2FromHijack(
+                    _v2Request,
+                    _searchParameters,
+                    _text,
+                    _hijackResult,
+                    _duration);
+
+                var result = response.Data[0];
+                Assert.NotNull(result.Version);
+                Assert.Equal(doc.NormalizedVersion, result.Version);
+                Assert.Equal(string.Empty, result.Description);
+                Assert.Equal(string.Empty, result.Summary);
+                Assert.Equal(string.Empty, result.Authors);
+                Assert.Equal(string.Empty, result.Tags);
+                Assert.False(result.RequiresLicenseAcceptance);
+            }
+
+            [Fact]
+            public void UsesVersionSpecificDownloadCount()
+            {
+                _auxiliaryData.Setup(x => x.GetDownloadCount(It.IsAny<string>(), "7.1.2-alpha")).Returns(4);
+
+                var response = _target.V2FromHijack(
+                    _v2Request,
+                    _searchParameters,
+                    _text,
+                    _hijackResult,
+                    _duration);
+
+                Assert.Equal(4, response.Data[0].DownloadCount);
+            }
+
+            [Fact]
+            public void CanIncludeDebugInformation()
+            {
+                _v2Request.ShowDebug = true;
+                var docResult = _hijackResult.Results[0];
+
+                var response = _target.V2FromHijack(
+                    _v2Request,
+                    _searchParameters,
+                    _text,
+                    _hijackResult,
+                    _duration);
+
+                Assert.NotNull(response.Debug);
+                var actualJson = JsonConvert.SerializeObject(response.Debug, _jsonSerializerSettings);
+                Assert.Equal(@"{
+  ""SearchRequest"": {
+    ""IgnoreFilter"": false,
+    ""CountOnly"": false,
+    ""SortBy"": ""Popularity"",
+    ""LuceneQuery"": false,
+    ""Skip"": 0,
+    ""Take"": 0,
+    ""IncludePrerelease"": true,
+    ""IncludeSemVer2"": true,
+    ""ShowDebug"": true
+  },
+  ""IndexName"": ""hijack-index"",
+  ""SearchParameters"": {
+    ""IncludeTotalResultCount"": false,
+    ""QueryType"": ""simple"",
+    ""SearchMode"": ""any""
+  },
+  ""SearchText"": ""azure storage sdk"",
+  ""DocumentSearchResult"": {
+    ""Count"": 1
+  },
+  ""QueryDuration"": ""00:00:00.2500000"",
+  ""AuxiliaryFilesMetadata"": {
+    ""Downloads"": {
+      ""LastModified"": ""2019-01-01T11:00:00+00:00"",
+      ""Loaded"": ""2019-01-01T12:00:00+00:00"",
+      ""LoadDuration"": ""00:00:15"",
+      ""FileSize"": 1234,
+      ""ETag"": ""\""etag-a\""""
+    },
+    ""VerifiedPackages"": {
+      ""LastModified"": ""2019-01-02T11:00:00+00:00"",
+      ""Loaded"": ""2019-01-02T12:00:00+00:00"",
+      ""LoadDuration"": ""00:00:30"",
+      ""FileSize"": 5678,
+      ""ETag"": ""\""etag-b\""""
+    }
+  }
+}", actualJson);
+                Assert.Same(docResult, response.Data[0].Debug);
+            }
+
+            [Fact]
+            public void ProducesExpectedResponse()
+            {
+                var response = _target.V2FromHijack(
+                    _v2Request,
+                    _searchParameters,
+                    _text,
+                    _hijackResult,
+                    _duration);
+
+                var actualJson = JsonConvert.SerializeObject(response, _jsonSerializerSettings);
+                Assert.Equal(@"{
+  ""totalHits"": 1,
+  ""data"": [
+    {
+      ""PackageRegistration"": {
+        ""Id"": ""WindowsAzure.Storage"",
+        ""DownloadCount"": 1001,
+        ""Verified"": true,
+        ""Owners"": []
+      },
+      ""Version"": ""7.1.2.0-alpha+git"",
+      ""NormalizedVersion"": ""7.1.2-alpha"",
+      ""Title"": ""Windows Azure Storage"",
+      ""Description"": ""Description."",
+      ""Summary"": ""Summary."",
+      ""Authors"": ""Microsoft"",
+      ""Copyright"": ""© Microsoft Corporation. All rights reserved."",
+      ""Language"": ""en-US"",
+      ""Tags"": ""Microsoft Azure Storage Table Blob File Queue Scalable windowsazureofficial"",
+      ""ReleaseNotes"": ""Release notes."",
+      ""ProjectUrl"": ""https://github.com/Azure/azure-storage-net"",
+      ""IconUrl"": ""http://go.microsoft.com/fwlink/?LinkID=288890"",
+      ""IsLatestStable"": false,
+      ""IsLatest"": true,
+      ""Listed"": true,
+      ""Created"": ""2017-01-01T00:00:00+00:00"",
+      ""Published"": ""2017-01-03T00:00:00+00:00"",
+      ""LastUpdated"": ""2017-01-03T00:00:00+00:00"",
+      ""LastEdited"": ""2017-01-02T00:00:00+00:00"",
+      ""DownloadCount"": 23,
+      ""FlattenedDependencies"": ""Microsoft.Data.OData:5.6.4:net40-client|Newtonsoft.Json:6.0.8:net40-client"",
+      ""Dependencies"": [],
+      ""SupportedFrameworks"": [],
+      ""MinClientVersion"": ""2.12"",
+      ""Hash"": ""oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33+Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ=="",
+      ""HashAlgorithm"": ""SHA512"",
+      ""PackageFileSize"": 3039254,
+      ""LicenseUrl"": ""http://go.microsoft.com/fwlink/?LinkId=331471"",
+      ""RequiresLicenseAcceptance"": true
+    }
+  ]
+}", actualJson);
+            }
+        }
+
+        public class V2FromSearch : BaseFacts
+        {
+            [Theory]
+            [MemberData(nameof(MissingTitles))]
+            public void UsesIdForMissingTitle(string title)
+            {
+                _searchResult.Results[0].Document.Title = title;
+
+                var response = _target.V2FromSearch(
+                    _v2Request,
+                    _searchParameters,
+                    _text,
+                    _searchResult,
+                    _duration);
+
+                Assert.Equal(Data.PackageId, response.Data[0].Title);
+            }
+
+            [Fact]
+            public void CoalescesSomeNullFields()
+            {
+                var doc = _searchResult.Results[0].Document;
+                doc.OriginalVersion = null;
+                doc.Description = null;
+                doc.Summary = null;
+                doc.Authors = null;
+                doc.Tags = null;
+                doc.RequiresLicenseAcceptance = null;
+
+                var response = _target.V2FromSearch(
+                    _v2Request,
+                    _searchParameters,
+                    _text,
+                    _searchResult,
+                    _duration);
+
+                var result = response.Data[0];
+                Assert.NotNull(result.Version);
+                Assert.Equal(doc.NormalizedVersion, result.Version);
+                Assert.Equal(string.Empty, result.Description);
+                Assert.Equal(string.Empty, result.Summary);
+                Assert.Equal(string.Empty, result.Authors);
+                Assert.Equal(string.Empty, result.Tags);
+                Assert.False(result.RequiresLicenseAcceptance);
+            }
+
+            [Fact]
+            public void UsesVersionSpecificDownloadCount()
+            {
+                _auxiliaryData.Setup(x => x.GetDownloadCount(It.IsAny<string>(), "7.1.2-alpha")).Returns(4);
+
+                var response = _target.V2FromSearch(
+                    _v2Request,
+                    _searchParameters,
+                    _text,
+                    _searchResult,
+                    _duration);
+
+                Assert.Equal(4, response.Data[0].DownloadCount);
+            }
+
+            [Fact]
+            public void CanIncludeDebugInformation()
+            {
+                _v2Request.ShowDebug = true;
+                var docResult = _searchResult.Results[0];
+
+                var response = _target.V2FromSearch(
+                    _v2Request,
+                    _searchParameters,
+                    _text,
+                    _searchResult,
+                    _duration);
+
+                Assert.NotNull(response.Debug);
+                var actualJson = JsonConvert.SerializeObject(response.Debug, _jsonSerializerSettings);
+                Assert.Equal(@"{
+  ""SearchRequest"": {
+    ""IgnoreFilter"": false,
+    ""CountOnly"": false,
+    ""SortBy"": ""Popularity"",
+    ""LuceneQuery"": false,
+    ""Skip"": 0,
+    ""Take"": 0,
+    ""IncludePrerelease"": true,
+    ""IncludeSemVer2"": true,
+    ""ShowDebug"": true
+  },
+  ""IndexName"": ""search-index"",
+  ""SearchParameters"": {
+    ""IncludeTotalResultCount"": false,
+    ""QueryType"": ""simple"",
+    ""SearchMode"": ""any""
+  },
+  ""SearchText"": ""azure storage sdk"",
+  ""DocumentSearchResult"": {
+    ""Count"": 1
+  },
+  ""QueryDuration"": ""00:00:00.2500000"",
+  ""AuxiliaryFilesMetadata"": {
+    ""Downloads"": {
+      ""LastModified"": ""2019-01-01T11:00:00+00:00"",
+      ""Loaded"": ""2019-01-01T12:00:00+00:00"",
+      ""LoadDuration"": ""00:00:15"",
+      ""FileSize"": 1234,
+      ""ETag"": ""\""etag-a\""""
+    },
+    ""VerifiedPackages"": {
+      ""LastModified"": ""2019-01-02T11:00:00+00:00"",
+      ""Loaded"": ""2019-01-02T12:00:00+00:00"",
+      ""LoadDuration"": ""00:00:30"",
+      ""FileSize"": 5678,
+      ""ETag"": ""\""etag-b\""""
+    }
+  }
+}", actualJson);
+                Assert.Same(docResult, response.Data[0].Debug);
+            }
+
+            [Fact]
+            public void ProducesExpectedResponse()
+            {
+                var response = _target.V2FromSearch(
+                    _v2Request,
+                    _searchParameters,
+                    _text,
+                    _searchResult,
+                    _duration);
+
+                var actualJson = JsonConvert.SerializeObject(response, _jsonSerializerSettings);
+                Assert.Equal(@"{
+  ""totalHits"": 1,
+  ""data"": [
+    {
+      ""PackageRegistration"": {
+        ""Id"": ""WindowsAzure.Storage"",
+        ""DownloadCount"": 1001,
+        ""Verified"": true,
+        ""Owners"": [
+          ""Microsoft"",
+          ""azure-sdk""
+        ]
+      },
+      ""Version"": ""7.1.2.0-alpha+git"",
+      ""NormalizedVersion"": ""7.1.2-alpha"",
+      ""Title"": ""Windows Azure Storage"",
+      ""Description"": ""Description."",
+      ""Summary"": ""Summary."",
+      ""Authors"": ""Microsoft"",
+      ""Copyright"": ""© Microsoft Corporation. All rights reserved."",
+      ""Language"": ""en-US"",
+      ""Tags"": ""Microsoft Azure Storage Table Blob File Queue Scalable windowsazureofficial"",
+      ""ReleaseNotes"": ""Release notes."",
+      ""ProjectUrl"": ""https://github.com/Azure/azure-storage-net"",
+      ""IconUrl"": ""http://go.microsoft.com/fwlink/?LinkID=288890"",
+      ""IsLatestStable"": false,
+      ""IsLatest"": true,
+      ""Listed"": true,
+      ""Created"": ""2017-01-01T00:00:00+00:00"",
+      ""Published"": ""2017-01-03T00:00:00+00:00"",
+      ""LastUpdated"": ""2017-01-03T00:00:00+00:00"",
+      ""LastEdited"": ""2017-01-02T00:00:00+00:00"",
+      ""DownloadCount"": 23,
+      ""FlattenedDependencies"": ""Microsoft.Data.OData:5.6.4:net40-client|Newtonsoft.Json:6.0.8:net40-client"",
+      ""Dependencies"": [],
+      ""SupportedFrameworks"": [],
+      ""MinClientVersion"": ""2.12"",
+      ""Hash"": ""oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33+Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ=="",
+      ""HashAlgorithm"": ""SHA512"",
+      ""PackageFileSize"": 3039254,
+      ""LicenseUrl"": ""http://go.microsoft.com/fwlink/?LinkId=331471"",
+      ""RequiresLicenseAcceptance"": true
+    }
+  ]
+}", actualJson);
+            }
+        }
+
+        public class V3FromSearch : BaseFacts
+        {
+            [Theory]
+            [InlineData(false, "https://example/reg/")]
+            [InlineData(true, "https://example/reg-gz-semver2/")]
+            public void UsesProperSemVer2Url(bool includeSemVer2, string registrationsBaseUrl)
+            {
+                _v3Request.IncludeSemVer2 = includeSemVer2;
+
+                var response = _target.V3FromSearch(
+                    _v3Request,
+                    _searchParameters,
+                    _text,
+                    _searchResult,
+                    _duration);
+
+                Assert.Equal(response.Context.Base, registrationsBaseUrl);
+                Assert.Equal(response.Data[0].AtId, registrationsBaseUrl + "windowsazure.storage/index.json");
+                Assert.Equal(response.Data[0].Registration, registrationsBaseUrl + "windowsazure.storage/index.json");
+                Assert.All(
+                    response.Data[0].Versions,
+                    x =>
+                    {
+                        var lowerVersion = NuGetVersion.Parse(x.Version).ToNormalizedString().ToLowerInvariant();
+                        Assert.Equal(x.AtId, registrationsBaseUrl + "windowsazure.storage/" + lowerVersion + ".json");
+                    });
+            }
+
+            [Theory]
+            [MemberData(nameof(MissingTitles))]
+            public void UsesIdForMissingTitle(string title)
+            {
+                _searchResult.Results[0].Document.Title = title;
+
+                var response = _target.V3FromSearch(
+                    _v3Request,
+                    _searchParameters,
+                    _text,
+                    _searchResult,
+                    _duration);
+
+                Assert.Equal(Data.PackageId, response.Data[0].Title);
+            }
+
+            [Fact]
+            public void CoalescesSomeNullFields()
+            {
+                var doc = _searchResult.Results[0].Document;
+                doc.Description = null;
+                doc.Summary = null;
+                doc.Tags = null;
+                doc.Authors = null;
+
+                var response = _target.V3FromSearch(
+                    _v3Request,
+                    _searchParameters,
+                    _text,
+                    _searchResult,
+                    _duration);
+
+                var result = response.Data[0];
+                Assert.Equal(string.Empty, result.Description);
+                Assert.Equal(string.Empty, result.Summary);
+                Assert.Empty(result.Tags);
+                Assert.Equal(string.Empty, Assert.Single(result.Authors));
+            }
+
+            [Fact]
+            public void UsesVersionSpecificDownloadCount()
+            {
+                _auxiliaryData.Setup(x => x.GetDownloadCount(It.IsAny<string>(), "1.0.0")).Returns(1);
+                _auxiliaryData.Setup(x => x.GetDownloadCount(It.IsAny<string>(), "2.0.0")).Returns(2);
+                _auxiliaryData.Setup(x => x.GetDownloadCount(It.IsAny<string>(), "3.0.0-alpha.1")).Returns(3);
+                _auxiliaryData.Setup(x => x.GetDownloadCount(It.IsAny<string>(), "7.1.2-alpha")).Returns(4);
+
+                var response = _target.V3FromSearch(
+                    _v3Request,
+                    _searchParameters,
+                    _text,
+                    _searchResult,
+                    _duration);
+
+                var versions = response.Data[0].Versions;
+                Assert.Equal(1, versions[0].Downloads);
+                Assert.Equal(2, versions[1].Downloads);
+                Assert.Equal(3, versions[2].Downloads);
+                Assert.Equal(4, versions[3].Downloads);
+            }
+
+            [Fact]
+            public void CanIncludeDebugInformation()
+            {
+                _v3Request.ShowDebug = true;
+                var docResult = _searchResult.Results[0];
+
+                var response = _target.V3FromSearch(
+                    _v3Request,
+                    _searchParameters,
+                    _text,
+                    _searchResult,
+                    _duration);
+
+                Assert.NotNull(response.Debug);
+                var actualJson = JsonConvert.SerializeObject(response.Debug, _jsonSerializerSettings);
+                Assert.Equal(@"{
+  ""SearchRequest"": {
+    ""Skip"": 0,
+    ""Take"": 0,
+    ""IncludePrerelease"": true,
+    ""IncludeSemVer2"": true,
+    ""ShowDebug"": true
+  },
+  ""IndexName"": ""search-index"",
+  ""SearchParameters"": {
+    ""IncludeTotalResultCount"": false,
+    ""QueryType"": ""simple"",
+    ""SearchMode"": ""any""
+  },
+  ""SearchText"": ""azure storage sdk"",
+  ""DocumentSearchResult"": {
+    ""Count"": 1
+  },
+  ""QueryDuration"": ""00:00:00.2500000"",
+  ""AuxiliaryFilesMetadata"": {
+    ""Downloads"": {
+      ""LastModified"": ""2019-01-01T11:00:00+00:00"",
+      ""Loaded"": ""2019-01-01T12:00:00+00:00"",
+      ""LoadDuration"": ""00:00:15"",
+      ""FileSize"": 1234,
+      ""ETag"": ""\""etag-a\""""
+    },
+    ""VerifiedPackages"": {
+      ""LastModified"": ""2019-01-02T11:00:00+00:00"",
+      ""Loaded"": ""2019-01-02T12:00:00+00:00"",
+      ""LoadDuration"": ""00:00:30"",
+      ""FileSize"": 5678,
+      ""ETag"": ""\""etag-b\""""
+    }
+  }
+}", actualJson);
+                Assert.Same(docResult, response.Data[0].Debug);
+            }
+
+            [Fact]
+            public void ProducesExpectedResponse()
+            {
+                var response = _target.V3FromSearch(
+                    _v3Request,
+                    _searchParameters,
+                    _text,
+                    _searchResult,
+                    _duration);
+
+                var actualJson = JsonConvert.SerializeObject(response, _jsonSerializerSettings);
+                Assert.Equal(@"{
+  ""@context"": {
+    ""@vocab"": ""http://schema.nuget.org/schema#"",
+    ""@base"": ""https://example/reg-gz-semver2/""
+  },
+  ""totalHits"": 1,
+  ""data"": [
+    {
+      ""@id"": ""https://example/reg-gz-semver2/windowsazure.storage/index.json"",
+      ""@type"": ""Package"",
+      ""registration"": ""https://example/reg-gz-semver2/windowsazure.storage/index.json"",
+      ""id"": ""WindowsAzure.Storage"",
+      ""version"": ""7.1.2-alpha+git"",
+      ""description"": ""Description."",
+      ""summary"": ""Summary."",
+      ""title"": ""Windows Azure Storage"",
+      ""iconUrl"": ""http://go.microsoft.com/fwlink/?LinkID=288890"",
+      ""licenseUrl"": ""http://go.microsoft.com/fwlink/?LinkId=331471"",
+      ""projectUrl"": ""https://github.com/Azure/azure-storage-net"",
+      ""tags"": [
+        ""Microsoft"",
+        ""Azure"",
+        ""Storage"",
+        ""Table"",
+        ""Blob"",
+        ""File"",
+        ""Queue"",
+        ""Scalable"",
+        ""windowsazureofficial""
+      ],
+      ""authors"": [
+        ""Microsoft""
+      ],
+      ""totalDownloads"": 1001,
+      ""verified"": true,
+      ""versions"": [
+        {
+          ""version"": ""1.0.0"",
+          ""downloads"": 23,
+          ""@id"": ""https://example/reg-gz-semver2/windowsazure.storage/1.0.0.json""
+        },
+        {
+          ""version"": ""2.0.0+git"",
+          ""downloads"": 23,
+          ""@id"": ""https://example/reg-gz-semver2/windowsazure.storage/2.0.0.json""
+        },
+        {
+          ""version"": ""3.0.0-alpha.1"",
+          ""downloads"": 23,
+          ""@id"": ""https://example/reg-gz-semver2/windowsazure.storage/3.0.0-alpha.1.json""
+        },
+        {
+          ""version"": ""7.1.2-alpha+git"",
+          ""downloads"": 23,
+          ""@id"": ""https://example/reg-gz-semver2/windowsazure.storage/7.1.2-alpha.json""
+        }
+      ]
+    }
+  ]
+}", actualJson);
+            }
+        }
+
+        public abstract class BaseFacts
+        {
+            protected readonly Mock<IAuxiliaryData> _auxiliaryData;
+            protected readonly SearchServiceConfiguration _config;
+            protected readonly Mock<IOptionsSnapshot<SearchServiceConfiguration>> _options;
+            protected readonly V2SearchRequest _v2Request;
+            protected readonly V3SearchRequest _v3Request;
+            protected readonly SearchParameters _searchParameters;
+            protected readonly string _text;
+            protected readonly TimeSpan _duration;
+            protected readonly DocumentSearchResult<SearchDocument.Full> _searchResult;
+            protected readonly DocumentSearchResult<HijackDocument.Full> _hijackResult;
+            protected readonly JsonSerializerSettings _jsonSerializerSettings;
+            protected readonly SearchResponseBuilder _target;
+            protected readonly AuxiliaryFilesMetadata _auxiliaryMetadata;
+
+            public static IEnumerable<object[]> MissingTitles = new[]
+            {
+                new object[] { null },
+                new object[] { string.Empty },
+                new object[] { " " },
+                new object[] { " \t"},
+            };
+
+            public BaseFacts()
+            {
+                _auxiliaryData = new Mock<IAuxiliaryData>();
+                _config = new SearchServiceConfiguration();
+                _options = new Mock<IOptionsSnapshot<SearchServiceConfiguration>>();
+                _options.Setup(x => x.Value).Returns(() => _config);
+                _auxiliaryMetadata = new AuxiliaryFilesMetadata(
+                    new AuxiliaryFileMetadata(
+                        new DateTimeOffset(2019, 1, 1, 11, 0, 0, TimeSpan.Zero),
+                        new DateTimeOffset(2019, 1, 1, 12, 0, 0, TimeSpan.Zero),
+                        TimeSpan.FromSeconds(15),
+                        1234,
+                        "\"etag-a\""),
+                    new AuxiliaryFileMetadata(
+                        new DateTimeOffset(2019, 1, 2, 11, 0, 0, TimeSpan.Zero),
+                        new DateTimeOffset(2019, 1, 2, 12, 0, 0, TimeSpan.Zero),
+                        TimeSpan.FromSeconds(30),
+                        5678,
+                        "\"etag-b\""));
+
+                _config.SearchIndexName = "search-index";
+                _config.HijackIndexName = "hijack-index";
+                _config.SemVer1RegistrationsBaseUrl = "https://example/reg/";
+                _config.SemVer2RegistrationsBaseUrl = "https://example/reg-gz-semver2/";
+
+                _auxiliaryData
+                    .Setup(x => x.GetTotalDownloadCount(It.IsAny<string>()))
+                    .Returns(Data.TotalDownloadCount);
+                _auxiliaryData
+                    .Setup(x => x.GetDownloadCount(It.IsAny<string>(), It.IsAny<string>()))
+                    .Returns(23);
+                _auxiliaryData
+                    .Setup(x => x.IsVerified(It.IsAny<string>()))
+                    .Returns(true);
+                _auxiliaryData
+                    .Setup(x => x.Metadata)
+                    .Returns(() => _auxiliaryMetadata);
+
+                _v2Request = new V2SearchRequest
+                {
+                    IncludePrerelease = true,
+                    IncludeSemVer2 = true,
+                };
+                _v3Request = new V3SearchRequest
+                {
+                    IncludePrerelease = true,
+                    IncludeSemVer2 = true
+                };
+                _searchParameters = new SearchParameters();
+                _text = "azure storage sdk";
+                _duration = TimeSpan.FromMilliseconds(250);
+                _searchResult = new DocumentSearchResult<SearchDocument.Full>
+                {
+                    Count = 1,
+                    Results = new List<SearchResult<SearchDocument.Full>>
+                    {
+                        new SearchResult<SearchDocument.Full>
+                        {
+                            Document = Data.SearchDocument,
+                        },
+                    },
+                };
+                _hijackResult = new DocumentSearchResult<HijackDocument.Full>
+                {
+                    Count = 1,
+                    Results = new List<SearchResult<HijackDocument.Full>>
+                    {
+                        new SearchResult<HijackDocument.Full>
+                        {
+                            Document = Data.HijackDocument,
+                        },
+                    },
+                };
+
+                _jsonSerializerSettings = new JsonSerializerSettings
+                {
+                    NullValueHandling = NullValueHandling.Ignore,
+                    Converters =
+                    {
+                        new StringEnumConverter(),
+                    },
+                    Formatting = Formatting.Indented,
+                };
+
+                _target = new SearchResponseBuilder(
+                    new Lazy<IAuxiliaryData>(() => _auxiliaryData.Object),
+                    _options.Object);
+            }
+        }
+
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/Support/Data.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Support/Data.cs
@@ -58,6 +58,48 @@ namespace NuGet.Services.AzureSearch.Support
             Version = "7.1.2.0-alpha+git",
         };
 
+        public static string[] Versions => new[]
+        {
+            "1.0.0",
+            "2.0.0+git",
+            "3.0.0-alpha.1",
+            FullVersion
+        };
+
+        public static string[] Owners => new[]
+        {
+            "Microsoft",
+            "azure-sdk",
+        };
+
+        public const int TotalDownloadCount = 1001;
+
+        public static readonly SearchFilters SearchFilters = SearchFilters.IncludePrereleaseAndSemVer2;
+
+        public static SearchDocument.Full SearchDocument => new SearchDocumentBuilder().FullFromDb(
+            PackageId,
+            SearchFilters.IncludePrereleaseAndSemVer2,
+            Versions,
+            isLatestStable: false,
+            isLatest: true,
+            fullVersion: FullVersion,
+            package: PackageEntity,
+            owners: Owners,
+            totalDownloadCount: TotalDownloadCount);
+
+        public static HijackDocumentChanges HijackDocumentChanges => new HijackDocumentChanges(
+            delete: false,
+            updateMetadata: true,
+            latestStableSemVer1: false,
+            latestSemVer1: true,
+            latestStableSemVer2: false,
+            latestSemVer2: true);
+
+        public static HijackDocument.Full HijackDocument => new HijackDocumentBuilder().FullFromDb(
+            PackageId,
+            HijackDocumentChanges,
+            PackageEntity);
+
         public static PackageDetailsCatalogLeaf Leaf => new PackageDetailsCatalogLeaf
         {
             Authors = "Microsoft",


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/6450
Progress on https://github.com/NuGet/NuGetGallery/issues/6453
Progress on https://github.com/NuGet/NuGetGallery/issues/6455

Map a document from Azure Search plus auxiliary data into a V2 or V3 search response.

Add unit tests which assert the contract.