### PR TITLE
Add /search/diag endpoint to Azure Search Service

### DIFF
--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -76,6 +76,14 @@ namespace NuGet.Services.AzureSearch
                     c.ResolveKeyed<ISearchIndexClientWrapper>(searchIndexKey),
                     c.ResolveKeyed<ISearchIndexClientWrapper>(hijackIndexKey),
                     c.Resolve<ISearchResponseBuilder>()));
+
+            containerBuilder
+                .Register<ISearchStatusService>(c => new SearchStatusService(
+                    c.ResolveKeyed<ISearchIndexClientWrapper>(searchIndexKey),
+                    c.ResolveKeyed<ISearchIndexClientWrapper>(hijackIndexKey),
+                    c.Resolve<IAuxiliaryDataCache>(),
+                    c.Resolve<IOptionsSnapshot<SearchServiceConfiguration>>(),
+                    c.Resolve<ILogger<SearchStatusService>>()));
         }
 
         private static void RegisterAzureSearchJobStorageServices(ContainerBuilder containerBuilder, string key)

--- a/src/NuGet.Services.AzureSearch/DurationMeasurement.cs
+++ b/src/NuGet.Services.AzureSearch/DurationMeasurement.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class DurationMeasurement<T>
+    {
+        public DurationMeasurement(T result, TimeSpan duration)
+        {
+            Value = result;
+            Duration = duration;
+        }
+
+        public T Value { get; }
+        public TimeSpan Duration { get; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Measure.cs
+++ b/src/NuGet.Services.AzureSearch/Measure.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.AzureSearch
+{
+    public static class Measure
+    {
+        public static async Task<DurationMeasurement<T>> DurationWithValueAsync<T>(Func<Task<T>> actAsync)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var value = await actAsync();
+            stopwatch.Stop();
+            return new DurationMeasurement<T>(value, stopwatch.Elapsed);
+        }
+
+        public static async Task<TimeSpan> DurationAsync(Func<Task> actAsync)
+        {
+            var result = await DurationWithValueAsync(async () =>
+            {
+                await actAsync();
+                return 0;
+            });
+            return result.Duration;
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -43,6 +43,8 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Measure.cs" />
+    <Compile Include="DurationMeasurement.cs" />
     <Compile Include="SearchService\AuxiliaryDataCache.cs" />
     <Compile Include="SearchService\AuxiliaryFileClient.cs" />
     <Compile Include="SearchService\AuxiliaryFileReloader.cs" />
@@ -104,6 +106,7 @@
     <Compile Include="SearchService\IAuxiliaryDataCache.cs" />
     <Compile Include="SearchService\IAuxiliaryFileClient.cs" />
     <Compile Include="SearchService\IAuxiliaryFileReloader.cs" />
+    <Compile Include="SearchService\ISearchStatusService.cs" />
     <Compile Include="SearchService\Models\AuxiliaryFileMetadata.cs" />
     <Compile Include="SearchService\Models\AuxiliaryFilesMetadata.cs" />
     <Compile Include="SearchService\AzureSearchService.cs" />
@@ -113,7 +116,10 @@
     <Compile Include="SearchService\ISearchResponseBuilder.cs" />
     <Compile Include="SearchService\ISearchService.cs" />
     <Compile Include="SearchService\Models\DebugInformation.cs" />
+    <Compile Include="SearchService\Models\IndexStatus.cs" />
     <Compile Include="SearchService\Models\SearchRequest.cs" />
+    <Compile Include="SearchService\Models\ServerInformation.cs" />
+    <Compile Include="SearchService\Models\SearchStatusResponse.cs" />
     <Compile Include="SearchService\Models\V2SearchDependency.cs" />
     <Compile Include="SearchService\Models\V2SearchPackage.cs" />
     <Compile Include="SearchService\Models\V2SearchPackageRegistration.cs" />
@@ -127,6 +133,7 @@
     <Compile Include="SearchService\SearchParametersBuilder.cs" />
     <Compile Include="SearchService\Models\V2SortBy.cs" />
     <Compile Include="SearchService\SearchResponseBuilder.cs" />
+    <Compile Include="SearchService\SearchStatusService.cs" />
     <Compile Include="VersionList\Guard.cs" />
     <Compile Include="VersionList\HijackIndexChange.cs" />
     <Compile Include="VersionList\HijackIndexChangeType.cs" />

--- a/src/NuGet.Services.AzureSearch/SearchService/AzureSearchService.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AzureSearchService.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using NuGet.Services.AzureSearch.Wrappers;
 
@@ -44,11 +43,16 @@ namespace NuGet.Services.AzureSearch.SearchService
             var text = _parametersBuilder.GetSearchTextForV3Search(request);
             var parameters = _parametersBuilder.GetSearchParametersForV3Search(request);
 
-            var (result, duration) = await MeasureAsync(() => _searchIndex.Documents.SearchAsync<SearchDocument.Full>(
+            var result = await Measure.DurationWithValueAsync(() => _searchIndex.Documents.SearchAsync<SearchDocument.Full>(
                 text,
                 parameters));
 
-            return _responseBuilder.V3FromSearch(request, parameters, text, result, duration);
+            return _responseBuilder.V3FromSearch(
+                request,
+                parameters,
+                text,
+                result.Value,
+                result.Duration);
         }
 
         private async Task<V2SearchResponse> UseHijackIndexAsync(V2SearchRequest request)
@@ -56,11 +60,16 @@ namespace NuGet.Services.AzureSearch.SearchService
             var parameters = _parametersBuilder.GetSearchParametersForV2Search(request);
             var text = _parametersBuilder.GetSearchTextForV2Search(request);
 
-            var (result, duration) = await MeasureAsync(() => _hijackIndex.Documents.SearchAsync<HijackDocument.Full>(
+            var result = await Measure.DurationWithValueAsync(() => _hijackIndex.Documents.SearchAsync<HijackDocument.Full>(
                 text,
                 parameters));
 
-            return _responseBuilder.V2FromHijack(request, parameters, text, result, duration);
+            return _responseBuilder.V2FromHijack(
+                request,
+                parameters,
+                text,
+                result.Value,
+                result.Duration);
         }
 
         private async Task<V2SearchResponse> UseSearchIndexAsync(V2SearchRequest request)
@@ -68,19 +77,16 @@ namespace NuGet.Services.AzureSearch.SearchService
             var parameters = _parametersBuilder.GetSearchParametersForV2Search(request);
             var text = _parametersBuilder.GetSearchTextForV2Search(request);
 
-            var (result, duration) = await MeasureAsync(() => _searchIndex.Documents.SearchAsync<SearchDocument.Full>(
+            var result = await Measure.DurationWithValueAsync(() => _searchIndex.Documents.SearchAsync<SearchDocument.Full>(
                 text,
                 parameters));
 
-            return _responseBuilder.V2FromSearch(request, parameters, text, result, duration);
-        }
-
-        private async Task<(T result, TimeSpan duration)> MeasureAsync<T>(Func<Task<T>> actAsync)
-        {
-            var stopwatch = Stopwatch.StartNew();
-            var result = await actAsync();
-            stopwatch.Stop();
-            return (result, stopwatch.Elapsed);
+            return _responseBuilder.V2FromSearch(
+                request,
+                parameters,
+                text,
+                result.Value,
+                result.Duration);
         }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/ISearchStatusService.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/ISearchStatusService.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public interface ISearchStatusService
+    {
+        Task<SearchStatusResponse> GetStatusAsync(Assembly assemblyForMetadata);
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/IndexStatus.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/IndexStatus.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class IndexStatus
+    {
+        public string Name { get; set; }
+        public long DocumentCount { get; set; }
+        public TimeSpan WarmQueryDuration { get; set; } 
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/SearchStatusResponse.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/SearchStatusResponse.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class SearchStatusResponse
+    {
+        /// <summary>
+        /// This success boolean indicates whether all dependencies of the search service can be communicated with.
+        /// Any of the properties on this type, aside from <see cref="Success"/> or <see cref="Duration"/>, can be null
+        /// if <see cref="Success"/> is false. If <see cref="Success"/> is true, all properties will be non-null.
+        /// </summary>
+        public bool Success { get; set; }
+        public TimeSpan Duration { get; set; }
+        public ServerStatus Server { get; set; }
+        public IndexStatus SearchIndex { get; set; }
+        public IndexStatus HijackIndex { get; set; }
+        public AuxiliaryFilesMetadata AuxiliaryFiles { get; set; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/ServerInformation.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/ServerInformation.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class ServerStatus
+    {
+        public string MachineName { get; set; }
+        public int ProcessId { get; set; }
+        public DateTimeOffset ProcessStartTime { get; set; }
+        public TimeSpan ProcessDuration { get; set; }
+        public string DeploymentLabel { get; set; }
+        public string AssemblyCommitId { get; set; }
+        public string AssemblyInformationalVersion { get; set; }
+        public string AssemblyBuildDateUtc { get; set; }
+        public string InstanceId { get; set; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
@@ -15,5 +15,6 @@ namespace NuGet.Services.AzureSearch.SearchService
         public string AuxiliaryDataStorageVerifiedPackagesPath { get; set; }
         public TimeSpan AuxiliaryDataReloadFrequency { get; set; }
         public TimeSpan AuxiliaryDataReloadFailureRetryFrequency { get; set; }
+        public string DeploymentLabel { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchStatusService.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchStatusService.cs
@@ -1,0 +1,155 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Azure.Search.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NuGet.Services.AzureSearch.Wrappers;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class SearchStatusService : ISearchStatusService
+    {
+        private readonly ISearchIndexClientWrapper _searchIndex;
+        private readonly ISearchIndexClientWrapper _hijackIndex;
+        private readonly IAuxiliaryDataCache _auxiliaryDataCache;
+        private readonly IOptionsSnapshot<SearchServiceConfiguration> _options;
+        private readonly ILogger<SearchStatusService> _logger;
+
+        public SearchStatusService(
+            ISearchIndexClientWrapper searchIndex,
+            ISearchIndexClientWrapper hijackIndex,
+            IAuxiliaryDataCache auxiliaryDataCache,
+            IOptionsSnapshot<SearchServiceConfiguration> options,
+            ILogger<SearchStatusService> logger)
+        {
+            _searchIndex = searchIndex ?? throw new ArgumentNullException(nameof(searchIndex));
+            _hijackIndex = hijackIndex ?? throw new ArgumentNullException(nameof(hijackIndex));
+            _auxiliaryDataCache = auxiliaryDataCache ?? throw new ArgumentNullException(nameof(auxiliaryDataCache));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<SearchStatusResponse> GetStatusAsync(Assembly assemblyForMetadata)
+        {
+            var response = new SearchStatusResponse
+            {
+                Success = true,
+            };
+
+            response.Duration = await Measure.DurationAsync(() => PopulateResponseAsync(assemblyForMetadata, response));
+
+            _logger.LogInformation(
+                "It took {Duration} to fetch the search status. Success is {Success}.",
+                response.Duration,
+                response.Success);
+
+            return response;
+        }
+
+        private async Task PopulateResponseAsync(Assembly assembly, SearchStatusResponse response)
+        {
+            await Task.WhenAll(
+                TryAsync(
+                    async () => response.SearchIndex = await GetIndexStatusAsync(_searchIndex),
+                    response,
+                    "warming the search index"),
+                TryAsync(
+                    async () => response.HijackIndex = await GetIndexStatusAsync(_hijackIndex),
+                    response,
+                    "warming the hijack index"),
+                TryAsync(
+                    async () => response.AuxiliaryFiles = await GetAuxiliaryFilesMetadataAsync(),
+                    response,
+                    "getting cached auxiliary data"),
+                TryAsync(
+                    async () => response.Server = await GetServerStatusAsync(assembly),
+                    response,
+                    "getting server information"));
+        }
+
+        private async Task TryAsync<T>(
+            Func<Task<T>> getAsync,
+            SearchStatusResponse response,
+            string operation)
+        {
+            try
+            {
+                await Task.Yield();
+                await getAsync();
+            }
+            catch (Exception ex)
+            {
+                response.Success = false;
+                _logger.LogError(0, ex, "When getting the search status, {Operation} failed.", operation);
+            }
+        }
+
+        private Task<ServerStatus> GetServerStatusAsync(Assembly assembly)
+        {
+            DateTimeOffset processStartTime;
+            int processId;
+            using (var process = Process.GetCurrentProcess())
+            {
+                processStartTime = process.StartTime.ToUniversalTime();
+                processId = process.Id;
+            }
+
+            var serverStatus = new ServerStatus
+            {
+                AssemblyBuildDateUtc = GetAssemblyMetadataOrNull(assembly, "BuildDateUtc"),
+                AssemblyCommitId = GetAssemblyMetadataOrNull(assembly, "CommitId"),
+                AssemblyInformationalVersion = GetAssemblyInformationalVersionOrNull(assembly),
+                DeploymentLabel = _options.Value.DeploymentLabel,
+                MachineName = Environment.MachineName,
+                InstanceId = Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID"),
+                ProcessDuration = DateTimeOffset.UtcNow - processStartTime,
+                ProcessId = processId,
+                ProcessStartTime = processStartTime,
+            };
+
+            return Task.FromResult(serverStatus);
+        }
+
+        private async Task<AuxiliaryFilesMetadata> GetAuxiliaryFilesMetadataAsync()
+        {
+            await _auxiliaryDataCache.InitializeAsync();
+            return _auxiliaryDataCache.Get().Metadata;
+        }
+
+        private static string GetAssemblyInformationalVersionOrNull(Assembly assembly)
+        {
+            return assembly
+                .GetCustomAttributes<AssemblyInformationalVersionAttribute>()
+                .Select(x => x.InformationalVersion)
+                .FirstOrDefault();
+        }
+
+        private static string GetAssemblyMetadataOrNull(Assembly assembly, string name)
+        {
+            return assembly
+                .GetCustomAttributes<AssemblyMetadataAttribute>()
+                .Where(x => x.Key == name)
+                .Select(x => x.Value)
+                .FirstOrDefault();
+        }
+
+        private static async Task<IndexStatus> GetIndexStatusAsync(ISearchIndexClientWrapper index)
+        {
+            var documentCount = await index.Documents.CountAsync();
+            var warmQueryDuration = await Measure.DurationAsync(() => index.Documents.SearchAsync("*", new SearchParameters()));
+
+            return new IndexStatus
+            {
+                DocumentCount = documentCount,
+                Name = index.IndexName,
+                WarmQueryDuration = warmQueryDuration,
+            };
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Wrappers/DocumentsOperationsWrapper.cs
+++ b/src/NuGet.Services.AzureSearch/Wrappers/DocumentsOperationsWrapper.cs
@@ -22,9 +22,19 @@ namespace NuGet.Services.AzureSearch.Wrappers
             return await _inner.IndexAsync(batch);
         }
 
+        public async Task<DocumentSearchResult> SearchAsync(string searchText, SearchParameters searchParameters)
+        {
+            return await _inner.SearchAsync(searchText, searchParameters);
+        }
+
         public async Task<DocumentSearchResult<T>> SearchAsync<T>(string searchText, SearchParameters searchParameters) where T : class
         {
             return await _inner.SearchAsync<T>(searchText, searchParameters);
+        }
+
+        public async Task<long> CountAsync()
+        {
+            return await _inner.CountAsync();
         }
     }
 }

--- a/src/NuGet.Services.AzureSearch/Wrappers/IDocumentsOperationsWrapper.cs
+++ b/src/NuGet.Services.AzureSearch/Wrappers/IDocumentsOperationsWrapper.cs
@@ -9,8 +9,12 @@ namespace NuGet.Services.AzureSearch.Wrappers
     public interface IDocumentsOperationsWrapper
     {
         Task<DocumentIndexResult> IndexAsync<T>(IndexBatch<T> batch) where T : class;
+        Task<DocumentSearchResult> SearchAsync(
+            string searchText,
+            SearchParameters searchParameters);
         Task<DocumentSearchResult<T>> SearchAsync<T>(
             string searchText,
             SearchParameters searchParameters) where T : class;
+        Task<long> CountAsync();
     }
 }

--- a/src/NuGet.Services.SearchService/App_Start/WebApiConfig.cs
+++ b/src/NuGet.Services.SearchService/App_Start/WebApiConfig.cs
@@ -44,6 +44,15 @@ namespace NuGet.Services.SearchService
             config.MapHttpAttributeRoutes();
 
             config.Routes.MapHttpRoute(
+                name: "GetStatus",
+                routeTemplate: "search/diag",
+                defaults: new
+                {
+                    controller = GetControllerName<SearchController>(),
+                    action = nameof(SearchController.GetStatusAsync),
+                });
+
+            config.Routes.MapHttpRoute(
                 name: "V2Search",
                 routeTemplate: "search/query",
                 defaults: new

--- a/src/NuGet.Services.SearchService/Settings/local.json
+++ b/src/NuGet.Services.SearchService/Settings/local.json
@@ -11,7 +11,8 @@
     "AuxiliaryDataStorageDownloadsPath": "downloads.v1.json",
     "AuxiliaryDataStorageVerifiedPackagesPath": "verifiedPackages.json",
     "AuxiliaryDataReloadFrequency": "01:00:00",
-    "AuxiliaryDataReloadFailureRetryFrequency": "00:00:30"
+    "AuxiliaryDataReloadFailureRetryFrequency": "00:00:30",
+    "DeploymentLabel": "1.0.0-zlocal"
   },
 
   "KeyVault_VaultName": "",

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryDocumentsOperations.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryDocumentsOperations.cs
@@ -22,6 +22,11 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
             }
         }
 
+        public Task<long> CountAsync()
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<DocumentIndexResult> IndexAsync<T>(IndexBatch<T> batch) where T : class
         {
             if (typeof(T) != typeof(KeyedDocument))
@@ -35,6 +40,11 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
         }
 
         public Task<DocumentSearchResult<T>> SearchAsync<T>(string searchText, SearchParameters searchParameters) where T : class
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<DocumentSearchResult> SearchAsync(string searchText, SearchParameters searchParameters)
         {
             throw new NotImplementedException();
         }

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="SearchService\AzureSearchServiceFacts.cs" />
     <Compile Include="SearchService\SearchParametersBuilderFacts.cs" />
     <Compile Include="SearchService\SearchResponseBuilderFacts.cs" />
+    <Compile Include="SearchService\SearchStatusServiceFacts.cs" />
     <Compile Include="Support\Cursor.cs" />
     <Compile Include="Support\Data.cs" />
     <Compile Include="Support\SerializationUtilities.cs" />

--- a/tests/NuGet.Services.AzureSearch.Tests/Properties/AssemblyInfo.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Properties/AssemblyInfo.cs
@@ -7,3 +7,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("NuGet.Services.AzureSearch.Tests")]
 [assembly: ComVisible(false)]
 [assembly: Guid("6a9c3802-a2a2-49cf-87bd-c1303533b846")]
+
+[assembly: AssemblyMetadata("BuildDateUtc", "This is a fake build date for testing.")]
+[assembly: AssemblyMetadata("CommitId", "This is a fake commit ID for testing.")]
+[assembly: AssemblyInformationalVersion("1.0.0-fakefortesting")]

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchStatusServiceFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchStatusServiceFacts.cs
@@ -1,0 +1,199 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Search.Models;
+using Microsoft.Extensions.Options;
+using Moq;
+using NuGet.Services.AzureSearch.Support;
+using NuGet.Services.AzureSearch.Wrappers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class SearchStatusServiceFacts
+    {
+        public class GetStatusAsync : BaseFacts
+        {
+            public GetStatusAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task ReturnsFullStatus()
+            {
+                var before = DateTimeOffset.UtcNow;
+                var status = await _target.GetStatusAsync(_assembly);
+
+                Assert.True(status.Success);
+                Assert.InRange(status.Duration, TimeSpan.FromMilliseconds(1), TimeSpan.MaxValue);
+
+                Assert.Equal("This is a fake build date for testing.", status.Server.AssemblyBuildDateUtc);
+                Assert.Equal("This is a fake commit ID for testing.", status.Server.AssemblyCommitId);
+                Assert.Equal("1.0.0-fakefortesting", status.Server.AssemblyInformationalVersion);
+                Assert.Equal(_config.DeploymentLabel, status.Server.DeploymentLabel);
+                Assert.Equal("Fake website instance ID.", status.Server.InstanceId);
+                Assert.Equal(Environment.MachineName, status.Server.MachineName);
+                Assert.InRange(status.Server.ProcessDuration, TimeSpan.FromMilliseconds(1), TimeSpan.MaxValue);
+                Assert.NotEqual(0, status.Server.ProcessId);
+                Assert.InRange(status.Server.ProcessStartTime, DateTimeOffset.MinValue, before);
+
+                Assert.Equal(23, status.SearchIndex.DocumentCount);
+                Assert.Equal("search-index", status.SearchIndex.Name);
+                Assert.InRange(status.SearchIndex.WarmQueryDuration, TimeSpan.FromMilliseconds(1), TimeSpan.MaxValue);
+
+                Assert.Equal(42, status.HijackIndex.DocumentCount);
+                Assert.Equal("hijack-index", status.HijackIndex.Name);
+                Assert.InRange(status.HijackIndex.WarmQueryDuration, TimeSpan.FromMilliseconds(1), TimeSpan.MaxValue);
+
+                Assert.Same(_auxiliaryFilesMetadata, status.AuxiliaryFiles);
+
+                _searchDocuments.Verify(x => x.CountAsync(), Times.Once);
+                _searchDocuments.Verify(x => x.SearchAsync("*", It.IsAny<SearchParameters>()), Times.Once);
+                _hijackDocuments.Verify(x => x.CountAsync(), Times.Once);
+                _hijackDocuments.Verify(x => x.SearchAsync("*", It.IsAny<SearchParameters>()), Times.Once);
+            }
+
+            [Fact]
+            public async Task HandlesFailedServerStatus()
+            {
+                _options.Setup(x => x.Value).Throws(new InvalidOperationException("Can't get the deployment label."));
+
+                var status = await _target.GetStatusAsync(_assembly);
+
+                Assert.False(status.Success);
+                Assert.InRange(status.Duration, TimeSpan.FromMilliseconds(1), TimeSpan.MaxValue);
+                Assert.Null(status.Server);
+                Assert.NotNull(status.SearchIndex);
+                Assert.NotNull(status.HijackIndex);
+                Assert.NotNull(status.AuxiliaryFiles);
+            }
+
+            [Fact]
+            public async Task HandlesFailedSearchIndexStatus()
+            {
+                _searchDocuments
+                    .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<SearchParameters>()))
+                    .ThrowsAsync(new InvalidOperationException("Could not hit the search index."));
+
+                var status = await _target.GetStatusAsync(_assembly);
+
+                Assert.False(status.Success);
+                Assert.InRange(status.Duration, TimeSpan.FromMilliseconds(1), TimeSpan.MaxValue);
+                Assert.NotNull(status.Server);
+                Assert.Null(status.SearchIndex);
+                Assert.NotNull(status.HijackIndex);
+                Assert.NotNull(status.AuxiliaryFiles);
+            }
+
+            [Fact]
+            public async Task HandlesFailedHijackIndexStatus()
+            {
+                _hijackDocuments
+                    .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<SearchParameters>()))
+                    .ThrowsAsync(new InvalidOperationException("Could not hit the hijack index."));
+
+                var status = await _target.GetStatusAsync(_assembly);
+
+                Assert.False(status.Success);
+                Assert.InRange(status.Duration, TimeSpan.FromMilliseconds(1), TimeSpan.MaxValue);
+                Assert.NotNull(status.Server);
+                Assert.NotNull(status.SearchIndex);
+                Assert.Null(status.HijackIndex);
+                Assert.NotNull(status.AuxiliaryFiles);
+            }
+
+            [Fact]
+            public async Task HandlesFailedAuxiliaryData()
+            {
+                _auxiliaryDataCache
+                    .Setup(x => x.InitializeAsync())
+                    .Throws(new InvalidOperationException("Could not initialize the auxiliary data."));
+
+                var status = await _target.GetStatusAsync(_assembly);
+
+                Assert.False(status.Success);
+                Assert.InRange(status.Duration, TimeSpan.FromMilliseconds(1), TimeSpan.MaxValue);
+                Assert.NotNull(status.Server);
+                Assert.NotNull(status.SearchIndex);
+                Assert.NotNull(status.HijackIndex);
+                Assert.Null(status.AuxiliaryFiles);
+            }
+        }
+
+        public abstract class BaseFacts
+        {
+            protected readonly Mock<ISearchIndexClientWrapper> _searchIndex;
+            protected readonly Mock<IDocumentsOperationsWrapper> _searchDocuments;
+            protected readonly Mock<ISearchIndexClientWrapper> _hijackIndex;
+            protected readonly Mock<IDocumentsOperationsWrapper> _hijackDocuments;
+            protected readonly Mock<IAuxiliaryDataCache> _auxiliaryDataCache;
+            protected readonly Mock<IAuxiliaryData> _auxiliaryData;
+            protected readonly SearchServiceConfiguration _config;
+            protected readonly Mock<IOptionsSnapshot<SearchServiceConfiguration>> _options;
+            protected readonly RecordingLogger<SearchStatusService> _logger;
+            protected readonly AuxiliaryFilesMetadata _auxiliaryFilesMetadata;
+            protected readonly Assembly _assembly;
+            protected readonly SearchStatusService _target;
+
+            public BaseFacts(ITestOutputHelper output)
+            {
+                _searchIndex = new Mock<ISearchIndexClientWrapper>();
+                _searchDocuments = new Mock<IDocumentsOperationsWrapper>();
+                _hijackIndex = new Mock<ISearchIndexClientWrapper>();
+                _hijackDocuments = new Mock<IDocumentsOperationsWrapper>();
+                _auxiliaryDataCache = new Mock<IAuxiliaryDataCache>();
+                _auxiliaryData = new Mock<IAuxiliaryData>();
+                _options = new Mock<IOptionsSnapshot<SearchServiceConfiguration>>();
+                _logger = output.GetLogger<SearchStatusService>();
+
+                _auxiliaryFilesMetadata = new AuxiliaryFilesMetadata(
+                    new AuxiliaryFileMetadata(
+                        DateTimeOffset.MinValue,
+                        DateTimeOffset.MinValue,
+                        TimeSpan.Zero,
+                        0,
+                        string.Empty),
+                    new AuxiliaryFileMetadata(
+                        DateTimeOffset.MinValue,
+                        DateTimeOffset.MinValue,
+                        TimeSpan.Zero,
+                        0,
+                        string.Empty));
+                _assembly = typeof(BaseFacts).Assembly;
+                _config = new SearchServiceConfiguration();
+                _config.DeploymentLabel = "Fake deployment label.";
+                Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", "Fake website instance ID.");
+
+                _searchIndex.Setup(x => x.IndexName).Returns("search-index");
+                _hijackIndex.Setup(x => x.IndexName).Returns("hijack-index");
+                _searchIndex.Setup(x => x.Documents).Returns(() => _searchDocuments.Object);
+                _hijackIndex.Setup(x => x.Documents).Returns(() => _hijackDocuments.Object);
+                _searchDocuments.Setup(x => x.CountAsync()).ReturnsAsync(23);
+                _hijackDocuments.Setup(x => x.CountAsync()).ReturnsAsync(42);
+                _searchDocuments
+                    .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<SearchParameters>()))
+                    .ReturnsAsync(new DocumentSearchResult())
+                    .Callback(() => Thread.Sleep(TimeSpan.FromMilliseconds(1)));
+                _hijackDocuments
+                    .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<SearchParameters>()))
+                    .ReturnsAsync(new DocumentSearchResult())
+                    .Callback(() => Thread.Sleep(TimeSpan.FromMilliseconds(1)));
+                _options.Setup(x => x.Value).Returns(() => _config);
+                _auxiliaryDataCache.Setup(x => x.Get()).Returns(() => _auxiliaryData.Object);
+                _auxiliaryData.Setup(x => x.Metadata).Returns(() => _auxiliaryFilesMetadata);
+
+                _target = new SearchStatusService(
+                    _searchIndex.Object,
+                    _hijackIndex.Object,
+                    _auxiliaryDataCache.Object,
+                    _options.Object,
+                    _logger);
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/Support/XunitLogger.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Support/XunitLogger.cs
@@ -30,7 +30,12 @@ namespace Microsoft.Extensions.Logging
                 return;
             }
             var firstLinePrefix = $"| {_category} {logLevel}: ";
-            var lines = formatter(state, exception).Split('\n');
+            var formattedMessage = formatter(state, exception);
+            if (exception != null)
+            {
+                formattedMessage += Environment.NewLine + exception.ToString();
+            }
+            var lines = formattedMessage.Split('\n');
             _output.WriteLine(firstLinePrefix + lines.First().TrimEnd(NewLineChars));
 
             var additionalLinePrefix = "|" + new string(' ', firstLinePrefix.Length - 1);


### PR DESCRIPTION
I changed the response body to have more helpful information. 

Address https://github.com/nuget/nugetgallery/issues/6454

Output looks like this:

```json
{
    "Success": true,
    "Server": {
        "MachineName": "RD00155D941F25",
        "ProcessId": 12376,
        "ProcessStartTime": "2019-01-10T03:25:46.7568469+00:00",
        "ProcessDuration": "00:02:35.3677385",
        "DeploymentLabel": "DEV-USNC-4.0.0-jver-diag-2320652",
        "AssemblyCommitId": "796a27a",
        "AssemblyInformationalVersion": "4.0.0-jver-azsdep-2320652",
        "AssemblyBuildDateUtc": "01/10/2019 03:13:07 +00:00",
        "InstanceId": "8da5b5cd140c25c0d571bac7c5d4593bcc2f07fa87f6215e576e76ca1fc30873"
    },
    "SearchIndex": {
        "Name": "search-dev-20181214-00",
        "DocumentCount": 503741,
        "WarmQueryDuration": "00:00:00.1491502"
    },
    "HijackIndex": {
        "Name": "hijack-dev-20181214-00",
        "DocumentCount": 1798018,
        "WarmQueryDuration": "00:00:00.0913182"
    },
    "AuxiliaryFiles": {
        "Downloads": {
            "LastModified": "2018-12-17T19:57:48+00:00",
            "Loaded": "2019-01-10T03:27:43.6653936+00:00",
            "LoadDuration": "00:00:19.0527679",
            "FileSize": 42507754,
            "ETag": "\"0x8D66459EB34E3FB\""
        },
        "VerifiedPackages": {
            "LastModified": "2018-12-17T19:57:49+00:00",
            "Loaded": "2019-01-10T03:27:25.6290707+00:00",
            "LoadDuration": "00:00:00.6896924",
            "FileSize": 370219,
            "ETag": "\"0x8D66459EBD0F1C5\""
        }
    }
}
```