### PR TITLE
Initialize the owners.v2.json file in Db2AzureSearch

### DIFF
--- a/src/NuGet.Jobs.Db2AzureSearch/NuGet.Jobs.Db2AzureSearch.csproj
+++ b/src/NuGet.Jobs.Db2AzureSearch/NuGet.Jobs.Db2AzureSearch.csproj
@@ -71,9 +71,9 @@
   <Import Project="$(SignPath)\sign.targets" Condition="Exists('$(SignPath)\sign.targets')" />
   <Import Project="$(SignPath)\sign.microbuild.targets" Condition="Exists('$(SignPath)\sign.microbuild.targets')" />
   <ItemGroup>
-    <ExecutablesToNotSign Include="nssm.exe" />
-    <PowerShellScriptsToNotSign Include="Functions.ps1" />
-    <PowerShellScriptsToNotSign Include="PreDeploy.ps1" />
+    <ExecutablesToNotSign Include="nssm.exe" Visible="false" />
+    <PowerShellScriptsToNotSign Include="Functions.ps1" Visible="false" />
+    <PowerShellScriptsToNotSign Include="PreDeploy.ps1" Visible="false" />
   </ItemGroup>
   <Import Project="$(SignPath)\sign.scripts.targets" Condition="Exists('$(SignPath)\sign.scripts.targets')" />
   <Import Project="..\..\sign.thirdparty.targets" />

--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -163,6 +163,7 @@ namespace NuGet.Services.AzureSearch
                     c.Resolve<Func<IBatchPusher>>(),
                     c.Resolve<ICatalogClient>(),
                     c.ResolveKeyed<IStorageFactory>(key),
+                    c.Resolve<IOwnerDataClient>(),
                     c.Resolve<IOptionsSnapshot<Db2AzureSearchConfiguration>>(),
                     c.Resolve<ILogger<Db2AzureSearchCommand>>()));
 

--- a/src/NuGet.Services.AzureSearch/IOwnerDataClient.cs
+++ b/src/NuGet.Services.AzureSearch/IOwnerDataClient.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuGetGallery;
 
-namespace NuGet.Services.AzureSearch.Owners2AzureSearch
+namespace NuGet.Services.AzureSearch
 {
     /// <summary>
     /// The purpose of this interface is allow reading and writing owner information from storage. The Catalog2Owners

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -53,9 +53,9 @@
     <Compile Include="Owners2AzureSearch\IOwnerSetComparer.cs" />
     <Compile Include="Owners2AzureSearch\OwnerIndexActionBuilder.cs" />
     <Compile Include="Owners2AzureSearch\OwnerSetComparer.cs" />
-    <Compile Include="Owners2AzureSearch\PackageIdToOwnersBuilder.cs" />
-    <Compile Include="Owners2AzureSearch\IOwnerDataClient.cs" />
-    <Compile Include="Owners2AzureSearch\OwnerDataClient.cs" />
+    <Compile Include="PackageIdToOwnersBuilder.cs" />
+    <Compile Include="IOwnerDataClient.cs" />
+    <Compile Include="OwnerDataClient.cs" />
     <Compile Include="ScoringProfiles\DownloadCountBoosterProfile.cs" />
     <Compile Include="Owners2AzureSearch\Owners2AzureSearchCommand.cs" />
     <Compile Include="SearchService\AzureSearchQueryBuilder.cs" />

--- a/src/NuGet.Services.AzureSearch/OwnerDataClient.cs
+++ b/src/NuGet.Services.AzureSearch/OwnerDataClient.cs
@@ -12,7 +12,7 @@ using Microsoft.WindowsAzure.Storage;
 using Newtonsoft.Json;
 using NuGetGallery;
 
-namespace NuGet.Services.AzureSearch.Owners2AzureSearch
+namespace NuGet.Services.AzureSearch
 {
     public class OwnerDataClient : IOwnerDataClient
     {

--- a/src/NuGet.Services.AzureSearch/PackageIdToOwnersBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/PackageIdToOwnersBuilder.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
-namespace NuGet.Services.AzureSearch.Owners2AzureSearch
+namespace NuGet.Services.AzureSearch
 {
     public class PackageIdToOwnersBuilder
     {

--- a/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/NewPackageRegistrationProducerFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/NewPackageRegistrationProducerFacts.cs
@@ -164,7 +164,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
             }
 
             [Fact]
-            public async Task ProducersWorkPerPackageRegistration()
+            public async Task ProducesWorkPerPackageRegistration()
             {
                 _config.DatabaseBatchSize = 4;
                 _packageRegistrations.Add(new PackageRegistration
@@ -201,12 +201,20 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                         new Package { Version = "4.0.0" },
                     },
                 });
+                _packageRegistrations.Add(new PackageRegistration
+                {
+                    Key = 4,
+                    Id = "D",
+                    DownloadCount = 26,
+                    Owners = new[] { new User { Username = "OwnerE" } },
+                    Packages = new Package[0],
+                });
                 InitializePackagesFromPackageRegistrations();
 
                 await _target.ProduceWorkAsync(_work, _token);
 
                 var work = _work.Reverse().ToList();
-                Assert.Equal(3, work.Count);
+                Assert.Equal(4, work.Count);
 
                 Assert.Equal("A", work[0].PackageId);
                 Assert.Equal("1.0.0", work[0].Packages[0].Version);
@@ -223,6 +231,11 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                 Assert.Equal("4.0.0", work[2].Packages[0].Version);
                 Assert.Equal(new[] { "OwnerC", "OwnerD" }, work[2].Owners);
                 Assert.Equal(25, work[2].TotalDownloadCount);
+
+                Assert.Equal("D", work[3].PackageId);
+                Assert.Empty(work[3].Packages);
+                Assert.Equal(new[] { "OwnerE" }, work[3].Owners);
+                Assert.Equal(26, work[3].TotalDownloadCount);
             }
 
             private void InitializePackagesFromPackageRegistrations()


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/7114

Chose to make a small design change. Now all package registrations are processed, not just ones that have packages. If there are no versions, however, no index changes will be made.

This change is so the resulting owners.v2.json has owners even for package registrations currently with no versions. The source of this case is package deletes.

Also, come code was moved out og the `Owners2AzureSearch` namespace since it is now used by more than one job.