### PR TITLE
Create individual packages for all of the deployed ng jobs

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -106,6 +106,13 @@ Invoke-BuildStep 'Creating artifacts' {
         }
 
         $nuspecPackages = `
+            "src\Ng\Catalog2Dnx.nuspec", `
+            "src\Ng\Catalog2Lucene.nuspec", `
+            "src\Ng\Catalog2Monitoring.nuspec", `
+            "src\Ng\Catalog2Registration.nuspec", `
+            "src\Ng\Feed2Catalog.nuspec", `
+            "src\Ng\Monitoring2Monitoring.nuspec", `
+            "src\Ng\MonitoringProcessor.nuspec", `
             "src\Ng\Ng.nuspec", `
             "src\Ng\Ng.Operations.nuspec"
 

--- a/src/Ng/Catalog2Dnx.nuspec
+++ b/src/Ng/Catalog2Dnx.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Catalog2Dnx</id>
+    <version>$version$</version>
+    <authors>.NET Foundation</authors>
+    <owners>.NET Foundation</owners>
+    <description>The Catalog2Dnx job.</description>
+    <copyright>Copyright .NET Foundation</copyright>
+  </metadata>
+  <files>
+    <file src="bin\$configuration$\*.*" target="Ng"/>
+    <file src="Scripts\*.cmd" />
+    <file src="Scripts\*.ps1" />
+    <file src="Scripts\nssm.exe" />
+  </files>
+</package>

--- a/src/Ng/Catalog2Lucene.nuspec
+++ b/src/Ng/Catalog2Lucene.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Catalog2Lucene</id>
+    <version>$version$</version>
+    <authors>.NET Foundation</authors>
+    <owners>.NET Foundation</owners>
+    <description>The Catalog2Lucene job.</description>
+    <copyright>Copyright .NET Foundation</copyright>
+  </metadata>
+  <files>
+    <file src="bin\$configuration$\*.*" target="Ng"/>
+    <file src="Scripts\*.cmd" />
+    <file src="Scripts\*.ps1" />
+    <file src="Scripts\nssm.exe" />
+  </files>
+</package>

--- a/src/Ng/Catalog2Monitoring.nuspec
+++ b/src/Ng/Catalog2Monitoring.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Catalog2Monitoring</id>
+    <version>$version$</version>
+    <authors>.NET Foundation</authors>
+    <owners>.NET Foundation</owners>
+    <description>The Catalog2Monitoring job.</description>
+    <copyright>Copyright .NET Foundation</copyright>
+  </metadata>
+  <files>
+    <file src="bin\$configuration$\*.*" target="Ng"/>
+    <file src="Scripts\*.cmd" />
+    <file src="Scripts\*.ps1" />
+    <file src="Scripts\nssm.exe" />
+  </files>
+</package>

--- a/src/Ng/Catalog2Registration.nuspec
+++ b/src/Ng/Catalog2Registration.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Catalog2Registration</id>
+    <version>$version$</version>
+    <authors>.NET Foundation</authors>
+    <owners>.NET Foundation</owners>
+    <description>The Catalog2Registration job.</description>
+    <copyright>Copyright .NET Foundation</copyright>
+  </metadata>
+  <files>
+    <file src="bin\$configuration$\*.*" target="Ng"/>
+    <file src="Scripts\*.cmd" />
+    <file src="Scripts\*.ps1" />
+    <file src="Scripts\nssm.exe" />
+  </files>
+</package>

--- a/src/Ng/Feed2Catalog.nuspec
+++ b/src/Ng/Feed2Catalog.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Feed2Catalog</id>
+    <version>$version$</version>
+    <authors>.NET Foundation</authors>
+    <owners>.NET Foundation</owners>
+    <description>The Feed2Catalog job.</description>
+    <copyright>Copyright .NET Foundation</copyright>
+  </metadata>
+  <files>
+    <file src="bin\$configuration$\*.*" target="Ng"/>
+    <file src="Scripts\*.cmd" />
+    <file src="Scripts\*.ps1" />
+    <file src="Scripts\nssm.exe" />
+  </files>
+</package>

--- a/src/Ng/Monitoring2Monitoring.nuspec
+++ b/src/Ng/Monitoring2Monitoring.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Monitoring2Monitoring</id>
+    <version>$version$</version>
+    <authors>.NET Foundation</authors>
+    <owners>.NET Foundation</owners>
+    <description>The Monitoring2Monitoring job.</description>
+    <copyright>Copyright .NET Foundation</copyright>
+  </metadata>
+  <files>
+    <file src="bin\$configuration$\*.*" target="Ng"/>
+    <file src="Scripts\*.cmd" />
+    <file src="Scripts\*.ps1" />
+    <file src="Scripts\nssm.exe" />
+  </files>
+</package>

--- a/src/Ng/MonitoringProcessor.nuspec
+++ b/src/Ng/MonitoringProcessor.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>MonitoringProcessor</id>
+    <version>$version$</version>
+    <authors>.NET Foundation</authors>
+    <owners>.NET Foundation</owners>
+    <description>The MonitoringProcessor job.</description>
+    <copyright>Copyright .NET Foundation</copyright>
+  </metadata>
+  <files>
+    <file src="bin\$configuration$\*.*" target="Ng"/>
+    <file src="Scripts\*.cmd" />
+    <file src="Scripts\*.ps1" />
+    <file src="Scripts\nssm.exe" />
+  </files>
+</package>

--- a/src/Ng/Ng.csproj
+++ b/src/Ng/Ng.csproj
@@ -117,6 +117,13 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="Catalog2Dnx.nuspec" />
+    <None Include="Catalog2Lucene.nuspec" />
+    <None Include="Catalog2Monitoring.nuspec" />
+    <None Include="Catalog2Registration.nuspec" />
+    <None Include="Feed2Catalog.nuspec" />
+    <None Include="Monitoring2Monitoring.nuspec" />
+    <None Include="MonitoringProcessor.nuspec" />
     <None Include="Ng.Operations.nuspec">
       <SubType>Designer</SubType>
     </None>


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/2117.

This is because the Ev2 work for jobs expects the package name to be the same as the job name.

Additionally, this is more in line with the pattern we have on all other jobs and facilitates us moving the Ng jobs to the common jobs infrastructure at some point. Once this change is done, we can more easily iterate individual Ng job code (e.g. extracting one out to its own entry point) without affecting the others.