### PR TITLE
Make AzureStorageFactory not always create the container

### DIFF
--- a/src/Catalog/Persistence/AzureStorageFactory.cs
+++ b/src/Catalog/Persistence/AzureStorageFactory.cs
@@ -15,6 +15,7 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
         private readonly TimeSpan _maxExecutionTime;
         private readonly TimeSpan _serverTimeout;
         private readonly bool _useServerSideCopy;
+        private readonly bool _initializeContainer;
 
         public AzureStorageFactory(
             CloudStorageAccount account,
@@ -25,7 +26,8 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             Uri baseAddress,
             bool useServerSideCopy,
             bool compressContent,
-            bool verbose)
+            bool verbose,
+            bool initializeContainer)
         {
             _account = account;
             _containerName = containerName;
@@ -33,6 +35,7 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             _maxExecutionTime = maxExecutionTime;
             _serverTimeout = serverTimeout;
             _useServerSideCopy = useServerSideCopy;
+            _initializeContainer = initializeContainer;
 
             if (path != null)
             {
@@ -97,7 +100,8 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
                 _serverTimeout,
                 _useServerSideCopy,
                 CompressContent,
-                Verbose);
+                Verbose,
+                _initializeContainer);
         }
     }
 }

--- a/src/Ng/CommandHelpers.cs
+++ b/src/Ng/CommandHelpers.cs
@@ -269,7 +269,8 @@ namespace Ng
                     storageBaseAddress,
                     storageUseServerSideCopy,
                     compressed,
-                    verbose);
+                    verbose,
+                    initializeContainer: true);
             }
             throw new ArgumentException($"Unrecognized storageType \"{storageType}\"");
         }

--- a/src/NuGet.Services.AzureSearch/BlobContainerBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/BlobContainerBuilder.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+using NuGetGallery;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class BlobContainerBuilder : IBlobContainerBuilder
+    {
+        private readonly ICloudBlobClient _cloudBlobClient;
+        private readonly IOptionsSnapshot<AzureSearchJobConfiguration> _options;
+        private readonly ILogger<BlobContainerBuilder> _logger;
+        private readonly Lazy<ICloudBlobContainer> _lazyContainer;
+        private readonly TimeSpan _retryDelay;
+
+        public BlobContainerBuilder(
+            ICloudBlobClient cloudBlobClient,
+            IOptionsSnapshot<AzureSearchJobConfiguration> options,
+            ILogger<BlobContainerBuilder> logger) : this(
+                cloudBlobClient,
+                options,
+                logger,
+                retryDelay: TimeSpan.FromSeconds(10))
+        {
+        }
+
+        /// <summary>
+        /// This constructor is used for testing.
+        /// </summary>
+        internal BlobContainerBuilder(
+            ICloudBlobClient cloudBlobClient,
+            IOptionsSnapshot<AzureSearchJobConfiguration> options,
+            ILogger<BlobContainerBuilder> logger,
+            TimeSpan retryDelay)
+        {
+            _cloudBlobClient = cloudBlobClient ?? throw new ArgumentNullException(nameof(cloudBlobClient));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _lazyContainer = new Lazy<ICloudBlobContainer>(() =>
+            {
+                return _cloudBlobClient.GetContainerReference(_options.Value.StorageContainer);
+            });
+            _retryDelay = retryDelay;
+        }
+
+        private ICloudBlobContainer Container => _lazyContainer.Value;
+
+        public async Task CreateAsync(bool retryOnConflict)
+        {
+            _logger.LogInformation("Creating blob container {ContainerName}.", _options.Value.StorageContainer);
+            var containerCreated = false;
+            var waitStopwatch = Stopwatch.StartNew();
+            while (!containerCreated)
+            {
+                try
+                {
+                    await Container.CreateAsync();
+                    await Container.SetPermissionsAsync(new BlobContainerPermissions { PublicAccess = BlobContainerPublicAccessType.Blob });
+                    containerCreated = true;
+                }
+                catch (StorageException ex) when (retryOnConflict && ex.RequestInformation.HttpStatusCode == (int)HttpStatusCode.Conflict)
+                {
+                    if (waitStopwatch.Elapsed < TimeSpan.FromMinutes(5))
+                    {
+                        _logger.LogInformation(
+                            "The blob container is still being deleted. Attempting creation again in {RetryDelay}.",
+                            _retryDelay);
+                        await Task.Delay(_retryDelay);
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+            }
+            _logger.LogInformation("Done creating blob container {ContainerName}.", _options.Value.StorageContainer);
+        }
+
+        public async Task CreateIfNotExistsAsync()
+        {
+            if (await Container.ExistsAsync())
+            {
+                _logger.LogInformation("Skipping creation of blob container {ContainerName} since it already exists.", _options.Value.StorageContainer);
+            }
+            else
+            {
+                await CreateAsync(retryOnConflict: false);
+            }
+        }
+
+        public async Task<bool> DeleteIfExistsAsync()
+        {
+            _logger.LogWarning("Attempting to delete blob container {ContainerName}.", _options.Value.StorageContainer);
+            var containerDeleted = await Container.DeleteIfExistsAsync();
+            if (containerDeleted)
+            {
+                _logger.LogWarning("Done deleting blob container {ContainerName}.", _options.Value.StorageContainer);
+            }
+            else
+            {
+                _logger.LogInformation("Blob container {ContainerName} was not deleted since it does not exist.", _options.Value.StorageContainer);
+            }
+
+            return containerDeleted;
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchCommand.cs
@@ -3,19 +3,15 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Linq;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.WindowsAzure.Storage;
 using NuGet.Protocol.Catalog;
 using NuGet.Services.AzureSearch.Catalog2AzureSearch;
 using NuGet.Services.Metadata.Catalog;
 using NuGet.Services.Metadata.Catalog.Persistence;
-using NuGetGallery;
 
 namespace NuGet.Services.AzureSearch.Db2AzureSearch
 {
@@ -23,7 +19,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
     {
         private readonly INewPackageRegistrationProducer _producer;
         private readonly IPackageEntityIndexActionBuilder _indexActionBuilder;
-        private readonly ICloudBlobClient _cloudBlobClient;
+        private readonly IBlobContainerBuilder _blobContainerBuilder;
         private readonly IIndexBuilder _indexBuilder;
         private readonly Func<IBatchPusher> _batchPusherFactory;
         private readonly ICatalogClient _catalogClient;
@@ -34,7 +30,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
         public Db2AzureSearchCommand(
             INewPackageRegistrationProducer producer,
             IPackageEntityIndexActionBuilder indexActionBuilder,
-            ICloudBlobClient cloudBlobClient,
+            IBlobContainerBuilder blobContainerBuilder,
             IIndexBuilder indexBuilder,
             Func<IBatchPusher> batchPusherFactory,
             ICatalogClient catalogClient,
@@ -44,7 +40,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
         {
             _producer = producer ?? throw new ArgumentNullException(nameof(producer));
             _indexActionBuilder = indexActionBuilder ?? throw new ArgumentNullException(nameof(indexActionBuilder));
-            _cloudBlobClient = cloudBlobClient ?? throw new ArgumentNullException(nameof(cloudBlobClient));
+            _blobContainerBuilder = blobContainerBuilder ?? throw new ArgumentNullException(nameof(blobContainerBuilder));
             _indexBuilder = indexBuilder ?? throw new ArgumentNullException(nameof(indexBuilder));
             _batchPusherFactory = batchPusherFactory ?? throw new ArgumentNullException(nameof(batchPusherFactory));
             _catalogClient = catalogClient ?? throw new ArgumentNullException(nameof(catalogClient));
@@ -125,50 +121,15 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
 
         private async Task InitializeAsync()
         {
-            var container = _cloudBlobClient.GetContainerReference(_options.Value.StorageContainer);
             var containerDeleted = false;
             if (_options.Value.ReplaceContainersAndIndexes)
             {
-                _logger.LogWarning("Attempting to delete blob container {ContainerName}.", _options.Value.StorageContainer);
-                containerDeleted = await container.DeleteIfExistsAsync();
-                if (containerDeleted)
-                {
-                    _logger.LogWarning("Done deleting blob container {ContainerName}.", _options.Value.StorageContainer);
-                }
-                else
-                {
-                    _logger.LogInformation("Blob container {ContainerName} was not deleted since it does not exist.", _options.Value.StorageContainer);
-                }
-
+                containerDeleted = await _blobContainerBuilder.DeleteIfExistsAsync();
                 await _indexBuilder.DeleteSearchIndexIfExistsAsync();
                 await _indexBuilder.DeleteHijackIndexIfExistsAsync();
             }
 
-            _logger.LogInformation("Creating blob container {ContainerName}.", _options.Value.StorageContainer);
-            var containerCreated = false;
-            var waitStopwatch = Stopwatch.StartNew();
-            while (!containerCreated)
-            {
-                try
-                {
-                    await container.CreateAsync();
-                    containerCreated = true;
-                }
-                catch (StorageException ex) when (containerDeleted && ex.RequestInformation.HttpStatusCode == (int)HttpStatusCode.Conflict)
-                {
-                    if (waitStopwatch.Elapsed < TimeSpan.FromMinutes(5))
-                    {
-                        _logger.LogInformation("The blob container is still being deleted. Attempting creation again in 10 seconds.");
-                        await Task.Delay(TimeSpan.FromSeconds(10));
-                    }
-                    else
-                    {
-                        throw;
-                    }
-                }
-            }
-            _logger.LogInformation("Done creating blob container {ContainerName}.", _options.Value.StorageContainer);
-
+            await _blobContainerBuilder.CreateAsync(containerDeleted);
             await _indexBuilder.CreateSearchIndexAsync();
             await _indexBuilder.CreateHijackIndexAsync();
         }

--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -125,16 +125,23 @@ namespace NuGet.Services.AzureSearch
                         baseAddress: null,
                         useServerSideCopy: true,
                         compressContent: false,
-                        verbose: true);
+                        verbose: true,
+                        initializeContainer: false);
                 })
                 .Keyed<IStorageFactory>(key);
+
+            containerBuilder
+                .Register<IBlobContainerBuilder>(c => new BlobContainerBuilder(
+                    c.ResolveKeyed<ICloudBlobClient>(key),
+                    c.Resolve<IOptionsSnapshot<AzureSearchJobConfiguration>>(),
+                    c.Resolve<ILogger<BlobContainerBuilder>>()));
 
             containerBuilder
                 .Register(c => new Catalog2AzureSearchCommand(
                     c.Resolve<ICollector>(),
                     c.ResolveKeyed<IStorageFactory>(key),
                     c.Resolve<Func<HttpMessageHandler>>(),
-                    c.ResolveKeyed<ICloudBlobClient>(key),
+                    c.Resolve<IBlobContainerBuilder>(),
                     c.Resolve<IIndexBuilder>(),
                     c.Resolve<IOptionsSnapshot<Catalog2AzureSearchConfiguration>>(),
                     c.Resolve<ILogger<Catalog2AzureSearchCommand>>()));
@@ -143,7 +150,7 @@ namespace NuGet.Services.AzureSearch
                 .Register(c => new Db2AzureSearchCommand(
                     c.Resolve<INewPackageRegistrationProducer>(),
                     c.Resolve<IPackageEntityIndexActionBuilder>(),
-                    c.ResolveKeyed<ICloudBlobClient>(key),
+                    c.Resolve<IBlobContainerBuilder>(),
                     c.Resolve<IIndexBuilder>(),
                     c.Resolve<Func<IBatchPusher>>(),
                     c.Resolve<ICatalogClient>(),

--- a/src/NuGet.Services.AzureSearch/IBlobContainerBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/IBlobContainerBuilder.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace NuGet.Services.AzureSearch
+{
+    public interface IBlobContainerBuilder
+    {
+        Task<bool> DeleteIfExistsAsync();
+        Task CreateAsync(bool retryOnConflict);
+        Task CreateIfNotExistsAsync();
+    }
+}

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -43,6 +43,8 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BlobContainerBuilder.cs" />
+    <Compile Include="IBlobContainerBuilder.cs" />
     <Compile Include="Measure.cs" />
     <Compile Include="DurationMeasurement.cs" />
     <Compile Include="SearchService\AuxiliaryDataCache.cs" />

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Catalog2AzureSearchCommandFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Catalog2AzureSearchCommandFacts.cs
@@ -13,7 +13,6 @@ using Newtonsoft.Json;
 using NuGet.Services.AzureSearch.Support;
 using NuGet.Services.Metadata.Catalog;
 using NuGet.Services.Metadata.Catalog.Persistence;
-using NuGetGallery;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -34,17 +33,13 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
             [InlineData(true, true)]
             public async Task ObservesCreateContainersAndIndexesOption(bool shouldCreate, bool containerExists)
             {
-                _cloudBlobContainer.Setup(x => x.ExistsAsync()).ReturnsAsync(containerExists);
                 _config.CreateContainersAndIndexes = shouldCreate;
                 var createIfExistsTimes = shouldCreate ? Times.Once() : Times.Never();
                 var createTimes = shouldCreate && !containerExists ? Times.Once() : Times.Never();
 
                 await _target.ExecuteAsync();
 
-                _cloudBlobClient.Verify(x => x.GetContainerReference(_config.StorageContainer), createIfExistsTimes);
-                _cloudBlobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), createIfExistsTimes);
-                _cloudBlobContainer.Verify(x => x.ExistsAsync(), createIfExistsTimes);
-                _cloudBlobContainer.Verify(x => x.CreateAsync(), createTimes);
+                _blobContainerBuilder.Verify(x => x.CreateIfNotExistsAsync(), createIfExistsTimes);
                 _indexBuilder.Verify(x => x.CreateSearchIndexIfNotExistsAsync(), createIfExistsTimes);
                 _indexBuilder.Verify(x => x.CreateHijackIndexIfNotExistsAsync(), createIfExistsTimes);
             }
@@ -121,8 +116,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
             protected readonly Mock<ICollector> _collector;
             protected readonly Mock<IStorageFactory> _storageFactory;
             protected readonly Mock<TestHttpMessageHandler> _httpMessageHandler;
-            protected readonly Mock<ICloudBlobClient> _cloudBlobClient;
-            protected readonly Mock<ICloudBlobContainer> _cloudBlobContainer;
+            protected readonly Mock<IBlobContainerBuilder> _blobContainerBuilder;
             protected readonly Mock<IIndexBuilder> _indexBuilder;
             protected readonly Mock<IOptionsSnapshot<Catalog2AzureSearchConfiguration>> _options;
             protected readonly Catalog2AzureSearchConfiguration _config;
@@ -135,8 +129,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                 _collector = new Mock<ICollector>();
                 _storageFactory = new Mock<IStorageFactory>();
                 _httpMessageHandler = new Mock<TestHttpMessageHandler>() { CallBase = true };
-                _cloudBlobClient = new Mock<ICloudBlobClient>();
-                _cloudBlobContainer = new Mock<ICloudBlobContainer>();
+                _blobContainerBuilder = new Mock<IBlobContainerBuilder>();
                 _indexBuilder = new Mock<IIndexBuilder>();
                 _options = new Mock<IOptionsSnapshot<Catalog2AzureSearchConfiguration>>();
                 _logger = output.GetLogger<Catalog2AzureSearchCommand>();
@@ -150,15 +143,12 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
                 _options.Setup(x => x.Value).Returns(() => _config);
                 _storageFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(() => _storage);
-                _cloudBlobClient
-                    .Setup(x => x.GetContainerReference(It.IsAny<string>()))
-                    .Returns(() => _cloudBlobContainer.Object);
 
                 _target = new Catalog2AzureSearchCommand(
                     _collector.Object,
                     _storageFactory.Object,
                     () => _httpMessageHandler.Object,
-                    _cloudBlobClient.Object,
+                    _blobContainerBuilder.Object,
                     _indexBuilder.Object,
                     _options.Object,
                     _logger);


### PR DESCRIPTION
In the Azure Search jobs, I have config that controls whether or not the job creates the containers/indexes. This existing behavior but it had a bug since the cursor storage would create the container even if the job configuration said not to.