### PR TITLE
Add instance name option to ng

### DIFF
--- a/src/Ng/Arguments.cs
+++ b/src/Ng/Arguments.cs
@@ -18,6 +18,7 @@ namespace Ng
         public const string Path = "path";
         public const string Source = "source";
         public const string Verbose = "verbose";
+        public const string InstanceName = "instanceName";
 
         public const int DefaultInterval = 3; // seconds
         public const string Interval = "interval";

--- a/src/Ng/Program.cs
+++ b/src/Ng/Program.cs
@@ -54,7 +54,8 @@ namespace Ng
                 }
 
                 var jobName = args[0];
-                TelemetryConfiguration.Active.TelemetryInitializers.Add(new JobNameTelemetryInitializer(jobName));
+                var instanceName = arguments.GetOrDefault(Arguments.InstanceName, jobName);
+                TelemetryConfiguration.Active.TelemetryInitializers.Add(new JobNameTelemetryInitializer(jobName, instanceName));
 
                 // Configure ApplicationInsights
                 ApplicationInsights.Initialize(arguments.GetOrDefault<string>(Arguments.InstrumentationKey));

--- a/src/Ng/Scripts/Catalog2DnxV3.cmd
+++ b/src/Ng/Scripts/Catalog2DnxV3.cmd
@@ -8,6 +8,7 @@ echo "Starting job - #{Jobs.ngcatalog2dnx.Title}"
 title #{Jobs.ngcatalog2dnx.Title}
 
 start /w Ng.exe catalog2dnx ^
+    -instanceName catalog2dnx-global ^
     -source #{Jobs.ngcatalog2dnx.Catalog.Source} ^
     -contentBaseAddress #{Jobs.ngcatalog2dnx.ContentBaseAddress} ^
     -storageBaseAddress #{Jobs.ngcatalog2dnx.StorageBaseAddress} ^

--- a/src/Ng/Scripts/Catalog2DnxV3China.cmd
+++ b/src/Ng/Scripts/Catalog2DnxV3China.cmd
@@ -8,6 +8,7 @@ echo "Starting job - #{Jobs.ngcatalog2dnxChina.Title}"
 title #{Jobs.ngcatalog2dnxChina.Title}
 
 start /w Ng.exe catalog2dnx ^
+    -instanceName catalog2dnx-china ^
     -source #{Jobs.ngcatalog2dnx.Catalog.Source} ^
     -contentBaseAddress #{Jobs.China.ngcatalog2dnx.ContentBaseAddress} ^
     -storageBaseAddress #{Jobs.China.ngcatalog2dnx.StorageBaseAddress} ^

--- a/src/Ng/Scripts/Catalog2LuceneV3-Asia.cmd
+++ b/src/Ng/Scripts/Catalog2LuceneV3-Asia.cmd
@@ -8,6 +8,7 @@ echo "Starting job - #{Jobs.Asia.catalog2lucenev3.Title}"
 title #{Jobs.Asia.catalog2lucenev3.Title}
 
 start /w Ng.exe catalog2lucene ^
+    -instanceName catalog2lucene-ea ^
     -source #{Jobs.common.v3.Source} ^
     -luceneDirectoryType azure ^
     -luceneStorageAccountName #{Jobs.Asia.v3.Storage.Name} ^

--- a/src/Ng/Scripts/Catalog2LuceneV3-Reg2-USSC.cmd
+++ b/src/Ng/Scripts/Catalog2LuceneV3-Reg2-USSC.cmd
@@ -8,6 +8,7 @@ echo "Starting job - #{Jobs.catalog2lucenev3reg2ussc.Title}"
 title #{Jobs.catalog2lucenev3reg2ussc.Title}
 
 start /w ng.exe catalog2lucene ^
+    -instanceName catalog2lucene-ussc ^
     -source #{Jobs.common.v3.Source} ^
     -luceneDirectoryType azure ^
     -luceneStorageAccountName #{Jobs.common.v3.Storage.USSC.Name} ^

--- a/src/Ng/Scripts/Catalog2LuceneV3-Reg2.cmd
+++ b/src/Ng/Scripts/Catalog2LuceneV3-Reg2.cmd
@@ -8,6 +8,7 @@ echo "Starting job - #{Jobs.catalog2lucenev3reg2.Title}"
 title #{Jobs.catalog2lucenev3reg2.Title}
 
 start /w ng.exe catalog2lucene ^
+    -instanceName catalog2lucene-usnc ^
     -source #{Jobs.common.v3.Source} ^
     -luceneDirectoryType azure ^
     -luceneStorageAccountName #{Jobs.common.v3.Storage.Primary.Name} ^

--- a/src/Ng/Scripts/Catalog2LuceneV3-SouthEastAsia.cmd
+++ b/src/Ng/Scripts/Catalog2LuceneV3-SouthEastAsia.cmd
@@ -8,6 +8,7 @@ echo "Starting job - #{Jobs.catalog2lucenev3reg2southeastasia.Title}"
 title #{Jobs.catalog2lucenev3reg2southeastasia.Title}
 
 start /w Ng.exe catalog2lucene ^
+    -instanceName catalog2lucene-sea ^
     -source #{Jobs.common.v3.Source} ^
     -luceneDirectoryType azure ^
     -luceneStorageAccountName #{Jobs.SouthEastAsia.v3.Storage.Name} ^

--- a/src/Ng/Scripts/Catalog2RegistrationV3-Reg3-China.cmd
+++ b/src/Ng/Scripts/Catalog2RegistrationV3-Reg3-China.cmd
@@ -8,6 +8,7 @@ echo "Starting job - #{Jobs.China.catalog2registrationv3reg3.Title}"
 title #{Jobs.China.catalog2registrationv3reg3.Title}
 
 start /w ng.exe catalog2registration ^
+    -instanceName catalog2registration-china ^
     -source #{Jobs.common.China.v3.Source} ^
     -contentBaseAddress #{Jobs.China.catalog2registrationv3reg3.ContentBaseAddress} ^
     -storageType azure ^

--- a/src/Ng/Scripts/Catalog2RegistrationV3-Reg3.cmd
+++ b/src/Ng/Scripts/Catalog2RegistrationV3-Reg3.cmd
@@ -8,6 +8,7 @@ echo "Starting job - #{Jobs.catalog2registrationv3reg3.Title}"
 title #{Jobs.catalog2registrationv3reg3.Title}
 
 start /w ng.exe catalog2registration ^
+    -instanceName catalog2registration-global ^
     -source #{Jobs.catalog2registrationv3reg3.Source} ^
     -contentBaseAddress #{Jobs.catalog2registrationv3reg3.ContentBaseAddress} ^
     -storageType azure ^

--- a/src/Ng/Telemetry/JobNameTelemetryInitializer.cs
+++ b/src/Ng/Telemetry/JobNameTelemetryInitializer.cs
@@ -10,17 +10,21 @@ namespace Ng
     public class JobNameTelemetryInitializer : ITelemetryInitializer
     {
         private const string JobNameKey = "JobName";
+        private const string InstanceNameKey = "InstanceName";
 
         private readonly string _jobName;
+        private readonly string _instanceName;
 
-        public JobNameTelemetryInitializer(string jobName)
+        public JobNameTelemetryInitializer(string jobName, string instanceName)
         {
             _jobName = jobName ?? throw new ArgumentNullException(nameof(jobName));
+            _instanceName = instanceName ?? throw new ArgumentNullException(nameof(instanceName));
         }
 
         public void Initialize(ITelemetry telemetry)
         {
             telemetry.Context.Properties[JobNameKey] = _jobName;
+            telemetry.Context.Properties[InstanceNameKey] = _instanceName;
         }
     }
 }

--- a/tests/NgTests/JobNameTelemetryInitializerTests.cs
+++ b/tests/NgTests/JobNameTelemetryInitializerTests.cs
@@ -16,13 +16,22 @@ namespace NgTests
         public void Constructor_WhenJobNameIsNull_Throws()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new JobNameTelemetryInitializer(jobName: null));
+                () => new JobNameTelemetryInitializer(jobName: null, instanceName: "instanceName"));
 
             Assert.Equal("jobName", exception.ParamName);
         }
 
         [Fact]
-        public void Initialize_WhenTelemetryIsNotNull_SetsJobName()
+        public void Constructor_WhenInstanceNameIsNull_Throws()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new JobNameTelemetryInitializer(jobName: "jobName", instanceName: null));
+
+            Assert.Equal("instanceName", exception.ParamName);
+        }
+
+        [Fact]
+        public void Initialize_WhenTelemetryIsNotNull_SetsJobNameAndInstanceName()
         {
             var telemetryContext = new TelemetryContext();
             var telemetry = new Mock<ITelemetry>();
@@ -30,12 +39,13 @@ namespace NgTests
             telemetry.SetupGet(x => x.Context)
                 .Returns(telemetryContext);
 
-            var initializer = new JobNameTelemetryInitializer(jobName: "a");
+            var initializer = new JobNameTelemetryInitializer(jobName: "a", instanceName: "b");
 
             initializer.Initialize(telemetry.Object);
 
-            Assert.Equal(1, telemetryContext.Properties.Count);
+            Assert.Equal(2, telemetryContext.Properties.Count);
             Assert.Equal("a", telemetryContext.Properties["JobName"]);
+            Assert.Equal("b", telemetryContext.Properties["InstanceName"]);
         }
     }
 }


### PR DESCRIPTION
This allows us to differentiate between multiple instances of the job running in the same environment but with different configuration.

The default value is the job name. I chose a non-null default so it is easy to `summarize` by it. 

Progress on https://github.com/NuGet/Engineering/issues/2087