### PR TITLE
Fix a flaky test that depends on real system time

### DIFF
--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -252,6 +252,7 @@ namespace NuGet.Services.AzureSearch
             services.AddTransient<ISearchServiceClientWrapper, SearchServiceClientWrapper>();
             services.AddTransient<ISearchTextBuilder, SearchTextBuilder>();
             services.AddTransient<ISimpleHttpClient, SimpleHttpClient>();
+            services.AddTransient<ISystemTime, SystemTime>();
             services.AddTransient<ITelemetryService, TelemetryService>();
 
             return services;

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -192,9 +192,11 @@
     <Compile Include="Wrappers\IndexesOperationsWrapper.cs" />
     <Compile Include="Wrappers\ISearchIndexClientWrapper.cs" />
     <Compile Include="Wrappers\ISearchServiceClientWrapper.cs" />
+    <Compile Include="Wrappers\ISystemTime.cs" />
     <Compile Include="Wrappers\SearchIndexClientWrapper.cs" />
     <Compile Include="Wrappers\SearchServiceClientWrapper.cs" />
     <Compile Include="SearchService\SearchServiceConfiguration.cs" />
+    <Compile Include="Wrappers\SystemTime.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core">

--- a/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryFileReloader.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryFileReloader.cs
@@ -6,21 +6,25 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using NuGet.Services.AzureSearch.Wrappers;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
     public class AuxiliaryFileReloader : IAuxiliaryFileReloader
     {
         private readonly IAuxiliaryDataCache _cache;
+        private readonly ISystemTime _systemTime;
         private readonly IOptionsSnapshot<SearchServiceConfiguration> _options;
         private readonly ILogger<AuxiliaryFileReloader> _logger;
 
         public AuxiliaryFileReloader(
             IAuxiliaryDataCache cache,
+            ISystemTime systemTime,
             IOptionsSnapshot<SearchServiceConfiguration> options,
             ILogger<AuxiliaryFileReloader> logger)
         {
             _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+            _systemTime = systemTime ?? throw new ArgumentNullException(nameof(systemTime));
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
@@ -39,7 +43,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError((EventId)0, ex, "An exception was thrown while reloading the auxiliary data.");
+                    _logger.LogError(0, ex, "An exception was thrown while reloading the auxiliary data.");
 
                     delay = _options.Value.AuxiliaryDataReloadFailureRetryFrequency;
                 }
@@ -52,7 +56,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 _logger.LogInformation(
                     "Waiting {Duration} before attempting to reload the auxiliary data again.",
                     delay);
-                await Task.Delay(delay, token);
+                await _systemTime.Delay(delay, token);
             }
         }
     }

--- a/src/NuGet.Services.AzureSearch/Wrappers/ISystemTime.cs
+++ b/src/NuGet.Services.AzureSearch/Wrappers/ISystemTime.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.AzureSearch.Wrappers
+{
+    /// <summary>
+    /// A wrapper that allows for unit tests related to system time.
+    /// </summary>
+    public interface ISystemTime
+    {
+        Task Delay(TimeSpan delay);
+        Task Delay(TimeSpan delay, CancellationToken token);
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Wrappers/SystemTime.cs
+++ b/src/NuGet.Services.AzureSearch/Wrappers/SystemTime.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.AzureSearch.Wrappers
+{
+    public class SystemTime : ISystemTime
+    {
+        public async Task Delay(TimeSpan delay)
+        {
+            await Task.Delay(delay);
+        }
+
+        public async Task Delay(TimeSpan delay, CancellationToken token)
+        {
+            await Task.Delay(delay, token);
+        }
+    }
+}


### PR DESCRIPTION
A test turned out to be flaky. Apparently `Task.Delay` can take less than the provided time to complete. I had assumed that the actual delay would always be greater than or equal to the provided `TimeSpan`, but apparently that is not true.

```
##[error]    NuGet.Services.AzureSearch.SearchService.AuxiliaryFileReloaderFacts+ReloadContinuouslyAsync.UsesReloadFrequencyOnSuccess [FAIL]

      Assert.InRange() Failure
      Range:  (00:00:00.1000000 - 01:00:00)
      Actual: 00:00:00.0975096
      Stack Trace:
        src\AzureSearchService\submodules\NuGet.Services.Metadata\tests\NuGet.Services.AzureSearch.Tests\SearchService\AuxiliaryFileReloaderFacts.cs(58,0): at NuGet.Services.AzureSearch.SearchService.AuxiliaryFileReloaderFacts.ReloadContinuouslyAsync.<UsesReloadFrequencyOnSuccess>d__3.MoveNext()
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
        --- End of stack trace from previous location where exception was thrown ---
           at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
      Output:
        | NuGet.Services.AzureSearch.SearchService.AuxiliaryFileReloader Information: Trying to reload the auxiliary data.
        | NuGet.Services.AzureSearch.SearchService.AuxiliaryFileReloader Information: Waiting 00:00:00.1000000 before attempting to reload the auxiliary data again.
        | NuGet.Services.AzureSearch.SearchService.AuxiliaryFileReloader Information: Trying to reload the auxiliary data.
```

Failed build:
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2706000