### PR TITLE
[Azure Search 3] Move IVersionListDataClient down to CatalogIndexActionBuilder

### DIFF
--- a/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/AzureSearchCollectorLogic.cs
+++ b/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/AzureSearchCollectorLogic.cs
@@ -16,7 +16,6 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
     public class AzureSearchCollectorLogic : ICommitCollectorLogic
     {
         private readonly ICatalogClient _catalogClient;
-        private readonly IVersionListDataClient _versionListDataClient;
         private readonly ICatalogIndexActionBuilder _indexActionBuilder;
         private readonly Func<IBatchPusher> _batchPusherFactory;
         private readonly IOptionsSnapshot<Catalog2AzureSearchConfiguration> _options;
@@ -24,14 +23,12 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
         public AzureSearchCollectorLogic(
             ICatalogClient catalogClient,
-            IVersionListDataClient versionListDataClient,
             ICatalogIndexActionBuilder indexActionBuilder,
             Func<IBatchPusher> batchPusherFactory,
             IOptionsSnapshot<Catalog2AzureSearchConfiguration> options,
             ILogger<AzureSearchCollectorLogic> logger)
         {
             _catalogClient = catalogClient ?? throw new ArgumentNullException(nameof(catalogClient));
-            _versionListDataClient = versionListDataClient ?? throw new ArgumentNullException(nameof(versionListDataClient));
             _indexActionBuilder = indexActionBuilder ?? throw new ArgumentNullException(nameof(indexActionBuilder));
             _batchPusherFactory = batchPusherFactory ?? throw new ArgumentNullException(nameof(batchPusherFactory));
             _options = options ?? throw new ArgumentNullException(nameof(options));
@@ -208,11 +205,8 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .Single();
 
-            var versionListDataResult = await _versionListDataClient.ReadAsync(packageId);
-
             return await _indexActionBuilder.AddCatalogEntriesAsync(
                 packageId,
-                versionListDataResult,
                 entries,
                 entryToLeaf);
         }

--- a/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/ICatalogIndexActionBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/ICatalogIndexActionBuilder.cs
@@ -12,7 +12,6 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
     {
         Task<IndexActions> AddCatalogEntriesAsync(
             string packageId,
-            ResultAndAccessCondition<VersionListData> versionListDataResult,
             IReadOnlyList<CatalogCommitItem> latestEntries,
             IReadOnlyDictionary<CatalogCommitItem, PackageDetailsCatalogLeaf> entryToLeaf);
     }

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/AzureSearchCollectorLogicFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/AzureSearchCollectorLogicFacts.cs
@@ -98,14 +98,9 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                 _catalogClient.Verify(x => x.GetPackageDetailsLeafAsync(It.IsAny<string>()), Times.Exactly(1));
                 _catalogClient.Verify(x => x.GetPackageDeleteLeafAsync(It.IsAny<string>()), Times.Never);
 
-                _versionListDataClient.Verify(x => x.ReadAsync("NuGet.Versioning"), Times.Once);
-                _versionListDataClient.Verify(x => x.ReadAsync("NuGet.Frameworks"), Times.Once);
-                _versionListDataClient.Verify(x => x.ReadAsync(It.IsAny<string>()), Times.Exactly(2));
-
                 _catalogIndexActionBuilder.Verify(
                     x => x.AddCatalogEntriesAsync(
                         "NuGet.Versioning",
-                        It.IsAny<ResultAndAccessCondition<VersionListData>>(),
                         It.Is<IReadOnlyList<CatalogCommitItem>>(
                             y => y.Count == 1),
                         It.Is<IReadOnlyDictionary<CatalogCommitItem, PackageDetailsCatalogLeaf>>(
@@ -114,7 +109,6 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                 _catalogIndexActionBuilder.Verify(
                     x => x.AddCatalogEntriesAsync(
                         "NuGet.Frameworks",
-                        It.IsAny<ResultAndAccessCondition<VersionListData>>(),
                         It.Is<IReadOnlyList<CatalogCommitItem>>(
                             y => y.Count == 1),
                         It.Is<IReadOnlyDictionary<CatalogCommitItem, PackageDetailsCatalogLeaf>>(
@@ -176,14 +170,9 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                 _catalogClient.Verify(x => x.GetPackageDetailsLeafAsync("https://example/3"), Times.Once);
                 _catalogClient.Verify(x => x.GetPackageDetailsLeafAsync(It.IsAny<string>()), Times.Exactly(3));
 
-                _versionListDataClient.Verify(x => x.ReadAsync("NuGet.Versioning"), Times.Once);
-                _versionListDataClient.Verify(x => x.ReadAsync("NuGet.Frameworks"), Times.Once);
-                _versionListDataClient.Verify(x => x.ReadAsync(It.IsAny<string>()), Times.Exactly(2));
-
                 _catalogIndexActionBuilder.Verify(
                     x => x.AddCatalogEntriesAsync(
                         "NuGet.Versioning",
-                        It.IsAny<ResultAndAccessCondition<VersionListData>>(),
                         It.Is<IReadOnlyList<CatalogCommitItem>>(
                             y => y.Count == 2),
                         It.Is<IReadOnlyDictionary<CatalogCommitItem, PackageDetailsCatalogLeaf>>(
@@ -192,7 +181,6 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                 _catalogIndexActionBuilder.Verify(
                     x => x.AddCatalogEntriesAsync(
                         "NuGet.Frameworks",
-                        It.IsAny<ResultAndAccessCondition<VersionListData>>(),
                         It.Is<IReadOnlyList<CatalogCommitItem>>(
                             y => y.Count == 1),
                         It.Is<IReadOnlyDictionary<CatalogCommitItem, PackageDetailsCatalogLeaf>>(
@@ -248,7 +236,6 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
         public abstract class BaseFacts
         {
             protected readonly Mock<ICatalogClient> _catalogClient;
-            protected readonly Mock<IVersionListDataClient> _versionListDataClient;
             protected readonly Mock<ICatalogIndexActionBuilder> _catalogIndexActionBuilder;
             protected readonly Mock<IBatchPusher> _batchPusher;
             protected readonly Mock<IOptionsSnapshot<Catalog2AzureSearchConfiguration>> _options;
@@ -259,7 +246,6 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
             public BaseFacts(ITestOutputHelper output)
             {
                 _catalogClient = new Mock<ICatalogClient>();
-                _versionListDataClient = new Mock<IVersionListDataClient>();
                 _catalogIndexActionBuilder = new Mock<ICatalogIndexActionBuilder>();
                 _batchPusher = new Mock<IBatchPusher>();
                 _options = new Mock<IOptionsSnapshot<Catalog2AzureSearchConfiguration>>();
@@ -271,7 +257,6 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
                 _target = new AzureSearchCollectorLogic(
                     _catalogClient.Object,
-                    _versionListDataClient.Object,
                     _catalogIndexActionBuilder.Object,
                     () => _batchPusher.Object,
                     _options.Object,

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/CatalogIndexActionBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/CatalogIndexActionBuilderFacts.cs
@@ -34,7 +34,6 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
                 var ex = await Assert.ThrowsAsync<ArgumentException>(() => _target.AddCatalogEntriesAsync(
                     _packageId,
-                    _versionListDataResult,
                     _latestEntries,
                     _entryToLeaf));
                 Assert.Contains("There must be at least one catalog item to process.", ex.Message);
@@ -46,7 +45,6 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
             {
                 var indexActions = await _target.AddCatalogEntriesAsync(
                     _packageId,
-                    _versionListDataResult,
                     _latestEntries,
                     _entryToLeaf);
 
@@ -80,7 +78,6 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
                 var indexActions = await _target.AddCatalogEntriesAsync(
                     _packageId,
-                    _versionListDataResult,
                     _latestEntries,
                     _entryToLeaf);
 
@@ -120,7 +117,6 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
                 var indexActions = await _target.AddCatalogEntriesAsync(
                     _packageId,
-                    _versionListDataResult,
                     _latestEntries,
                     _entryToLeaf);
 
@@ -177,7 +173,6 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
                 var indexActions = await _target.AddCatalogEntriesAsync(
                     _packageId,
-                    _versionListDataResult,
                     _latestEntries,
                     _entryToLeaf);
 
@@ -253,7 +248,6 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
                 var indexActions = await _target.AddCatalogEntriesAsync(
                     _packageId,
-                    _versionListDataResult,
                     _latestEntries,
                     _entryToLeaf);
 
@@ -321,7 +315,6 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
                 var indexActions = await _target.AddCatalogEntriesAsync(
                     _packageId,
-                    _versionListDataResult,
                     _latestEntries,
                     _entryToLeaf);
 
@@ -419,7 +412,6 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
                 var indexActions = await _target.AddCatalogEntriesAsync(
                     _packageId,
-                    _versionListDataResult,
                     _latestEntries,
                     _entryToLeaf);
 
@@ -478,7 +470,6 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
                 var indexActions = await _target.AddCatalogEntriesAsync(
                     _packageId,
-                    _versionListDataResult,
                     _latestEntries,
                     _entryToLeaf);
 
@@ -522,7 +513,6 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
                 var indexActions = await _target.AddCatalogEntriesAsync(
                     _packageId,
-                    _versionListDataResult,
                     _latestEntries,
                     _entryToLeaf);
 
@@ -553,7 +543,6 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
                 var indexActions = await _target.AddCatalogEntriesAsync(
                     _packageId,
-                    _versionListDataResult,
                     _latestEntries,
                     _entryToLeaf);
 
@@ -577,6 +566,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
         public abstract class BaseFacts
         {
+            protected readonly Mock<IVersionListDataClient> _versionListDataClient;
             protected readonly Mock<ICatalogLeafFetcher> _fetcher;
             protected readonly Mock<ISearchDocumentBuilder> _search;
             protected readonly Mock<IHijackDocumentBuilder> _hijack;
@@ -593,6 +583,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
             public BaseFacts(ITestOutputHelper output)
             {
+                _versionListDataClient = new Mock<IVersionListDataClient>();
                 _fetcher = new Mock<ICatalogLeafFetcher>();
                 _search = new Mock<ISearchDocumentBuilder>();
                 _hijack = new Mock<IHijackDocumentBuilder>();
@@ -620,6 +611,10 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                 _latestCatalogLeaves = new LatestCatalogLeaves(
                     new HashSet<NuGetVersion>(),
                     new Dictionary<NuGetVersion, PackageDetailsCatalogLeaf>());
+
+                _versionListDataClient
+                    .Setup(x => x.ReadAsync(It.IsAny<string>()))
+                    .ReturnsAsync(() => _versionListDataResult);
 
                 _search
                     .Setup(x => x.LatestFlagsOrNull(It.IsAny<VersionLists>(), It.IsAny<SearchFilters>()))
@@ -677,6 +672,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                     .ReturnsAsync(() => _latestCatalogLeaves);
 
                 _target = new CatalogIndexActionBuilder(
+                    _versionListDataClient.Object,
                     _fetcher.Object,
                     _search.Object,
                     _hijack.Object,


### PR DESCRIPTION
This is a small refactor. It just pushes the `IVersionListDataClient` down one level since it can become an implementation detail of a lower level component.

Depends on https://github.com/NuGet/NuGet.Services.Metadata/pull/502.
Progress on https://github.com/NuGet/NuGetGallery/issues/6475.