### PR TITLE
Monitoring:  enable monitoring of repository signatures

### DIFF
--- a/src/Catalog/PackageEntry.cs
+++ b/src/Catalog/PackageEntry.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
-using System.Collections.Generic;
 using System.IO.Compression;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace NuGet.Services.Metadata.Catalog
 {
@@ -17,15 +15,27 @@ namespace NuGet.Services.Metadata.Catalog
 
         public PackageEntry(ZipArchiveEntry zipArchiveEntry)
         {
+            if (zipArchiveEntry == null)
+            {
+                throw new ArgumentNullException(nameof(zipArchiveEntry));
+            }
+
             FullName = zipArchiveEntry.FullName;
             Name = zipArchiveEntry.Name;
             Length = zipArchiveEntry.Length;
             CompressedLength = zipArchiveEntry.CompressedLength;
         }
 
+        [JsonProperty("fullName")]
         public string FullName { get; set; }
+
+        [JsonProperty("name")]
         public string Name { get; set; }
+
+        [JsonProperty("length")]
         public long Length { get; set; }
+
+        [JsonProperty("compressedLength")]
         public long CompressedLength { get; set; }
     }
 }

--- a/src/Ng/Arguments.cs
+++ b/src/Ng/Arguments.cs
@@ -154,7 +154,7 @@ namespace Ng
         /// <summary>
         /// If true, packages are expected to have at least a repository signature.
         /// </summary>
-        public const string RequireSignature = "requireSignature";
+        public const string RequireRepositorySignature = "requireRepositorySignature";
         #endregion
 
         #region KeyVault

--- a/src/Ng/Jobs/MonitoringProcessorJob.cs
+++ b/src/Ng/Jobs/MonitoringProcessorJob.cs
@@ -42,7 +42,7 @@ namespace Ng.Jobs
             var index = arguments.GetOrThrow<string>(Arguments.Index);
             var packageBaseAddress = arguments.GetOrThrow<string>(Arguments.ContentBaseAddress);
             var source = arguments.GetOrThrow<string>(Arguments.Source);
-            var requireSignature = arguments.GetOrDefault(Arguments.RequireSignature, false);
+            var requireRepositorySignature = arguments.GetOrDefault(Arguments.RequireRepositorySignature, false);
             var verbose = arguments.GetOrDefault(Arguments.Verbose, false);
 
             CommandHelpers.AssertAzureStorage(arguments);
@@ -59,7 +59,7 @@ namespace Ng.Jobs
 
             var validatorConfig = new ValidatorConfiguration(
                 packageBaseAddress,
-                requireSignature);
+                requireRepositorySignature);
 
             _packageValidator = ValidationFactory.CreatePackageValidator(
                 gallery, 

--- a/src/Ng/Scripts/MonitoringProcessor.cmd
+++ b/src/Ng/Scripts/MonitoringProcessor.cmd
@@ -9,7 +9,7 @@ title #{Jobs.monitoringprocessor.Title}
 
 start /w .\Ng.exe monitoringprocessor ^
     -source #{Jobs.common.v3.Source} ^
-    -requireSignature #{Jobs.endpointmonitoring.RequireSignature} ^
+    -requireRepositorySignature #{Jobs.endpointmonitoring.RequireRepositorySignature} ^
     -index #{Jobs.common.v3.index} ^
     -gallery #{Jobs.common.v3.f2c.Gallery} ^
     -contentBaseAddress #{Jobs.endpointmonitoring.ContentBaseAddress} ^

--- a/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/FlatContainer/PackageIsRepositorySignedValidator.cs
+++ b/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/FlatContainer/PackageIsRepositorySignedValidator.cs
@@ -23,7 +23,7 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
 
         protected async override Task<bool> ShouldRunAsync(ValidationContext context)
         {
-            if (!Config.RequirePackageSignature)
+            if (!Config.RequireRepositorySignature)
             {
                 return false;
             }
@@ -39,7 +39,7 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
             if (signature == null)
             {
                 throw new MissingRepositorySignatureException(
-                    $"Package {context.Package.Id} {context.Package.Version} is unsigned",
+                    $"Package {context.Package.Id} {context.Package.Version} is unsigned.",
                     MissingRepositorySignatureReason.Unsigned);
             }
 
@@ -58,7 +58,7 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
                     if (repositorySignature == null)
                     {
                         throw new MissingRepositorySignatureException(
-                            $"Package {context.Package.Id} {context.Package.Version} is author signed but not repository signed",
+                            $"Package {context.Package.Id} {context.Package.Version} is author signed but not repository signed.",
                             MissingRepositorySignatureReason.AuthorSignedNoRepositoryCountersignature);
                     }
 
@@ -67,12 +67,12 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
                 default:
                 case SignatureType.Unknown:
                     throw new MissingRepositorySignatureException(
-                        $"Package {context.Package.Id} {context.Package.Version} has an unknown signature type '{signature.Type}'",
+                        $"Package {context.Package.Id} {context.Package.Version} has an unknown signature type '{signature.Type}'.",
                         MissingRepositorySignatureReason.UnknownSignature);
             }
 
             Logger.LogInformation(
-                "Package {PackageId} {PackageVersion} has a repository signature with service index {ServiceIndex} and owners {Owners}",
+                "Package {PackageId} {PackageVersion} has a repository signature with service index {ServiceIndex} and owners {Owners}.",
                 context.Package.Id,
                 context.Package.Version,
                 repositorySignature.V3ServiceIndexUrl,
@@ -88,7 +88,7 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
             {
                 if (packageStream == null)
                 {
-                    throw new InvalidOperationException($"Package {context.Package.Id} {context.Package.Version} couldn't be downloaded at {uri}");
+                    throw new InvalidOperationException($"Package {context.Package.Id} {context.Package.Version} couldn't be downloaded at {uri.AbsoluteUri}.");
                 }
 
                 using (var package = new PackageArchiveReader(packageStream))

--- a/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/ValidatorConfiguration.cs
+++ b/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/ValidatorConfiguration.cs
@@ -10,7 +10,7 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
     /// </summary>
     public sealed class ValidatorConfiguration
     {
-        public ValidatorConfiguration(string packageBaseAddress, bool requirePackageSignature)
+        public ValidatorConfiguration(string packageBaseAddress, bool requireRepositorySignature)
         {
             if (string.IsNullOrEmpty(packageBaseAddress))
             {
@@ -18,7 +18,7 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
             }
 
             PackageBaseAddress = packageBaseAddress.TrimEnd('/');
-            RequirePackageSignature = requirePackageSignature;
+            RequireRepositorySignature = requireRepositorySignature;
         }
 
         /// <summary>
@@ -28,8 +28,8 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
         public string PackageBaseAddress { get; }
 
         /// <summary>
-        /// Whether signature validations are required.
+        /// Whether repository signature validations are required.
         /// </summary>
-        public bool RequirePackageSignature { get; }
+        public bool RequireRepositorySignature { get; }
     }
 }

--- a/tests/CatalogTests/CatalogTests.csproj
+++ b/tests/CatalogTests/CatalogTests.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Helpers\UtilsTests.cs" />
     <Compile Include="PackageCatalogItemCreatorTests.cs" />
     <Compile Include="PackageCatalogItemTests.cs" />
+    <Compile Include="PackageEntryTests.cs" />
     <Compile Include="Persistence\AggregateStorageTests.cs" />
     <Compile Include="Persistence\AzureCloudBlockBlobTests.cs" />
     <Compile Include="Persistence\FileStorageTests.cs" />

--- a/tests/CatalogTests/PackageEntryTests.cs
+++ b/tests/CatalogTests/PackageEntryTests.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using Newtonsoft.Json;
+using NuGet.Services.Metadata.Catalog;
+using Xunit;
+
+namespace CatalogTests
+{
+    public class PackageEntryTests
+    {
+        [Fact]
+        public void DefaultConstructor_InitializesDefaultValues()
+        {
+            var packageEntry = new PackageEntry();
+
+            Assert.Null(packageEntry.FullName);
+            Assert.Null(packageEntry.Name);
+            Assert.Equal(0, packageEntry.CompressedLength);
+            Assert.Equal(0, packageEntry.Length);
+        }
+
+        [Fact]
+        public void Constructor_WhenZipArchiveEntryIsNull_Throws()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => new PackageEntry(zipArchiveEntry: null));
+
+            Assert.Equal("zipArchiveEntry", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WithValidArguments_InitializesInstance()
+        {
+            using (var zipArchive = CreateZipArchive())
+            {
+                var zipArchiveEntry = zipArchive.Entries[0];
+
+                var packageEntry = new PackageEntry(zipArchiveEntry);
+
+                Assert.Equal(zipArchiveEntry.FullName, packageEntry.FullName);
+                Assert.Equal(zipArchiveEntry.Name, packageEntry.Name);
+                Assert.Equal(zipArchiveEntry.CompressedLength, packageEntry.CompressedLength);
+                Assert.Equal(zipArchiveEntry.Length, packageEntry.Length);
+            }
+        }
+
+        [Fact]
+        public void JsonSerialization_ReturnsCorrectJson()
+        {
+            var packageEntry = new PackageEntry()
+            {
+                FullName = "a/b",
+                Name = "b",
+                CompressedLength = 2,
+                Length = 1
+            };
+
+            var json = JsonConvert.SerializeObject(packageEntry);
+
+            Assert.Equal("{\"fullName\":\"a/b\",\"name\":\"b\",\"length\":1,\"compressedLength\":2}", json);
+        }
+
+        [Fact]
+        public void JsonDeserialization_ReturnsCorrectObject()
+        {
+            var json = "{\"fullName\":\"a/b\",\"name\":\"b\",\"length\":1,\"compressedLength\":2}";
+
+            var packageEntry = JsonConvert.DeserializeObject<PackageEntry>(json);
+
+            Assert.Equal("a/b", packageEntry.FullName);
+            Assert.Equal("b", packageEntry.Name);
+            Assert.Equal(1, packageEntry.Length);
+            Assert.Equal(2, packageEntry.CompressedLength);
+        }
+
+        private static ZipArchive CreateZipArchive()
+        {
+            var archiveStream = new MemoryStream();
+
+            using (var archive = new ZipArchive(archiveStream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                var entry = archive.CreateEntry("a/b.c", CompressionLevel.Optimal);
+
+                using (var entryStream = entry.Open())
+                using (var writer = new StreamWriter(entryStream))
+                {
+                    writer.Write("peach");
+                }
+            }
+
+            return new ZipArchive(archiveStream, ZipArchiveMode.Read);
+        }
+    }
+}

--- a/tests/NgTests/NgTests.csproj
+++ b/tests/NgTests/NgTests.csproj
@@ -102,6 +102,7 @@
       <DependentUpon>TestCatalogEntries.resx</DependentUpon>
     </Compile>
     <Compile Include="Data\Catalogs.cs" />
+    <Compile Include="Validation\CatalogLeaf.cs" />
     <Compile Include="Validation\DummyAggregateValidator.cs" />
     <Compile Include="Validation\DummyValidator.cs" />
     <Compile Include="Validation\PackageHasSignatureValidatorFacts.cs" />

--- a/tests/NgTests/PackageTimestampMetadataTests.cs
+++ b/tests/NgTests/PackageTimestampMetadataTests.cs
@@ -15,7 +15,7 @@ using NuGet.Services.Metadata.Catalog.Monitoring;
 using NuGet.Versioning;
 using Xunit;
 
-namespace NgTests
+namespace NgTests.Validation
 {
     public class PackageTimestampMetadataTests
     {

--- a/tests/NgTests/Validation/CatalogLeaf.cs
+++ b/tests/NgTests/Validation/CatalogLeaf.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using NuGet.Services.Metadata.Catalog;
+
+namespace NgTests.Validation
+{
+    public sealed class CatalogLeaf
+    {
+        [JsonProperty("created")]
+        public DateTimeOffset Created { get; set; }
+        [JsonProperty("lastEdited")]
+        public DateTimeOffset LastEdited { get; set; }
+
+        [JsonProperty("packageEntries")]
+        public IEnumerable<PackageEntry> PackageEntries { get; set; }
+    }
+}

--- a/tests/NgTests/Validation/PackageIsRepositorySignedValidatorFacts.cs
+++ b/tests/NgTests/Validation/PackageIsRepositorySignedValidatorFacts.cs
@@ -9,17 +9,14 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using NgTests.Infrastructure;
-using NgTests.Validation;
 using NuGet.Packaging.Core;
 using NuGet.Services.Metadata.Catalog;
 using NuGet.Services.Metadata.Catalog.Monitoring;
 using NuGet.Versioning;
 using Xunit;
 
-namespace NgTests
+namespace NgTests.Validation
 {
     public class PackageIsRepositorySignedValidatorFacts
     {
@@ -29,7 +26,7 @@ namespace NgTests
 
             public Constructor()
             {
-                _configuration = new ValidatorConfiguration(packageBaseAddress: "a", requirePackageSignature: true);
+                _configuration = new ValidatorConfiguration(packageBaseAddress: "a", requireRepositorySignature: true);
             }
 
             [Fact]
@@ -63,10 +60,10 @@ namespace NgTests
             [InlineData(AuthorSignedPackageResource)]
             [InlineData(RepoSignedPackageResource)]
             [InlineData(AuthorAndRepoSignedPackageResource)]
-            public async Task SkipsIfConfigNotRequirePackageSignature(string packageResource)
+            public async Task SkipsIfConfigDoesNotRequireRepositorySignature(string packageResource)
             {
                 // Arrange
-                var target = CreateTarget(requirePackageSignature: false);
+                var target = CreateTarget(requireRepositorySignature: false);
                 var context = CreateValidationContext(packageResource);
 
                 // Act
@@ -90,7 +87,7 @@ namespace NgTests
                 // Assert
                 Assert.Equal(TestResult.Fail, result.Result);
                 Assert.NotNull(result.Exception);
-                Assert.Contains("Package TestPackage 1.0.0 couldn't be downloaded at https://nuget.test/packages/testpackage/1.0.0/testpackage.1.0.0.nupkg", result.Exception.Message);
+                Assert.StartsWith("Package TestPackage 1.0.0 couldn't be downloaded at https://nuget.test/packages/testpackage/1.0.0/testpackage.1.0.0.nupkg.", result.Exception.Message);
             }
 
             [Fact]
@@ -110,7 +107,7 @@ namespace NgTests
                 Assert.NotNull(exception);
 
                 Assert.Equal(MissingRepositorySignatureReason.Unsigned, exception.Reason);
-                Assert.Contains("Package TestPackage 1.0.0 is unsigned", exception.Message);
+                Assert.StartsWith("Package TestPackage 1.0.0 is unsigned.", exception.Message);
             }
 
             [Fact]
@@ -130,7 +127,7 @@ namespace NgTests
                 Assert.NotNull(exception);
 
                 Assert.Equal(MissingRepositorySignatureReason.AuthorSignedNoRepositoryCountersignature, exception.Reason);
-                Assert.Contains("Package TestPackage 1.0.0 is author signed but not repository signed", exception.Message);
+                Assert.StartsWith("Package TestPackage 1.0.0 is author signed but not repository signed.", exception.Message);
             }
 
             [Fact]
@@ -193,17 +190,17 @@ namespace NgTests
                         PackageIdentity)
                 };
 
-                AddCatalogLeafToMockServer("/catalog/leaf.json", new CatalogLeaf
+                ValidatorTestUtility.AddCatalogLeafToMockServer(_mockServer, new Uri("/catalog/leaf.json", UriKind.Relative), new CatalogLeaf
                 {
                     Created = PackageCreationTime,
                     LastEdited = PackageCreationTime
                 });
             }
 
-            protected PackageIsRepositorySignedValidator CreateTarget(bool requirePackageSignature = true)
+            protected PackageIsRepositorySignedValidator CreateTarget(bool requireRepositorySignature = true)
             {
                 var logger = Mock.Of<ILogger<PackageIsRepositorySignedValidator>>();
-                var config = ValidatorTestUtility.CreateValidatorConfig(requirePackageSignature: requirePackageSignature);
+                var config = ValidatorTestUtility.CreateValidatorConfig(requireRepositorySignature: requireRepositorySignature);
 
                 return new PackageIsRepositorySignedValidator(config, logger);
             }
@@ -238,30 +235,6 @@ namespace NgTests
                     _catalogEntries,
                     client: httpClient,
                     timestampMetadataResource: timestampMetadataResource.Object);
-            }
-
-            private void AddCatalogLeafToMockServer(string path, CatalogLeaf leaf)
-            {
-                var jsonSettings = new JsonSerializerSettings
-                {
-                    ContractResolver = new CamelCasePropertyNamesContractResolver()
-                };
-
-                _mockServer.SetAction(path, request =>
-                {
-                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        Content = new StringContent(JsonConvert.SerializeObject(leaf, jsonSettings))
-                    });
-                });
-            }
-
-            private class CatalogLeaf
-            {
-                public DateTimeOffset Created { get; set; }
-                public DateTimeOffset LastEdited { get; set; }
-
-                public IEnumerable<PackageEntry> PackageEntries { get; set; }
             }
         }
     }

--- a/tests/NgTests/Validation/RegistrationIndexValidatorTests.cs
+++ b/tests/NgTests/Validation/RegistrationIndexValidatorTests.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using NuGet.Services.Metadata.Catalog.Monitoring;
 using Xunit;
 
-namespace NgTests
+namespace NgTests.Validation
 {
     public class RegistrationIndexValidatorTests
     {

--- a/tests/NgTests/Validation/RegistrationLeafValidatorTests.cs
+++ b/tests/NgTests/Validation/RegistrationLeafValidatorTests.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using NuGet.Services.Metadata.Catalog.Monitoring;
 using Xunit;
 
-namespace NgTests
+namespace NgTests.Validation
 {
     public class RegistrationLeafValidatorTests
     {

--- a/tests/NgTests/Validation/RegistrationRequireLicenseAcceptanceValidatorTestData.cs
+++ b/tests/NgTests/Validation/RegistrationRequireLicenseAcceptanceValidatorTestData.cs
@@ -13,7 +13,7 @@ namespace NgTests
         protected override RegistrationRequireLicenseAcceptanceValidator CreateValidator(
             ILogger<RegistrationRequireLicenseAcceptanceValidator> logger)
         {
-            var config = new ValidatorConfiguration("https://nuget.test/packages", requirePackageSignature: false);
+            var config = new ValidatorConfiguration("https://nuget.test/packages", requireRepositorySignature: false);
 
             return new RegistrationRequireLicenseAcceptanceValidator(config, logger);
         }

--- a/tests/NgTests/Validation/ValidationContextTests.cs
+++ b/tests/NgTests/Validation/ValidationContextTests.cs
@@ -17,7 +17,7 @@ using NuGet.Services.Metadata.Catalog.Monitoring;
 using NuGet.Versioning;
 using Xunit;
 
-namespace NgTests.Validators
+namespace NgTests.Validation
 {
     public class ValidationContextTests
     {

--- a/tests/NgTests/Validation/ValidatorConfigurationTests.cs
+++ b/tests/NgTests/Validation/ValidatorConfigurationTests.cs
@@ -15,7 +15,7 @@ namespace NgTests.Validation
         public void Constructor_WhenPackageBaseAddressIsNullOrEmpty_Throws(string packageBaseAddress)
         {
             var exception = Assert.Throws<ArgumentException>(
-                () => new ValidatorConfiguration(packageBaseAddress, requirePackageSignature: true));
+                () => new ValidatorConfiguration(packageBaseAddress, requireRepositorySignature: true));
 
             Assert.Equal("packageBaseAddress", exception.ParamName);
         }
@@ -25,12 +25,12 @@ namespace NgTests.Validation
         [InlineData("b", false)]
         public void Constructor_WhenArgumentsAreValid_InitializesInstance(
             string packageBaseAddress,
-            bool requirePackageSignature)
+            bool requireRepositorySignature)
         {
-            var configuration = new ValidatorConfiguration(packageBaseAddress, requirePackageSignature);
+            var configuration = new ValidatorConfiguration(packageBaseAddress, requireRepositorySignature);
 
             Assert.Equal(packageBaseAddress, configuration.PackageBaseAddress);
-            Assert.Equal(requirePackageSignature, configuration.RequirePackageSignature);
+            Assert.Equal(requireRepositorySignature, configuration.RequireRepositorySignature);
         }
     }
 }

--- a/tests/NgTests/Validation/ValidatorTests.cs
+++ b/tests/NgTests/Validation/ValidatorTests.cs
@@ -6,13 +6,12 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
-using NgTests.Validation;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Services.Metadata.Catalog.Monitoring;
 using Xunit;
 
-namespace NgTests
+namespace NgTests.Validation
 {
     public class ValidatorTests
     {
@@ -106,7 +105,7 @@ namespace NgTests
             feedToSource.Setup(x => x[It.IsAny<FeedType>()]).Returns(sourceRepository.Object);
 
             _feedToSource = feedToSource.Object;
-            _validatorConfiguration = new ValidatorConfiguration(packageBaseAddress: "a", requirePackageSignature: true);
+            _validatorConfiguration = new ValidatorConfiguration(packageBaseAddress: "a", requireRepositorySignature: true);
             _logger = Mock.Of<ILogger<Validator>>();
         }
 


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/6565.

This change enables the monitoring job to verify both that a package has a package signature file (per V3 catalog) and that the actual package has a repository signature (primary or countersignature).

@loic-sharma