### PR TITLE
Fetch owner information from DB in Catalog2AzureSearch

### DIFF
--- a/src/NuGet.Services.AzureSearch/AsDisposable.cs
+++ b/src/NuGet.Services.AzureSearch/AsDisposable.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.AzureSearch
+{
+    public static class AsDisposable
+    {
+        public static AsDisposable<T> Create<T>(T value) where T : class
+        {
+            return new AsDisposable<T>(value);
+        }
+    }
+
+    /// <summary>
+    /// This is invented because <see cref="IEntitiesContext"/> does not implement <see cref="IDisposable"/> but
+    /// the primary implementation is disposable.
+    /// </summary>
+    public class AsDisposable<T> : IDisposable where T : class
+    {
+        public AsDisposable(T value)
+        {
+            Value = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        public T Value { get; }
+
+        public void Dispose()
+        {
+            (Value as IDisposable)?.Dispose();
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/DatabaseOwnerFetcher.cs
+++ b/src/NuGet.Services.AzureSearch/DatabaseOwnerFetcher.cs
@@ -3,16 +3,21 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NuGet.Jobs;
 using NuGet.Jobs.Configuration;
 
-namespace NuGet.Services.AzureSearch.Owners2AzureSearch
+namespace NuGet.Services.AzureSearch
 {
     public class DatabaseOwnerFetcher : IDatabaseOwnerFetcher
     {
+        private static readonly string[] EmptyStringArray = new string[0];
+
         private readonly ISqlConnectionFactory<GalleryDbConfiguration> _connectionFactory;
+        private readonly IEntitiesContextFactory _entitiesContextFactory;
         private readonly ILogger<DatabaseOwnerFetcher> _logger;
 
         private const string Sql = @"
@@ -26,10 +31,45 @@ INNER JOIN Users u (NOLOCK) ON pro.UserKey = u.[Key]
 
         public DatabaseOwnerFetcher(
             ISqlConnectionFactory<GalleryDbConfiguration> connectionFactory,
+            IEntitiesContextFactory entitiesContextFactory,
             ILogger<DatabaseOwnerFetcher> logger)
         {
             _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+            _entitiesContextFactory = entitiesContextFactory ?? throw new ArgumentNullException(nameof(entitiesContextFactory));
             _logger = logger;
+        }
+
+        public async Task<string[]> GetOwnersOrEmptyAsync(string id)
+        {
+            using (var entitiesContext = AsDisposable.Create(await _entitiesContextFactory.CreateAsync(readOnly: true)))
+            {
+                _logger.LogInformation("Fetching owners for package registration with ID {PackageId}.", id);
+                var owners = await entitiesContext
+                    .Value
+                    .PackageRegistrations
+                    .Where(pr => pr.Id == id)
+                    .Select(pr => pr.Owners.Select(u => u.Username).ToList())
+                    .FirstOrDefaultAsync();
+
+                if (owners == null)
+                {
+                    _logger.LogWarning("No package registration with ID {PackageId} was found. Assuming no owners.", id);
+                    return EmptyStringArray;
+                }
+
+                if (owners.Count == 0)
+                {
+                    _logger.LogInformation("The package registration with ID {PackageId} has no owners.", id);
+                    return EmptyStringArray;
+                }
+
+                // Sort the usernames in a consistent manner.
+                var sortedOwners = owners
+                    .OrderBy(o => o, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+                _logger.LogInformation("The package registration with ID {PackageId} has {Count} owners.", id, sortedOwners.Length);
+                return sortedOwners;
+            }
         }
 
         public async Task<SortedDictionary<string, SortedSet<string>>> GetPackageIdToOwnersAsync()

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchCommand.cs
@@ -129,6 +129,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
 
         private async Task PushAllPackageRegistrationsAsync(CancellationTokenSource cancelledCts, CancellationTokenSource produceWorkCts, ConcurrentBag<IdAndValue<IReadOnlyList<string>>> allOwners)
         {
+            _logger.LogInformation("Pushing all packages to Azure Search and initializing version lists.");
             var allWork = new ConcurrentBag<NewPackageRegistration>();
             var producerTask = ProduceWorkAsync(allWork, produceWorkCts, cancelledCts.Token);
             var consumerTasks = Enumerable
@@ -146,6 +147,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
 
             await firstTask;
             await Task.WhenAll(allTasks);
+            _logger.LogInformation("Done initializing the Azure Search indexes and version lists.");
         }
 
         private async Task WriteOwnerDataAsync(ConcurrentBag<IdAndValue<IReadOnlyList<string>>> allOwners)
@@ -160,6 +162,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
             await _ownerDataClient.ReplaceLatestIndexedAsync(
                 ownersBuilder.GetResult(),
                 AccessConditionWrapper.GenerateIfNotExistsCondition());
+            _logger.LogInformation("Done uploading the initial owners file.");
         }
 
         private async Task ProduceWorkAsync(

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationProducer.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationProducer.cs
@@ -246,33 +246,6 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
             return AsDisposable.Create(await _contextFactory.CreateAsync(readOnly: true));
         }
 
-        private static class AsDisposable
-        {
-            public static AsDisposable<T> Create<T>(T value) where T : class
-            {
-                return new AsDisposable<T>(value);
-            }
-        }
-
-        /// <summary>
-        /// This is invented because <see cref="IEntitiesContext"/> does not implement <see cref="IDisposable"/> but
-        /// the primary implementation is disposable.
-        /// </summary>
-        private class AsDisposable<T> : IDisposable where T : class
-        {
-            public AsDisposable(T value)
-            {
-                Value = value ?? throw new ArgumentNullException(nameof(value));
-            }
-
-            public T Value { get; }
-
-            public void Dispose()
-            {
-                (Value as IDisposable)?.Dispose();
-            }
-        }
-
         private class PackageRegistrationRange
         {
             public PackageRegistrationRange(int minKey, int? maxKey, int packageCount)

--- a/src/NuGet.Services.AzureSearch/EntitiesContextFactory.cs
+++ b/src/NuGet.Services.AzureSearch/EntitiesContextFactory.cs
@@ -7,7 +7,7 @@ using NuGet.Jobs;
 using NuGet.Jobs.Configuration;
 using NuGetGallery;
 
-namespace NuGet.Services.AzureSearch.Db2AzureSearch
+namespace NuGet.Services.AzureSearch
 {
     public class EntitiesContextFactory : IEntitiesContextFactory
     {

--- a/src/NuGet.Services.AzureSearch/IDatabaseOwnerFetcher.cs
+++ b/src/NuGet.Services.AzureSearch/IDatabaseOwnerFetcher.cs
@@ -4,13 +4,20 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace NuGet.Services.AzureSearch.Owners2AzureSearch
+namespace NuGet.Services.AzureSearch
 {
     /// <summary>
     /// Fetches the current owner information from the database.
     /// </summary>
     public interface IDatabaseOwnerFetcher
     {
+        /// <summary>
+        /// Fetch the owners for a specific package ID. If the package registration does not exist or if there are no
+        /// owners, an empty string array is returned. If there are owners, they are sorted.
+        /// <param name="id">The package ID to fetch owners for.</param>
+        /// <returns>The sorted array of owners. Can be empty but won't ever be null.</returns>
+        Task<string[]> GetOwnersOrEmptyAsync(string id);
+
         /// <summary>
         /// Fetch a mapping from package ID to set of owners for each package registration (i.e. package ID) in the
         /// gallery database.

--- a/src/NuGet.Services.AzureSearch/IEntitiesContextFactory.cs
+++ b/src/NuGet.Services.AzureSearch/IEntitiesContextFactory.cs
@@ -4,7 +4,7 @@
 using System.Threading.Tasks;
 using NuGetGallery;
 
-namespace NuGet.Services.AzureSearch.Db2AzureSearch
+namespace NuGet.Services.AzureSearch
 {
     public interface IEntitiesContextFactory
     {

--- a/src/NuGet.Services.AzureSearch/ISearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/ISearchDocumentBuilder.cs
@@ -31,6 +31,16 @@ namespace NuGet.Services.AzureSearch
             bool isLatestStable,
             bool isLatest);
 
+        SearchDocument.UpdateVersionListAndOwners UpdateVersionListAndOwnersFromCatalog(
+            string packageId,
+            SearchFilters searchFilters,
+            DateTimeOffset lastCommitTimestamp,
+            string lastCommitId,
+            string[] versions,
+            bool isLatestStable,
+            bool isLatest,
+            string[] owners);
+
         SearchDocument.Full FullFromDb(
             string packageId, 
             SearchFilters searchFilters,
@@ -49,6 +59,7 @@ namespace NuGet.Services.AzureSearch
             bool isLatest,
             string normalizedVersion,
             string fullVersion,
-            PackageDetailsCatalogLeaf leaf);
+            PackageDetailsCatalogLeaf leaf,
+            string[] owners);
     }
 }

--- a/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
@@ -17,30 +17,23 @@ namespace NuGet.Services.AzureSearch
         /// download count).
         /// </summary>
         [SerializePropertyNamesAsCamelCase]
-        public class Full : AddFirst
+        public class Full : UpdateLatest
         {
             [IsFilterable]
             public long? TotalDownloadCount { get; set; }
         }
 
         /// <summary>
-        /// Used when processing <see cref="SearchIndexChangeType.AddFirst"/>.
+        /// Used when processing <see cref="SearchIndexChangeType.AddFirst"/>,
+        /// <see cref="SearchIndexChangeType.UpdateLatest"/> or <see cref="SearchIndexChangeType.DowngradeLatest"/>.
         /// </summary>
         [SerializePropertyNamesAsCamelCase]
-        public class AddFirst : UpdateLatest, IOwners
+        public class UpdateLatest : BaseMetadataDocument, IVersions, IOwners
         {
             [IsSearchable]
             [Analyzer(ExactMatchCustomAnalyzer.Name)]
             public string[] Owners { get; set; }
-        }
 
-        /// <summary>
-        /// Used when processing <see cref="SearchIndexChangeType.UpdateLatest"/> or
-        /// <see cref="SearchIndexChangeType.DowngradeLatest"/>.
-        /// </summary>
-        [SerializePropertyNamesAsCamelCase]
-        public class UpdateLatest : BaseMetadataDocument, IVersions
-        {
             [IsFilterable]
             public string SearchFilters { get; set; }
 
@@ -48,6 +41,18 @@ namespace NuGet.Services.AzureSearch
             public string[] Versions { get; set; }
             public bool? IsLatestStable { get; set; }
             public bool? IsLatest { get; set; }
+        }
+
+        /// <summary>
+        /// Used when processing <see cref="SearchIndexChangeType.UpdateVersionList"/> and the owner information has
+        /// been already been fetched for the purposes of <see cref="UpdateLatest"/>. Note that this model does not
+        /// need any analyzer or other Azure Search attributes since it is not used for index creation. The
+        /// <see cref="Full"/> and its parent classes handle this.
+        /// </summary>
+        [SerializePropertyNamesAsCamelCase]
+        public class UpdateVersionListAndOwners : UpdateVersionList, IOwners
+        {
+            public string[] Owners { get; set; }
         }
 
         /// <summary>

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -47,8 +47,9 @@
     <Compile Include="Analysis\IdentifierCustomTokenFilter.cs" />
     <Compile Include="Analysis\PackageIdCustomAnalyzer.cs" />
     <Compile Include="Analysis\PackageIdCustomTokenizer.cs" />
-    <Compile Include="Owners2AzureSearch\DatabaseOwnerFetcher.cs" />
-    <Compile Include="Owners2AzureSearch\IDatabaseOwnerFetcher.cs" />
+    <Compile Include="DatabaseOwnerFetcher.cs" />
+    <Compile Include="AsDisposable.cs" />
+    <Compile Include="IDatabaseOwnerFetcher.cs" />
     <Compile Include="Owners2AzureSearch\IOwnerIndexActionBuilder.cs" />
     <Compile Include="Owners2AzureSearch\IOwnerSetComparer.cs" />
     <Compile Include="Owners2AzureSearch\OwnerIndexActionBuilder.cs" />
@@ -88,9 +89,9 @@
     <Compile Include="Catalog2AzureSearch\ICollector.cs" />
     <Compile Include="Db2AzureSearch\Db2AzureSearchCommand.cs" />
     <Compile Include="Db2AzureSearch\Db2AzureSearchConfiguration.cs" />
-    <Compile Include="Db2AzureSearch\EntitiesContextFactory.cs" />
+    <Compile Include="EntitiesContextFactory.cs" />
     <Compile Include="Db2AzureSearch\EnumerableExtensions.cs" />
-    <Compile Include="Db2AzureSearch\IEntitiesContextFactory.cs" />
+    <Compile Include="IEntitiesContextFactory.cs" />
     <Compile Include="Db2AzureSearch\INewPackageRegistrationProducer.cs" />
     <Compile Include="Db2AzureSearch\NewPackageRegistration.cs" />
     <Compile Include="Db2AzureSearch\NewPackageRegistrationProducer.cs" />

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -116,6 +116,35 @@ namespace NuGet.Services.AzureSearch
             return document;
         }
 
+        public SearchDocument.UpdateVersionListAndOwners UpdateVersionListAndOwnersFromCatalog(
+            string packageId,
+            SearchFilters searchFilters,
+            DateTimeOffset lastCommitTimestamp,
+            string lastCommitId,
+            string[] versions,
+            bool isLatestStable,
+            bool isLatest,
+            string[] owners)
+        {
+            var document = new SearchDocument.UpdateVersionListAndOwners();
+
+            PopulateVersions(
+                document,
+                packageId,
+                searchFilters,
+                lastUpdatedFromCatalog: true,
+                lastCommitTimestamp: lastCommitTimestamp,
+                lastCommitId: lastCommitId,
+                versions: versions,
+                isLatestStable: isLatestStable,
+                isLatest: isLatest);
+            PopulateOwners(
+                document,
+                owners);
+
+            return document;
+        }
+
         public SearchDocument.UpdateLatest UpdateLatestFromCatalog(
             SearchFilters searchFilters,
             string[] versions,
@@ -123,7 +152,8 @@ namespace NuGet.Services.AzureSearch
             bool isLatest,
             string normalizedVersion,
             string fullVersion,
-            PackageDetailsCatalogLeaf leaf)
+            PackageDetailsCatalogLeaf leaf,
+            string[] owners)
         {
             var document = new SearchDocument.UpdateLatest();
 
@@ -137,7 +167,8 @@ namespace NuGet.Services.AzureSearch
                 versions: versions,
                 isLatestStable: isLatestStable,
                 isLatest: isLatest,
-                fullVersion: fullVersion);
+                fullVersion: fullVersion,
+                owners: owners);
             DocumentUtilities.PopulateMetadata(document, normalizedVersion, leaf);
 
             return document;
@@ -156,7 +187,7 @@ namespace NuGet.Services.AzureSearch
         {
             var document = new SearchDocument.Full();
 
-            PopulateAddFirst(
+            PopulateUpdateLatest(
                 document,
                 packageId,
                 searchFilters,
@@ -211,7 +242,8 @@ namespace NuGet.Services.AzureSearch
             string[] versions,
             bool isLatestStable,
             bool isLatest,
-            string fullVersion)
+            string fullVersion,
+            string[] owners)
         {
             PopulateVersions(
                 document,
@@ -225,32 +257,6 @@ namespace NuGet.Services.AzureSearch
                 isLatest);
             document.SearchFilters = DocumentUtilities.GetSearchFilterString(searchFilters);
             document.FullVersion = fullVersion;
-        }
-
-        private static void PopulateAddFirst(
-            SearchDocument.AddFirst document,
-            string packageId,
-            SearchFilters searchFilters,
-            bool lastUpdatedFromCatalog,
-            DateTimeOffset? lastCommitTimestamp,
-            string lastCommitId,
-            string[] versions,
-            bool isLatestStable,
-            bool isLatest,
-            string fullVersion,
-            string[] owners)
-        {
-            PopulateUpdateLatest(
-                document,
-                packageId,
-                searchFilters,
-                lastUpdatedFromCatalog,
-                lastCommitTimestamp,
-                lastCommitId,
-                versions,
-                isLatestStable,
-                isLatest,
-                fullVersion);
             PopulateOwners(
                 document,
                 owners);

--- a/tests/NuGet.Services.AzureSearch.Tests/DatabaseOwnerFetcherFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/DatabaseOwnerFetcherFacts.cs
@@ -1,0 +1,162 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Jobs;
+using NuGet.Jobs.Configuration;
+using NuGet.Services.AzureSearch.Support;
+using NuGet.Services.Entities;
+using NuGetGallery;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class DatabaseOwnerFetcherFacts
+    {
+        public class GetOwnersOrEmptyAsync : Facts
+        {
+            public GetOwnersOrEmptyAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task ReturnsEmptyArrayWhenPackageRegistrationDoesNotExist()
+            {
+                var owners = await Target.GetOwnersOrEmptyAsync(Data.PackageId);
+
+                Assert.Empty(owners);
+            }
+
+            [Fact]
+            public async Task ReturnsEmptyArrayWhenPackageRegistrationHasNoOwners()
+            {
+                PackageRegistrations.Add(new PackageRegistration
+                {
+                    Id = Data.PackageId,
+                    Owners = new List<User>(),
+                });
+
+                var owners = await Target.GetOwnersOrEmptyAsync(Data.PackageId);
+
+                Assert.Empty(owners);
+            }
+
+            [Fact]
+            public async Task ReturnsSortedOwners()
+            {
+                PackageRegistrations.Add(new PackageRegistration
+                {
+                    Id = Data.PackageId,
+                    Owners = new List<User>
+                    {
+                        new User { Username = "nuget" },
+                        new User { Username = "aspnet" },
+                        new User { Username = "EntityFramework" },
+                        new User { Username = "Microsoft" },
+                    }
+                });
+
+                var owners = await Target.GetOwnersOrEmptyAsync(Data.PackageId);
+
+                Assert.Equal(new[] { "aspnet", "EntityFramework", "Microsoft", "nuget"}, owners);
+                EntitiesContextFactory.Verify(x => x.CreateAsync(true), Times.Once);
+                EntitiesContextFactory.Verify(x => x.CreateAsync(It.IsAny<bool>()), Times.Once);
+            }
+
+            [Fact]
+            public async Task DisposesEntitiesContext()
+            {
+                var entitiesContext = new DisposableEntitiesContext();
+                EntitiesContextFactory.Setup(x => x.CreateAsync(It.IsAny<bool>())).ReturnsAsync(entitiesContext);
+
+                var owners = await Target.GetOwnersOrEmptyAsync(Data.PackageId);
+
+                Assert.True(entitiesContext.Disposed, "The entities context should have been disposed.");
+            }
+        }
+
+        public abstract class Facts
+        {
+            public Facts(ITestOutputHelper output)
+            {
+                SqlConnectionFactory = new Mock<ISqlConnectionFactory<GalleryDbConfiguration>>();
+                EntitiesContextFactory = new Mock<IEntitiesContextFactory>();
+                EntitiesContext = new Mock<IEntitiesContext>();
+                Logger = output.GetLogger<DatabaseOwnerFetcher>();
+
+                PackageRegistrations = DbSetMockFactory.Create<PackageRegistration>();
+
+                EntitiesContextFactory
+                    .Setup(x => x.CreateAsync(It.IsAny<bool>()))
+                    .ReturnsAsync(() => EntitiesContext.Object);
+                EntitiesContext
+                    .Setup(x => x.PackageRegistrations)
+                    .Returns(() => PackageRegistrations);
+
+                Target = new DatabaseOwnerFetcher(
+                    SqlConnectionFactory.Object,
+                    EntitiesContextFactory.Object,
+                    Logger);
+            }
+
+            public Mock<ISqlConnectionFactory<GalleryDbConfiguration>> SqlConnectionFactory { get; }
+            public Mock<IEntitiesContextFactory> EntitiesContextFactory { get; }
+            public Mock<IEntitiesContext> EntitiesContext { get; }
+            public RecordingLogger<DatabaseOwnerFetcher> Logger { get; }
+            public DbSet<PackageRegistration> PackageRegistrations { get; }
+            public DatabaseOwnerFetcher Target { get; }
+        }
+
+        private class DisposableEntitiesContext : IEntitiesContext, IDisposable
+        {
+            public DbSet<Certificate> Certificates { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public DbSet<PackageRegistration> PackageRegistrations { get; set; } = DbSetMockFactory.Create<PackageRegistration>();
+            public DbSet<Credential> Credentials { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public DbSet<Scope> Scopes { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public DbSet<User> Users { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public DbSet<UserSecurityPolicy> UserSecurityPolicies { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public DbSet<ReservedNamespace> ReservedNamespaces { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public DbSet<UserCertificate> UserCertificates { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public DbSet<SymbolPackage> SymbolPackages { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public DbSet<Cve> Cves { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public DbSet<Cwe> Cwes { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public bool Disposed { get; private set; }
+
+            public void DeleteOnCommit<T>(T entity) where T : class
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Dispose()
+            {
+                Disposed = true;
+            }
+
+            public IDatabase GetDatabase()
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<int> SaveChangesAsync()
+            {
+                throw new NotImplementedException();
+            }
+
+            public DbSet<T> Set<T>() where T : class
+            {
+                throw new NotImplementedException();
+            }
+
+            public void SetCommandTimeout(int? seconds)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Catalog2AzureSearch\Integration\InMemoryDocumentsOperations.cs" />
     <Compile Include="Catalog2AzureSearch\Integration\InMemoryFileReference.cs" />
     <Compile Include="Catalog2AzureSearch\Integration\InMemoryRegistrationClient.cs" />
+    <Compile Include="DatabaseOwnerFetcherFacts.cs" />
     <Compile Include="Db2AzureSearch\Db2AzureSearchCommandFacts.cs" />
     <Compile Include="Db2AzureSearch\EnumerableExtensionsFacts.cs" />
     <Compile Include="Db2AzureSearch\NewPackageRegistrationProducerFacts.cs" />

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
@@ -222,6 +222,59 @@ namespace NuGet.Services.AzureSearch
             }
         }
 
+        public class UpdateVersionListAndOwnersFromCatalog : BaseFacts
+        {
+            public UpdateVersionListAndOwnersFromCatalog(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Theory]
+            [InlineData(false, false)]
+            [InlineData(false, true)]
+            [InlineData(true, false)]
+            [InlineData(true, true)]
+            public async Task SetsExpectedProperties(bool isLatestStable, bool isLatest)
+            {
+                var document = _target.UpdateVersionListAndOwnersFromCatalog(
+                    Data.PackageId,
+                    Data.SearchFilters,
+                    Data.CommitTimestamp,
+                    Data.CommitId,
+                    Data.Versions,
+                    isLatestStable,
+                    isLatest,
+                    Data.Owners);
+
+                SetDocumentLastUpdated(document);
+                var json = await SerializationUtilities.SerializeToJsonAsync(document);
+                Assert.Equal(@"{
+  ""value"": [
+    {
+      ""@search.action"": ""upload"",
+      ""owners"": [
+        ""Microsoft"",
+        ""azure-sdk""
+      ],
+      ""versions"": [
+        ""1.0.0"",
+        ""2.0.0+git"",
+        ""3.0.0-alpha.1"",
+        ""7.1.2-alpha+git""
+      ],
+      ""isLatestStable"": " + isLatestStable.ToString().ToLowerInvariant() + @",
+      ""isLatest"": " + isLatest.ToString().ToLowerInvariant() + @",
+      ""lastUpdatedDocument"": ""2018-12-14T09:30:00+00:00"",
+      ""lastDocumentType"": ""NuGet.Services.AzureSearch.SearchDocument+UpdateVersionListAndOwners"",
+      ""lastUpdatedFromCatalog"": true,
+      ""lastCommitTimestamp"": ""2018-12-13T12:30:00+00:00"",
+      ""lastCommitId"": ""6b9b24dd-7aec-48ae-afc1-2a117e3d50d1"",
+      ""key"": ""windowsazure_storage-d2luZG93c2F6dXJlLnN0b3JhZ2U1-IncludePrereleaseAndSemVer2""
+    }
+  ]
+}", json);
+            }
+        }
+
         public class UpdateLatestFromCatalog : BaseFacts
         {
             public UpdateLatestFromCatalog(ITestOutputHelper output) : base(output)
@@ -242,7 +295,8 @@ namespace NuGet.Services.AzureSearch
                     isLatest: true,
                     normalizedVersion: Data.NormalizedVersion,
                     fullVersion: Data.FullVersion,
-                    leaf: leaf);
+                    leaf: leaf,
+                    owners: Data.Owners);
 
                 Assert.Equal(Data.PackageId.ToLowerInvariant(), document.SortableTitle);
             }
@@ -258,7 +312,8 @@ namespace NuGet.Services.AzureSearch
                     isLatest: true,
                     normalizedVersion: Data.NormalizedVersion,
                     fullVersion: Data.FullVersion,
-                    leaf: Data.Leaf);
+                    leaf: Data.Leaf,
+                    owners: Data.Owners);
 
                 SetDocumentLastUpdated(document);
                 var json = await SerializationUtilities.SerializeToJsonAsync(document);
@@ -266,6 +321,10 @@ namespace NuGet.Services.AzureSearch
   ""value"": [
     {
       ""@search.action"": ""upload"",
+      ""owners"": [
+        ""Microsoft"",
+        ""azure-sdk""
+      ],
       ""searchFilters"": """ + expected + @""",
       ""fullVersion"": ""7.1.2-alpha+git"",
       ""versions"": [
@@ -337,7 +396,8 @@ namespace NuGet.Services.AzureSearch
                     isLatest: true,
                     normalizedVersion: Data.NormalizedVersion,
                     fullVersion: Data.FullVersion,
-                    leaf: leaf);
+                    leaf: leaf,
+                    owners: Data.Owners);
 
                 Assert.Null(document.RequiresLicenseAcceptance);
             }


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/7113.

1. When the latest version on any search document is changed or reflowed, fetch the owner from DB. I chose this cadence so that we can easily reflow owner information into the index by reflowing the latest version
1. Remove the `SearchDocument.AddFirst` model. This was based off of a previous notion of how owners worked.
1. Add `SearchDocument.UpdateVersionListAndOwners`. When we have already fetched owners for another search document, set it on all search documents for that ID so things remain consistent.

Concerning any concerns about load on DB introduced by this change: the number of package events per hour is dwarfed by the number of hits on the package details page (which fetches owners from DB plus much more).

This is the number of **push events per hour**, over the past 90 days.

Median | P90 | P95 | P99 | P99.9 | Max
-- | -- | -- | -- | -- | --
73 | 181 | 243 | 392 | 602 | 2,453

This is the number of **hits on the package details page per hour**, over the past 90 days.


Median | P90 | P95 | P99 | P99.9 | Max
-- | -- | -- | -- | -- | --
33,718 | 58,705 | 63,491 | 70,837 | 186,314 | 199,019

As you can see, the worst hour for V3 (2,453) was less than one tenth of the median hour for display package page (33,718). In short, the DB load from package details page is so much higher than the volume caused by this implementation that I don't think we'll even notice the additional load. Additionally, when we configure this stuff, I plan on querying the read replica or USSC... not the write replica in USNC.