### PR TITLE
[Azure Search 2] Add UpdateOwners model to update just the owners field

### DIFF
--- a/src/NuGet.Services.AzureSearch/HijackDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/HijackDocumentBuilder.cs
@@ -93,7 +93,11 @@ namespace NuGet.Services.AzureSearch
             HijackDocumentChanges changes) where T : KeyedDocument, HijackDocument.ILatest
         {
             PopulateKey(document, packageId, normalizedVersion);
-            DocumentUtilities.PopulateCommitted(document, lastUpdatedFromCatalog, lastCommitTimestamp, lastCommitId);
+            DocumentUtilities.PopulateCommitted(
+                document,
+                lastUpdatedFromCatalog,
+                lastCommitTimestamp,
+                lastCommitId);
             document.IsLatestStableSemVer1 = changes.LatestStableSemVer1;
             document.IsLatestSemVer1 = changes.LatestSemVer1;
             document.IsLatestStableSemVer2 = changes.LatestStableSemVer2;

--- a/src/NuGet.Services.AzureSearch/ISearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/ISearchDocumentBuilder.cs
@@ -17,6 +17,11 @@ namespace NuGet.Services.AzureSearch
             string packageId,
             SearchFilters searchFilters);
 
+        SearchDocument.UpdateOwners UpdateOwners(
+            string packageId,
+            SearchFilters searchFilters,
+            string[] owners);
+
         SearchDocument.UpdateVersionList UpdateVersionListFromCatalog(
             string packageId,
             SearchFilters searchFilters,

--- a/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
@@ -27,7 +27,7 @@ namespace NuGet.Services.AzureSearch
         /// Used when processing <see cref="SearchIndexChangeType.AddFirst"/>.
         /// </summary>
         [SerializePropertyNamesAsCamelCase]
-        public class AddFirst : UpdateLatest
+        public class AddFirst : UpdateLatest, IOwners
         {
             [IsSearchable]
             [Analyzer(ExactMatchCustomAnalyzer.Name)]
@@ -62,6 +62,17 @@ namespace NuGet.Services.AzureSearch
         }
 
         /// <summary>
+        /// Used when updating just the owners of a document. Note that this model does not need any analyzer or
+        /// other Azure Search attributes since it is not used for index creation. The <see cref="Full"/> and its
+        /// parent classes handle this.
+        /// </summary>
+        [SerializePropertyNamesAsCamelCase]
+        public class UpdateOwners : CommittedDocument, IOwners
+        {
+            public string[] Owners { get; set; }
+        }
+
+        /// <summary>
         /// Allows index updating code to apply a new version list to a document.
         /// </summary>
         public interface IVersions : ICommittedDocument
@@ -69,6 +80,14 @@ namespace NuGet.Services.AzureSearch
             string[] Versions { get; set; }
             bool? IsLatestStable { get; set; }
             bool? IsLatest { get; set; }
+        }
+
+        /// <summary>
+        /// Allows index updating code to apply a new list of owners to a document.
+        /// </summary>
+        public interface IOwners : ICommittedDocument
+        {
+            string[] Owners { get; set; }
         }
 
         /// <summary>

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -186,7 +186,11 @@ namespace NuGet.Services.AzureSearch
             bool isLatest) where T : KeyedDocument, SearchDocument.IVersions
         {
             PopulateKey(document, packageId, searchFilters);
-            DocumentUtilities.PopulateCommitted(document, lastUpdatedFromCatalog, lastCommitTimestamp, lastCommitId);
+            DocumentUtilities.PopulateCommitted(
+                document,
+                lastUpdatedFromCatalog,
+                lastCommitTimestamp,
+                lastCommitId);
             document.Versions = versions;
             document.IsLatestStable = isLatestStable;
             document.IsLatest = isLatest;
@@ -247,7 +251,34 @@ namespace NuGet.Services.AzureSearch
                 isLatestStable,
                 isLatest,
                 fullVersion);
+            PopulateOwners(
+                document,
+                owners);
+        }
+
+        private static void PopulateOwners<T>(
+            T document,
+            string[] owners) where T : KeyedDocument, SearchDocument.IOwners
+        {
             document.Owners = owners;
+        }
+
+        public SearchDocument.UpdateOwners UpdateOwners(
+            string packageId,
+            SearchFilters searchFilters,
+            string[] owners)
+        {
+            var document = new SearchDocument.UpdateOwners();
+
+            PopulateKey(document, packageId, searchFilters);
+            DocumentUtilities.PopulateCommitted(
+                document,
+                lastUpdatedFromCatalog: false,
+                lastCommitTimestamp: null,
+                lastCommitId: null);
+            PopulateOwners(document, owners);
+
+            return document;
         }
     }
 }

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
@@ -138,6 +138,42 @@ namespace NuGet.Services.AzureSearch
             }
         }
 
+        public class UpdateOwners : BaseFacts
+        {
+            public UpdateOwners(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task SetsExpectedProperties()
+            {
+                var document = _target.UpdateOwners(
+                    Data.PackageId,
+                    Data.SearchFilters,
+                    Data.Owners);
+
+                SetDocumentLastUpdated(document);
+                var json = await SerializationUtilities.SerializeToJsonAsync(document);
+                Assert.Equal(@"{
+  ""value"": [
+    {
+      ""@search.action"": ""upload"",
+      ""owners"": [
+        ""Microsoft"",
+        ""azure-sdk""
+      ],
+      ""lastUpdatedDocument"": ""2018-12-14T09:30:00+00:00"",
+      ""lastDocumentType"": ""NuGet.Services.AzureSearch.SearchDocument+UpdateOwners"",
+      ""lastUpdatedFromCatalog"": false,
+      ""lastCommitTimestamp"": null,
+      ""lastCommitId"": null,
+      ""key"": ""windowsazure_storage-d2luZG93c2F6dXJlLnN0b3JhZ2U1-IncludePrereleaseAndSemVer2""
+    }
+  ]
+}", json);
+            }
+        }
+
         public class UpdateVersionListFromCatalog : BaseFacts
         {
             public UpdateVersionListFromCatalog(ITestOutputHelper output) : base(output)


### PR DESCRIPTION
Depends on https://github.com/NuGet/NuGet.Services.Metadata/pull/501.
Progress on https://github.com/NuGet/NuGetGallery/issues/6475.

Adds an Azure Search model so we can update just the owners field on a search document.