### PR TITLE
Add root page for Azure Search Service and warmup config

### DIFF
--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -159,6 +159,7 @@
     <Compile Include="SearchService\SearchParametersBuilder.cs" />
     <Compile Include="SearchService\Models\V2SortBy.cs" />
     <Compile Include="SearchService\SearchResponseBuilder.cs" />
+    <Compile Include="SearchService\SearchStatusOptions.cs" />
     <Compile Include="SearchService\SearchStatusService.cs" />
     <Compile Include="SearchService\SearchTextBuilder.cs" />
     <Compile Include="VersionList\Guard.cs" />

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/SearchStatusResponse.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/SearchStatusResponse.cs
@@ -13,7 +13,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         /// if <see cref="Success"/> is false. If <see cref="Success"/> is true, all properties will be non-null.
         /// </summary>
         public bool Success { get; set; }
-        public TimeSpan Duration { get; set; }
+        public TimeSpan? Duration { get; set; }
         public ServerStatus Server { get; set; }
         public IndexStatus SearchIndex { get; set; }
         public IndexStatus HijackIndex { get; set; }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchStatusOptions.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchStatusOptions.cs
@@ -1,13 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Reflection;
-using System.Threading.Tasks;
+using System;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
-    public interface ISearchStatusService
+    [Flags]
+    public enum SearchStatusOptions
     {
-        Task<SearchStatusResponse> GetStatusAsync(SearchStatusOptions options, Assembly assemblyForMetadata);
+        None = 0,
+        Server = 1 << 0,
+        AuxiliaryFiles = 1 << 1,
+        AzureSearch = 1 << 2,
+        All = ~None,
     }
 }

--- a/src/NuGet.Services.SearchService/App_Start/WebApiConfig.cs
+++ b/src/NuGet.Services.SearchService/App_Start/WebApiConfig.cs
@@ -47,6 +47,15 @@ namespace NuGet.Services.SearchService
             config.MapHttpAttributeRoutes();
 
             config.Routes.MapHttpRoute(
+                name: "Index",
+                routeTemplate: "",
+                defaults: new
+                {
+                    controller = GetControllerName<SearchController>(),
+                    action = nameof(SearchController.IndexAsync),
+                });
+
+            config.Routes.MapHttpRoute(
                 name: "GetStatus",
                 routeTemplate: "search/diag",
                 defaults: new

--- a/src/NuGet.Services.SearchService/Web.config
+++ b/src/NuGet.Services.SearchService/Web.config
@@ -16,6 +16,9 @@
         <add name="Strict-Transport-Security" value="max-age=31536000"/>
       </customHeaders>
     </httpProtocol>
+    <applicationInitialization>
+      <add initializationPage="/"/>
+    </applicationInitialization>
   </system.webServer>
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -104,6 +107,10 @@
 				<bindingRedirect oldVersion="0.0.0.0-2.46.0.0" newVersion="2.46.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
+				<assemblyIdentity name="NuGet.Protocol" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
+			</dependentAssembly>
+			<dependentAssembly>
 				<assemblyIdentity name="NuGet.Packaging.Core" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
 				<bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
 			</dependentAssembly>
@@ -113,14 +120,6 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="NuGet.Configuration" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="NuGet.Common" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
 				<bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
 			</dependentAssembly>
 			<dependentAssembly>

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchStatusServiceFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchStatusServiceFacts.cs
@@ -24,13 +24,55 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             [Fact]
+            public async Task AllowsSkippingAzureSearch()
+            {
+                var status = await _target.GetStatusAsync(SearchStatusOptions.All ^ SearchStatusOptions.AzureSearch, _assembly);
+
+                _searchDocuments.Verify(x => x.CountAsync(), Times.Never);
+                _searchDocuments.Verify(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<SearchParameters>()), Times.Never);
+                _hijackDocuments.Verify(x => x.CountAsync(), Times.Never);
+                _hijackDocuments.Verify(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<SearchParameters>()), Times.Never);
+                Assert.Null(status.SearchIndex);
+                Assert.Null(status.HijackIndex);
+
+                Assert.NotNull(status.Server);
+                Assert.NotNull(status.AuxiliaryFiles);
+            }
+
+            [Fact]
+            public async Task AllowsSkippingAuxiliaryFiles()
+            {
+                var status = await _target.GetStatusAsync(SearchStatusOptions.All ^ SearchStatusOptions.AuxiliaryFiles, _assembly);
+
+                _auxiliaryDataCache.Verify(x => x.EnsureInitializedAsync(), Times.Never);
+                _auxiliaryDataCache.Verify(x => x.Get(), Times.Never);
+                Assert.Null(status.AuxiliaryFiles);
+
+                Assert.NotNull(status.Server);
+                Assert.NotNull(status.SearchIndex);
+                Assert.NotNull(status.HijackIndex);
+            }
+
+            [Fact]
+            public async Task AllowsSkippingServer()
+            {
+                var status = await _target.GetStatusAsync(SearchStatusOptions.All ^ SearchStatusOptions.Server, _assembly);
+
+                Assert.Null(status.Server);
+
+                Assert.NotNull(status.AuxiliaryFiles);
+                Assert.NotNull(status.SearchIndex);
+                Assert.NotNull(status.HijackIndex);
+            }
+
+            [Fact]
             public async Task ReturnsFullStatus()
             {
                 var before = DateTimeOffset.UtcNow;
-                var status = await _target.GetStatusAsync(_assembly);
+                var status = await _target.GetStatusAsync(SearchStatusOptions.All, _assembly);
 
                 Assert.True(status.Success);
-                Assert.InRange(status.Duration, TimeSpan.FromMilliseconds(1), TimeSpan.MaxValue);
+                Assert.InRange(status.Duration.Value, TimeSpan.FromMilliseconds(1), TimeSpan.MaxValue);
 
                 Assert.Equal("This is a fake build date for testing.", status.Server.AssemblyBuildDateUtc);
                 Assert.Equal("This is a fake commit ID for testing.", status.Server.AssemblyCommitId);
@@ -63,10 +105,10 @@ namespace NuGet.Services.AzureSearch.SearchService
             {
                 _options.Setup(x => x.Value).Throws(new InvalidOperationException("Can't get the deployment label."));
 
-                var status = await _target.GetStatusAsync(_assembly);
+                var status = await _target.GetStatusAsync(SearchStatusOptions.All, _assembly);
 
                 Assert.False(status.Success);
-                Assert.InRange(status.Duration, TimeSpan.FromMilliseconds(1), TimeSpan.MaxValue);
+                Assert.InRange(status.Duration.Value, TimeSpan.FromMilliseconds(1), TimeSpan.MaxValue);
                 Assert.Null(status.Server);
                 Assert.NotNull(status.SearchIndex);
                 Assert.NotNull(status.HijackIndex);
@@ -80,10 +122,10 @@ namespace NuGet.Services.AzureSearch.SearchService
                     .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<SearchParameters>()))
                     .ThrowsAsync(new InvalidOperationException("Could not hit the search index."));
 
-                var status = await _target.GetStatusAsync(_assembly);
+                var status = await _target.GetStatusAsync(SearchStatusOptions.All, _assembly);
 
                 Assert.False(status.Success);
-                Assert.InRange(status.Duration, TimeSpan.FromMilliseconds(1), TimeSpan.MaxValue);
+                Assert.InRange(status.Duration.Value, TimeSpan.FromMilliseconds(1), TimeSpan.MaxValue);
                 Assert.NotNull(status.Server);
                 Assert.Null(status.SearchIndex);
                 Assert.NotNull(status.HijackIndex);
@@ -97,10 +139,10 @@ namespace NuGet.Services.AzureSearch.SearchService
                     .Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<SearchParameters>()))
                     .ThrowsAsync(new InvalidOperationException("Could not hit the hijack index."));
 
-                var status = await _target.GetStatusAsync(_assembly);
+                var status = await _target.GetStatusAsync(SearchStatusOptions.All, _assembly);
 
                 Assert.False(status.Success);
-                Assert.InRange(status.Duration, TimeSpan.FromMilliseconds(1), TimeSpan.MaxValue);
+                Assert.InRange(status.Duration.Value, TimeSpan.FromMilliseconds(1), TimeSpan.MaxValue);
                 Assert.NotNull(status.Server);
                 Assert.NotNull(status.SearchIndex);
                 Assert.Null(status.HijackIndex);
@@ -114,10 +156,10 @@ namespace NuGet.Services.AzureSearch.SearchService
                     .Setup(x => x.EnsureInitializedAsync())
                     .Throws(new InvalidOperationException("Could not initialize the auxiliary data."));
 
-                var status = await _target.GetStatusAsync(_assembly);
+                var status = await _target.GetStatusAsync(SearchStatusOptions.All, _assembly);
 
                 Assert.False(status.Success);
-                Assert.InRange(status.Duration, TimeSpan.FromMilliseconds(1), TimeSpan.MaxValue);
+                Assert.InRange(status.Duration.Value, TimeSpan.FromMilliseconds(1), TimeSpan.MaxValue);
                 Assert.NotNull(status.Server);
                 Assert.NotNull(status.SearchIndex);
                 Assert.NotNull(status.HijackIndex);


### PR DESCRIPTION
1. Make the root page "/" return something (`{"Success":true}`)
1. Add a web.config setting to tell Azure Web Apps to call a specific endpoint for warming an instance

Given that gallery has two health probe endpoint implementations by design, I introduced a `SearchStatusOptions` to select exactly what dependencies we want to check for a health probe. This will make course changes easier for Azure Search service in the future.