### PR TITLE
Make EnsureInitializedAsync no-op if it's already initialized

### DIFF
--- a/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryDataCache.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryDataCache.cs
@@ -27,20 +27,20 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         public bool Initialized => _data != null;
 
-        public async Task InitializeAsync()
+        public async Task EnsureInitializedAsync()
         {
             if (!Initialized)
             {
-                await LoadAsync(Timeout.InfiniteTimeSpan, CancellationToken.None);
+                await LoadAsync(Timeout.InfiniteTimeSpan, shouldReload: false, token: CancellationToken.None);
             }
         }
 
         public async Task TryLoadAsync(CancellationToken token)
         {
-            await LoadAsync(TimeSpan.Zero, token);
+            await LoadAsync(TimeSpan.Zero, shouldReload: true, token: token);
         }
 
-        private async Task LoadAsync(TimeSpan timeout, CancellationToken token)
+        private async Task LoadAsync(TimeSpan timeout, bool shouldReload, CancellationToken token)
         {
             var acquired = false;
             try
@@ -52,6 +52,11 @@ namespace NuGet.Services.AzureSearch.SearchService
                 }
                 else
                 {
+                    if (!shouldReload && Initialized)
+                    {
+                        return;
+                    }
+
                     _logger.LogInformation("Starting the reload of auxiliary data.");
 
                     var stopwatch = Stopwatch.StartNew();

--- a/src/NuGet.Services.AzureSearch/SearchService/IAuxiliaryDataCache.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IAuxiliaryDataCache.cs
@@ -19,17 +19,17 @@ namespace NuGet.Services.AzureSearch.SearchService
         /// Returns the cached loaded auxiliary data.
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        /// Thrown if there is not data available. <see cref="InitializeAsync"/> should be called if this is
+        /// Thrown if there is not data available. <see cref="EnsureInitializedAsync"/> should be called if this is
         /// thrown. <see cref="Initialized"/> can be used to check whether data is available.
         /// </exception>
         IAuxiliaryData Get();
 
         /// <summary>
         /// Load the latest version of the auxiliary data if it is not already loaded. If the data is already being
-        /// loaded by another caller, this method waits until that other reload finishes and then performs its own load
-        /// operation. If the data is already loaded, this method completes immediately without reloading the data.
+        /// loaded by another caller, this method waits until that other reload finishes and ensures that the data was
+        /// loaded. If the other caller successfully loaded the auxiliary data, this method will no-op.
         /// </summary>
-        Task InitializeAsync();
+        Task EnsureInitializedAsync();
 
         /// <summary>
         /// Tries to load the latest version of the auxiliary data. If the data is already being loaded by another

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchStatusService.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchStatusService.cs
@@ -118,7 +118,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         private async Task<AuxiliaryFilesMetadata> GetAuxiliaryFilesMetadataAsync()
         {
-            await _auxiliaryDataCache.InitializeAsync();
+            await _auxiliaryDataCache.EnsureInitializedAsync();
             return _auxiliaryDataCache.Get().Metadata;
         }
 

--- a/src/NuGet.Services.SearchService/Controllers/SearchController.cs
+++ b/src/NuGet.Services.SearchService/Controllers/SearchController.cs
@@ -112,7 +112,7 @@ namespace NuGet.Services.SearchService.Controllers
             /// Ensure the auxiliary data is loaded before processing a request. This is necessary because the response
             /// builder depends on <see cref="IAuxiliaryDataCache.Get" />, which requires that the auxiliary files have
             /// been loaded at least once.
-            await _auxiliaryDataCache.InitializeAsync();
+            await _auxiliaryDataCache.EnsureInitializedAsync();
         }
 
         private static V2SortBy GetSortBy(string sortBy)

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchStatusServiceFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchStatusServiceFacts.cs
@@ -111,7 +111,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             public async Task HandlesFailedAuxiliaryData()
             {
                 _auxiliaryDataCache
-                    .Setup(x => x.InitializeAsync())
+                    .Setup(x => x.EnsureInitializedAsync())
                     .Throws(new InvalidOperationException("Could not initialize the auxiliary data."));
 
                 var status = await _target.GetStatusAsync(_assembly);

--- a/tests/NuGet.Services.SearchService.Tests/Controllers/SearchControllerFacts.cs
+++ b/tests/NuGet.Services.SearchService.Tests/Controllers/SearchControllerFacts.cs
@@ -37,7 +37,7 @@ namespace NuGet.Services.SearchService.Controllers
             {
                 await _target.GetStatusAsync(_request);
 
-                _auxiliaryDataCache.Verify(x => x.InitializeAsync(), Times.Never);
+                _auxiliaryDataCache.Verify(x => x.EnsureInitializedAsync(), Times.Never);
             }
 
             [Fact]
@@ -69,7 +69,7 @@ namespace NuGet.Services.SearchService.Controllers
             {
                 await _target.V2SearchAsync();
 
-                _auxiliaryDataCache.Verify(x => x.InitializeAsync(), Times.Once);
+                _auxiliaryDataCache.Verify(x => x.EnsureInitializedAsync(), Times.Once);
             }
 
             [Fact]
@@ -174,7 +174,7 @@ namespace NuGet.Services.SearchService.Controllers
             {
                 await _target.V3SearchAsync();
 
-                _auxiliaryDataCache.Verify(x => x.InitializeAsync(), Times.Once);
+                _auxiliaryDataCache.Verify(x => x.EnsureInitializedAsync(), Times.Once);
             }
 
             [Fact]


### PR DESCRIPTION
Previously on start-up the first request would also try to load the auxiliary data. This is not necessary and caused troubling logs.