### PR TITLE
Add telemetry to Azure Search jobs and service

### DIFF
--- a/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
@@ -1,0 +1,244 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using NuGet.Services.AzureSearch.SearchService;
+using NuGet.Services.Logging;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class AzureSearchTelemetryService : IAzureSearchTelemetryService
+    {
+        private const string Prefix = "AzureSearch.";
+
+        private readonly ITelemetryClient _telemetryClient;
+
+        public AzureSearchTelemetryService(ITelemetryClient telemetryClient)
+        {
+            _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
+        }
+
+        public IDisposable TrackVersionListsUpdated(int versionListCount, int workerCount)
+        {
+            return _telemetryClient.TrackDuration(
+                Prefix + "VersionListsUpdatedSeconds",
+                new Dictionary<string, string>
+                {
+                    { "VersionListCount", versionListCount.ToString() },
+                    { "WorkerCount", workerCount.ToString() },
+                });
+        }
+
+        public void TrackIndexPushSuccess(string indexName, int documentCount, TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "IndexPushSuccessSeconds",
+                elapsed.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { "IndexName", indexName },
+                    { "DocumentCount", documentCount.ToString() },
+                });
+        }
+
+        public void TrackIndexPushFailure(string indexName, int documentCount, TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "IndexPushFailureSeconds",
+                elapsed.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { "IndexName", indexName },
+                    { "DocumentCount", documentCount.ToString() },
+                });
+        }
+
+        public void TrackIndexPushSplit(string indexName, int documentCount)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "IndexPushSplit",
+                1,
+                new Dictionary<string, string>
+                {
+                    { "IndexName", indexName },
+                    { "DocumentCount", documentCount.ToString() },
+                });
+        }
+
+        public IDisposable TrackGetLatestLeaves(string packageId, int requestedVersions)
+        {
+            return _telemetryClient.TrackDuration(
+                Prefix + "GetLatestLeavesSeconds",
+                new Dictionary<string, string>
+                {
+                    { "PackageId", packageId },
+                    { "RequestVersions", requestedVersions.ToString() },
+                });
+        }
+
+        public void TrackOwners2AzureSearchCompleted(bool success, TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "Owners2AzureSearchCompletedSeconds",
+                elapsed.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { "Success", success.ToString() },
+                });
+        }
+
+        public void TrackAuxiliaryFilesReload(IReadOnlyList<string> reloadedNames, IReadOnlyList<string> notModifiedNames, TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "AuxiliaryFilesReloadSeconds",
+                elapsed.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { "ReloadedNames", JsonConvert.SerializeObject(reloadedNames) },
+                    { "NotModifiedNames", JsonConvert.SerializeObject(notModifiedNames) },
+                });
+        }
+
+        public void TrackAuxiliaryFileDownloaded(string blobName, TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "AuxiliaryFileDownloadedSeconds",
+                elapsed.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { "BlobName", blobName },
+                });
+        }
+
+        public void TrackGetOwnersForPackageId(int ownerCount, TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "GetOwnersForPackageIdSeconds",
+                elapsed.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { "OwnerCount", ownerCount.ToString() },
+                });
+        }
+
+        public void TrackReadLatestIndexedOwners(int ownerCount, TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "ReadLatestIndexedOwnersSeconds",
+                elapsed.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { "OwnerCount", ownerCount.ToString() },
+                });
+        }
+
+        public void TrackAuxiliaryFileNotModified(string blobName, TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "AuxiliaryFileNotModifiedSeconds",
+                elapsed.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { "BlobName", blobName },
+                });
+        }
+
+        public IDisposable TrackUploadOwnerChangeHistory(int packageIdCount)
+        {
+            return _telemetryClient.TrackDuration(
+                Prefix + "UploadOwnerChangeHistorySeconds",
+                new Dictionary<string, string>
+                {
+                    { "PackageIdCount", packageIdCount.ToString() },
+                });
+        }
+
+        public IDisposable TrackReplaceLatestIndexedOwners(int packageIdCount)
+        {
+            return _telemetryClient.TrackDuration(
+                Prefix + "ReplaceLatestIndexedOwnersSeconds",
+                new Dictionary<string, string>
+                {
+                    { "PackageIdCount", packageIdCount.ToString() },
+                });
+        }
+
+        public void TrackReadLatestOwnersFromDatabase(int packageIdCount, TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "ReadLatestOwnersFromDatabaseSeconds",
+                elapsed.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { "PackageIdCount", packageIdCount.ToString() },
+                });
+        }
+
+        public void TrackOwnerSetComparison(int oldCount, int newCount, int changeCount, TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "OwnerSetComparisonSeconds",
+                elapsed.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { "OldCount", oldCount.ToString() },
+                    { "NewCount", newCount.ToString() },
+                    { "ChangeCount", changeCount.ToString() },
+                });
+        }
+
+        public IDisposable TrackCatalog2AzureSearchProcessBatch(int catalogLeafCount, int latestCatalogLeafCount, int packageIdCount)
+        {
+            return _telemetryClient.TrackDuration(
+                Prefix + "Catalog2AzureSearchBatchSeconds",
+                new Dictionary<string, string>
+                {
+                    { "CatalogLeafCount", catalogLeafCount.ToString() },
+                    { "LatestCatalogLeafCount", latestCatalogLeafCount.ToString() },
+                    { "PackageIdCount", packageIdCount.ToString() },
+                });
+        }
+
+        public void TrackV2SearchQueryWithSearchIndex(TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "V2SearchQueryWithSearchIndexMs",
+                elapsed.TotalMilliseconds);
+        }
+
+        public void TrackV2SearchQueryWithHijackIndex(TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "V2SearchQueryWithHijackIndexMs",
+                elapsed.TotalMilliseconds);
+        }
+
+        public void TrackAutocompleteQuery(TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "AutocompleteQueryMs",
+                elapsed.TotalMilliseconds);
+        }
+
+        public void TrackV3SearchQuery(TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "V3SearchQueryMs",
+                elapsed.TotalMilliseconds);
+        }
+
+        public void TrackGetSearchServiceStatus(SearchStatusOptions options, bool success, TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "GetSearchServiceStatusMs",
+                elapsed.TotalMilliseconds,
+                new Dictionary<string, string>
+                {
+                    { "Options", options.ToString() },
+                    { "Success", success.ToString() },
+                });
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/CatalogLeafFetcher.cs
+++ b/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/CatalogLeafFetcher.cs
@@ -19,17 +19,20 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
         private readonly IRegistrationClient _registrationClient;
         private readonly ICatalogClient _catalogClient;
         private readonly IOptionsSnapshot<Catalog2AzureSearchConfiguration> _options;
+        private readonly IAzureSearchTelemetryService _telemetryService;
         private readonly ILogger<CatalogLeafFetcher> _logger;
 
         public CatalogLeafFetcher(
             IRegistrationClient registrationClient,
             ICatalogClient catalogClient,
             IOptionsSnapshot<Catalog2AzureSearchConfiguration> options,
+            IAzureSearchTelemetryService telemetryService,
             ILogger<CatalogLeafFetcher> logger)
         {
             _registrationClient = registrationClient ?? throw new ArgumentNullException(nameof(registrationClient));
             _catalogClient = catalogClient ?? throw new ArgumentNullException(nameof(catalogClient));
             _options = options ?? throw new ArgumentNullException(nameof(options));
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
             if (_options.Value.MaxConcurrentBatches <= 0)
@@ -66,72 +69,75 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                 throw new ArgumentException("At least one version list must be provided.", nameof(versions));
             }
 
-            var unavailable = new HashSet<NuGetVersion>();
-            var fetched = new Dictionary<NuGetVersion, PackageDetailsCatalogLeaf>();
-            var unlisted = new Dictionary<NuGetVersion, string>();
-
-            var registrationIndexUrl = RegistrationUrlBuilder.GetIndexUrl(_options.Value.RegistrationsBaseUrl, packageId);
-            var registrationIndex = await _registrationClient.GetIndexOrNullAsync(registrationIndexUrl);
-            if (registrationIndex == null)
+            using (_telemetryService.TrackGetLatestLeaves(packageId, versions.SelectMany(v => v).Distinct().Count()))
             {
-                _logger.LogWarning(
-                    "No registation index was found. ID: {PackageId}, registration index URL: {RegistrationIndexUrl}",
-                    packageId,
-                    registrationIndexUrl);
+                var unavailable = new HashSet<NuGetVersion>();
+                var fetched = new Dictionary<NuGetVersion, PackageDetailsCatalogLeaf>();
+                var unlisted = new Dictionary<NuGetVersion, string>();
 
-                foreach (var version in versions.SelectMany(x => x))
+                var registrationIndexUrl = RegistrationUrlBuilder.GetIndexUrl(_options.Value.RegistrationsBaseUrl, packageId);
+                var registrationIndex = await _registrationClient.GetIndexOrNullAsync(registrationIndexUrl);
+                if (registrationIndex == null)
                 {
-                    unavailable.Add(version);
+                    _logger.LogWarning(
+                        "No registation index was found. ID: {PackageId}, registration index URL: {RegistrationIndexUrl}",
+                        packageId,
+                        registrationIndexUrl);
+
+                    foreach (var version in versions.SelectMany(x => x))
+                    {
+                        unavailable.Add(version);
+                    }
+
+                    return new LatestCatalogLeaves(unavailable, fetched);
+                }
+
+                var pageUrlToInfo = registrationIndex
+                    .Items
+                    .ToDictionary(x => x.Url, x => new RegistrationPageInfo(x));
+
+                // Make a list of ranges for logging purposes.
+                var ranges = pageUrlToInfo
+                    .OrderBy(x => x.Value.Range.MinVersion)
+                    .Select(x => x.Value.RangeString)
+                    .ToList();
+
+                foreach (var versionList in versions)
+                {
+                    await AddLatestLeafAsync(
+                        packageId,
+                        versionList,
+                        pageUrlToInfo,
+                        ranges,
+                        unavailable,
+                        fetched,
+                        unlisted);
+                }
+
+                // Fetch the unlisted version's metadata in parallel. This can be many versions in the case of a bulk
+                // unlist.
+                var allWork = new ConcurrentBag<KeyValuePair<NuGetVersion, string>>(unlisted);
+                var allResults = new ConcurrentBag<KeyValuePair<NuGetVersion, PackageDetailsCatalogLeaf>>();
+                var tasks = Enumerable
+                    .Range(0, _options.Value.MaxConcurrentBatches)
+                    .Select(async x =>
+                    {
+                        await Task.Yield();
+                        while (allWork.TryTake(out var work))
+                        {
+                            var leaf = await _catalogClient.GetPackageDetailsLeafAsync(work.Value);
+                            allResults.Add(KeyValuePair.Create(work.Key, leaf));
+                        }
+                    })
+                    .ToList();
+                await Task.WhenAll(tasks);
+                foreach (var pair in allResults)
+                {
+                    fetched.Add(pair.Key, pair.Value);
                 }
 
                 return new LatestCatalogLeaves(unavailable, fetched);
             }
-
-            var pageUrlToInfo = registrationIndex
-                .Items
-                .ToDictionary(x => x.Url, x => new RegistrationPageInfo(x));
-
-            // Make a list of ranges for logging purposes.
-            var ranges = pageUrlToInfo
-                .OrderBy(x => x.Value.Range.MinVersion)
-                .Select(x => x.Value.RangeString)
-                .ToList();
-
-            foreach (var versionList in versions)
-            {
-                await AddLatestLeafAsync(
-                    packageId,
-                    versionList,
-                    pageUrlToInfo,
-                    ranges,
-                    unavailable,
-                    fetched,
-                    unlisted);
-            }
-
-            // Fetch the unlisted version's metadata in parallel. This can be many versions in the case of a bulk
-            // unlist.
-            var allWork = new ConcurrentBag<KeyValuePair<NuGetVersion, string>>(unlisted);
-            var allResults = new ConcurrentBag<KeyValuePair<NuGetVersion, PackageDetailsCatalogLeaf>>();
-            var tasks = Enumerable
-                .Range(0, _options.Value.MaxConcurrentBatches)
-                .Select(async x =>
-                {
-                    await Task.Yield();
-                    while (allWork.TryTake(out var work))
-                    {
-                        var leaf = await _catalogClient.GetPackageDetailsLeafAsync(work.Value);
-                        allResults.Add(KeyValuePair.Create(work.Key, leaf));
-                    }
-                })
-                .ToList();
-            await Task.WhenAll(tasks);
-            foreach (var pair in allResults)
-            {
-                fetched.Add(pair.Key, pair.Value);
-            }
-
-            return new LatestCatalogLeaves(unavailable, fetched);
         }
 
         private async Task AddLatestLeafAsync(

--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -70,6 +70,7 @@ namespace NuGet.Services.AzureSearch
                     c.ResolveKeyed<ISearchIndexClientWrapper>(hijackIndexKey),
                     c.Resolve<IVersionListDataClient>(),
                     c.Resolve<IOptionsSnapshot<AzureSearchJobConfiguration>>(),
+                    c.Resolve<IAzureSearchTelemetryService>(),
                     c.Resolve<ILogger<BatchPusher>>()));
 
             containerBuilder
@@ -78,7 +79,8 @@ namespace NuGet.Services.AzureSearch
                     c.Resolve<ISearchParametersBuilder>(),
                     c.ResolveKeyed<ISearchIndexClientWrapper>(searchIndexKey),
                     c.ResolveKeyed<ISearchIndexClientWrapper>(hijackIndexKey),
-                    c.Resolve<ISearchResponseBuilder>()));
+                    c.Resolve<ISearchResponseBuilder>(),
+                    c.Resolve<IAzureSearchTelemetryService>()));
 
             containerBuilder
                 .Register<ISearchStatusService>(c => new SearchStatusService(
@@ -86,6 +88,7 @@ namespace NuGet.Services.AzureSearch
                     c.ResolveKeyed<ISearchIndexClientWrapper>(hijackIndexKey),
                     c.Resolve<IAuxiliaryDataCache>(),
                     c.Resolve<IOptionsSnapshot<SearchServiceConfiguration>>(),
+                    c.Resolve<IAzureSearchTelemetryService>(),
                     c.Resolve<ILogger<SearchStatusService>>()));
         }
 
@@ -144,6 +147,7 @@ namespace NuGet.Services.AzureSearch
                 .Register<IOwnerDataClient>(c => new OwnerDataClient(
                     c.ResolveKeyed<ICloudBlobClient>(key),
                     c.Resolve<IOptionsSnapshot<AzureSearchJobConfiguration>>(),
+                    c.Resolve<IAzureSearchTelemetryService>(),
                     c.Resolve<ILogger<OwnerDataClient>>()));
 
             containerBuilder
@@ -177,6 +181,7 @@ namespace NuGet.Services.AzureSearch
                     c.Resolve<IOwnerIndexActionBuilder>(),
                     c.Resolve<Func<IBatchPusher>>(),
                     c.Resolve<IOptionsSnapshot<AzureSearchJobConfiguration>>(),
+                    c.Resolve<IAzureSearchTelemetryService>(),
                     c.Resolve<ILogger<Owners2AzureSearchCommand>>()));
         }
 
@@ -196,6 +201,7 @@ namespace NuGet.Services.AzureSearch
                 .Register<IAuxiliaryFileClient>(c => new AuxiliaryFileClient(
                     c.ResolveKeyed<ICloudBlobClient>(key),
                     c.Resolve<IOptionsSnapshot<SearchServiceConfiguration>>(),
+                    c.Resolve<IAzureSearchTelemetryService>(),
                     c.Resolve<ILogger<AuxiliaryFileClient>>()));
         }
 
@@ -230,8 +236,9 @@ namespace NuGet.Services.AzureSearch
 
             services.AddSingleton<IAuxiliaryDataCache, AuxiliaryDataCache>();
             services.AddScoped(p => p.GetRequiredService<IAuxiliaryDataCache>().Get());
-
             services.AddSingleton<IAuxiliaryFileReloader, AuxiliaryFileReloader>();
+
+            services.AddTransient<IAzureSearchTelemetryService, AzureSearchTelemetryService>();
             services.AddTransient<ICatalogIndexActionBuilder, CatalogIndexActionBuilder>();
             services.AddTransient<ICatalogLeafFetcher, CatalogLeafFetcher>();
             services.AddTransient<ICollector, AzureSearchCollector>();

--- a/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Services.AzureSearch.SearchService;
+
+namespace NuGet.Services.AzureSearch
+{
+    public interface IAzureSearchTelemetryService
+    {
+        void TrackAuxiliaryFileDownloaded(string blobName, TimeSpan elapsed);
+        void TrackAuxiliaryFileNotModified(string blobName, TimeSpan elapsed);
+        void TrackAuxiliaryFilesReload(IReadOnlyList<string> reloadedNames, IReadOnlyList<string> notModifiedNames, TimeSpan elapsed);
+        IDisposable TrackGetLatestLeaves(string packageId, int requestedVersions);
+        void TrackGetOwnersForPackageId(int ownerCount, TimeSpan elapsed);
+        void TrackIndexPushFailure(string indexName, int documentCount, TimeSpan elapsed);
+        void TrackIndexPushSplit(string indexName, int documentCount);
+        void TrackIndexPushSuccess(string indexName, int documentCount, TimeSpan elapsed);
+        void TrackOwners2AzureSearchCompleted(bool success, TimeSpan elapsed);
+        void TrackOwnerSetComparison(int oldCount, int newCount, int changeCount, TimeSpan elapsed);
+        void TrackReadLatestIndexedOwners(int ownerCount, TimeSpan elapsed);
+        void TrackReadLatestOwnersFromDatabase(int packageIdCount, TimeSpan elapsed);
+        IDisposable TrackReplaceLatestIndexedOwners(int packageIdCount);
+        IDisposable TrackUploadOwnerChangeHistory(int packageIdCount);
+        IDisposable TrackVersionListsUpdated(int versionListCount, int workerCount);
+        IDisposable TrackCatalog2AzureSearchProcessBatch(int catalogLeafCount, int latestCatalogLeafCount, int packageIdCount);
+        void TrackV2SearchQueryWithSearchIndex(TimeSpan duration);
+        void TrackV2SearchQueryWithHijackIndex(TimeSpan duration);
+        void TrackAutocompleteQuery(TimeSpan duration);
+        void TrackV3SearchQuery(TimeSpan duration);
+        void TrackGetSearchServiceStatus(SearchStatusOptions options, bool success, TimeSpan duration);
+    }
+}

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Analysis\PackageIdCustomTokenizer.cs" />
     <Compile Include="AzureSearchScoringConfiguration.cs" />
     <Compile Include="DatabaseOwnerFetcher.cs" />
+    <Compile Include="IAzureSearchTelemetryService.cs" />
     <Compile Include="IDatabaseOwnerFetcher.cs" />
     <Compile Include="Owners2AzureSearch\IOwnerIndexActionBuilder.cs" />
     <Compile Include="Owners2AzureSearch\IOwnerSetComparer.cs" />
@@ -162,6 +163,7 @@
     <Compile Include="SearchService\SearchStatusOptions.cs" />
     <Compile Include="SearchService\SearchStatusService.cs" />
     <Compile Include="SearchService\SearchTextBuilder.cs" />
+    <Compile Include="AzureSearchTelemetryService.cs" />
     <Compile Include="VersionList\Guard.cs" />
     <Compile Include="VersionList\HijackIndexChange.cs" />
     <Compile Include="VersionList\HijackIndexChangeType.cs" />

--- a/src/NuGet.Services.AzureSearch/Owners2AzureSearch/Owners2AzureSearchCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Owners2AzureSearch/Owners2AzureSearchCommand.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -19,6 +20,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
         private readonly IOwnerIndexActionBuilder _indexActionBuilder;
         private readonly Func<IBatchPusher> _batchPusherFactory;
         private readonly IOptionsSnapshot<AzureSearchJobConfiguration> _options;
+        private readonly IAzureSearchTelemetryService _telemetryService;
         private readonly ILogger<Owners2AzureSearchCommand> _logger;
 
         public Owners2AzureSearchCommand(
@@ -28,6 +30,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
             IOwnerIndexActionBuilder indexActionBuilder,
             Func<IBatchPusher> batchPusherFactory,
             IOptionsSnapshot<AzureSearchJobConfiguration> options,
+            IAzureSearchTelemetryService telemetryService,
             ILogger<Owners2AzureSearchCommand> logger)
         {
             _databaseOwnerFetcher = databaseOwnerFetcher ?? throw new ArgumentNullException(nameof(databaseOwnerFetcher));
@@ -36,6 +39,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
             _indexActionBuilder = indexActionBuilder ?? throw new ArgumentNullException(nameof(indexActionBuilder));
             _batchPusherFactory = batchPusherFactory ?? throw new ArgumentNullException(nameof(batchPusherFactory));
             _options = options ?? throw new ArgumentNullException(nameof(options));
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
             if (_options.Value.MaxConcurrentBatches <= 0)
@@ -48,35 +52,47 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
 
         public async Task ExecuteAsync()
         {
-            _logger.LogInformation("Fetching old owner data from blob storage.");
-            var storageResult = await _ownerDataClient.ReadLatestIndexedAsync();
-
-            _logger.LogInformation("Fetching new owner data from the database.");
-            var databaseResult = await _databaseOwnerFetcher.GetPackageIdToOwnersAsync();
-
-            _logger.LogInformation("Detecting owner changes.");
-            var changes = _ownerSetComparer.Compare(storageResult.Result, databaseResult);
-            var changesBag = new ConcurrentBag<IdAndValue<string[]>>(changes.Select(x => new IdAndValue<string[]>(x.Key, x.Value)));
-            _logger.LogInformation("{Count} package IDs have owner changes.", changesBag.Count);
-
-            if (!changes.Any())
+            var stopwatch = Stopwatch.StartNew();
+            var success = false;
+            try
             {
-                return;
+                _logger.LogInformation("Fetching old owner data from blob storage.");
+                var storageResult = await _ownerDataClient.ReadLatestIndexedAsync();
+
+                _logger.LogInformation("Fetching new owner data from the database.");
+                var databaseResult = await _databaseOwnerFetcher.GetPackageIdToOwnersAsync();
+
+                _logger.LogInformation("Detecting owner changes.");
+                var changes = _ownerSetComparer.Compare(storageResult.Result, databaseResult);
+                var changesBag = new ConcurrentBag<IdAndValue<string[]>>(changes.Select(x => new IdAndValue<string[]>(x.Key, x.Value)));
+                _logger.LogInformation("{Count} package IDs have owner changes.", changesBag.Count);
+
+                if (!changes.Any())
+                {
+                    success = true;
+                    return;
+                }
+
+                _logger.LogInformation(
+                    "Starting {Count} workers pushing owners changes to Azure Search.",
+                    _options.Value.MaxConcurrentBatches);
+                await ParallelAsync.Repeat(() => WorkAsync(changesBag), _options.Value.MaxConcurrentBatches);
+                _logger.LogInformation("All of the owner changes have been pushed to Azure Search.");
+
+                // Persist in storage the list of all package IDs that have owner changes. This allows debugging and future
+                // analytics on frequency of ownership changes.
+                _logger.LogInformation("Uploading the package IDs that have owner changes to blob storage.");
+                await _ownerDataClient.UploadChangeHistoryAsync(changes.Keys.ToList());
+
+                _logger.LogInformation("Uploading the new owner data to blob storage.");
+                await _ownerDataClient.ReplaceLatestIndexedAsync(databaseResult, storageResult.AccessCondition);
+                success = true;
             }
-
-            _logger.LogInformation(
-                "Starting {Count} workers pushing owners changes to Azure Search.",
-                _options.Value.MaxConcurrentBatches);
-            await ParallelAsync.Repeat(() => WorkAsync(changesBag), _options.Value.MaxConcurrentBatches);
-            _logger.LogInformation("All of the owner changes have been pushed to Azure Search.");
-
-            // Persist in storage the list of all package IDs that have owner changes. This allows debugging and future
-            // analytics on frequency of ownership changes.
-            _logger.LogInformation("Uploading the package IDs that have owner changes to blob storage.");
-            await _ownerDataClient.UploadChangeHistoryAsync(changes.Keys.ToList());
-
-            _logger.LogInformation("Uploading the new owner data to blob storage.");
-            await _ownerDataClient.ReplaceLatestIndexedAsync(databaseResult, storageResult.AccessCondition);
+            finally
+            {
+                stopwatch.Stop();
+                _telemetryService.TrackOwners2AzureSearchCompleted(success, stopwatch.Elapsed);
+            }
         }
 
         private async Task WorkAsync(ConcurrentBag<IdAndValue<string[]>> changesBag)

--- a/src/NuGet.Services.AzureSearch/ScoringProfiles/DefaultScoringProfile.cs
+++ b/src/NuGet.Services.AzureSearch/ScoringProfiles/DefaultScoringProfile.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Azure.Search.Models;

--- a/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryFileClient.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryFileClient.cs
@@ -20,16 +20,19 @@ namespace NuGet.Services.AzureSearch.SearchService
     {
         private readonly ICloudBlobClient _cloudBlobClient;
         private readonly IOptionsSnapshot<SearchServiceConfiguration> _options;
+        private readonly IAzureSearchTelemetryService _telemetryService;
         private readonly ILogger<AuxiliaryFileClient> _logger;
         private readonly Lazy<ICloudBlobContainer> _lazyContainer;
 
         public AuxiliaryFileClient(
             ICloudBlobClient cloudBlobClient,
             IOptionsSnapshot<SearchServiceConfiguration> options,
+            IAzureSearchTelemetryService telemetryService,
             ILogger<AuxiliaryFileClient> logger)
         {
             _cloudBlobClient = cloudBlobClient ?? throw new ArgumentNullException(nameof(cloudBlobClient));
             _options = options ?? throw new ArgumentNullException(nameof(options));
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
             _lazyContainer = new Lazy<ICloudBlobContainer>(
@@ -85,6 +88,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                     var data = loadData(loader);
                     stopwatch.Stop();
 
+                    _telemetryService.TrackAuxiliaryFileDownloaded(blobName, stopwatch.Elapsed);
                     _logger.LogInformation(
                         "Loaded blob {BlobName} with etag {OldETag}. New etag is {NewETag}. Took {Duration}.",
                         blobName,
@@ -106,6 +110,8 @@ namespace NuGet.Services.AzureSearch.SearchService
             catch (StorageException ex) when (ex.RequestInformation?.HttpStatusCode == (int)HttpStatusCode.NotModified)
             {
                 stopwatch.Stop();
+
+                _telemetryService.TrackAuxiliaryFileNotModified(blobName, stopwatch.Elapsed);
                 _logger.LogInformation(
                     "Blob {BlobName} has not changed from the previous etag {ETag}. Took {Duration}.",
                     blobName,

--- a/src/NuGet.Services.AzureSearch/SearchService/AzureSearchQueryBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AzureSearchQueryBuilder.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/NuGet.Services.AzureSearch/SearchService/InvalidSearchRequestException.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/InvalidSearchRequestException.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchStatusService.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchStatusService.cs
@@ -19,6 +19,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         private readonly ISearchIndexClientWrapper _hijackIndex;
         private readonly IAuxiliaryDataCache _auxiliaryDataCache;
         private readonly IOptionsSnapshot<SearchServiceConfiguration> _options;
+        private readonly IAzureSearchTelemetryService _telemetryService;
         private readonly ILogger<SearchStatusService> _logger;
 
         public SearchStatusService(
@@ -26,12 +27,14 @@ namespace NuGet.Services.AzureSearch.SearchService
             ISearchIndexClientWrapper hijackIndex,
             IAuxiliaryDataCache auxiliaryDataCache,
             IOptionsSnapshot<SearchServiceConfiguration> options,
+            IAzureSearchTelemetryService telemetryService,
             ILogger<SearchStatusService> logger)
         {
             _searchIndex = searchIndex ?? throw new ArgumentNullException(nameof(searchIndex));
             _hijackIndex = hijackIndex ?? throw new ArgumentNullException(nameof(hijackIndex));
             _auxiliaryDataCache = auxiliaryDataCache ?? throw new ArgumentNullException(nameof(auxiliaryDataCache));
             _options = options ?? throw new ArgumentNullException(nameof(options));
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
@@ -44,10 +47,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 
             response.Duration = await Measure.DurationAsync(() => PopulateResponseAsync(options, assemblyForMetadata, response));
 
-            _logger.LogInformation(
-                "It took {Duration} to fetch the search status. Success is {Success}.",
-                response.Duration,
-                response.Success);
+            _telemetryService.TrackGetSearchServiceStatus(options, response.Success, response.Duration.Value);
 
             return response;
         }

--- a/src/NuGet.Services.SearchService/App_Start/WebApiConfig.cs
+++ b/src/NuGet.Services.SearchService/App_Start/WebApiConfig.cs
@@ -11,6 +11,7 @@ using System.Web.Http;
 using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using Autofac.Integration.WebApi;
+using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -130,6 +131,8 @@ namespace NuGet.Services.SearchService
             services.Configure<AzureSearchConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));
             services.Configure<SearchServiceConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));
             services.AddAzureSearch();
+            services.AddSingleton(new TelemetryClient());
+            services.AddTransient<ITelemetryClient, TelemetryClientWrapper>();
 
             var builder = new ContainerBuilder();
             builder.RegisterApiControllers(Assembly.GetExecutingAssembly());

--- a/tests/NuGet.Services.AzureSearch.Tests/BatchPusherFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/BatchPusherFacts.cs
@@ -516,6 +516,7 @@ namespace NuGet.Services.AzureSearch
             protected readonly Mock<IVersionListDataClient> _versionListDataClient;
             protected readonly AzureSearchJobConfiguration _config;
             protected readonly Mock<IOptionsSnapshot<AzureSearchJobConfiguration>> _options;
+            protected readonly Mock<IAzureSearchTelemetryService> _telemetryService;
             protected readonly IndexActions _indexActions;
             protected readonly BatchPusher _target;
 
@@ -542,6 +543,7 @@ namespace NuGet.Services.AzureSearch
                 _versionListDataClient = new Mock<IVersionListDataClient>();
                 _config = new AzureSearchJobConfiguration();
                 _options = new Mock<IOptionsSnapshot<AzureSearchJobConfiguration>>();
+                _telemetryService = new Mock<IAzureSearchTelemetryService>();
 
                 _searchIndexClientWrapper.Setup(x => x.IndexName).Returns("search");
                 _searchIndexClientWrapper.Setup(x => x.Documents).Returns(() => _searchDocumentsWrapper.Object);
@@ -600,6 +602,7 @@ namespace NuGet.Services.AzureSearch
                     _hijackIndexClientWrapper.Object,
                     _versionListDataClient.Object,
                     _options.Object,
+                    _telemetryService.Object,
                     _logger);
             }
         }

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/AzureSearchCollectorLogicFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/AzureSearchCollectorLogicFacts.cs
@@ -240,6 +240,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
             protected readonly Mock<IBatchPusher> _batchPusher;
             protected readonly Mock<IOptionsSnapshot<Catalog2AzureSearchConfiguration>> _options;
             protected readonly Catalog2AzureSearchConfiguration _config;
+            protected readonly Mock<IAzureSearchTelemetryService> _telemetryService;
             protected readonly RecordingLogger<AzureSearchCollectorLogic> _logger;
             protected readonly AzureSearchCollectorLogic _target;
 
@@ -250,6 +251,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                 _batchPusher = new Mock<IBatchPusher>();
                 _options = new Mock<IOptionsSnapshot<Catalog2AzureSearchConfiguration>>();
                 _config = new Catalog2AzureSearchConfiguration();
+                _telemetryService = new Mock<IAzureSearchTelemetryService>();
                 _logger = output.GetLogger<AzureSearchCollectorLogic>();
 
                 _options.Setup(x => x.Value).Returns(() => _config);
@@ -260,6 +262,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                     _catalogIndexActionBuilder.Object,
                     () => _batchPusher.Object,
                     _options.Object,
+                    _telemetryService.Object,
                     _logger);
             }
         }

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/CatalogLeafFetcherFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/CatalogLeafFetcherFacts.cs
@@ -608,6 +608,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
             protected readonly Mock<ICatalogClient> _catalogClient;
             protected readonly Mock<IOptionsSnapshot<Catalog2AzureSearchConfiguration>> _options;
             protected readonly Catalog2AzureSearchConfiguration _config;
+            protected readonly Mock<IAzureSearchTelemetryService> _telemetryService;
             protected readonly RecordingLogger<CatalogLeafFetcher> _logger;
             protected readonly List<IReadOnlyList<NuGetVersion>> _versions;
             protected readonly NuGetVersion[] _eachVersion;
@@ -622,6 +623,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                 {
                     MaxConcurrentBatches = 1,
                 };
+                _telemetryService = new Mock<IAzureSearchTelemetryService>();
                 _logger = output.GetLogger<CatalogLeafFetcher>();
 
                 _options.Setup(x => x.Value).Returns(() => _config);
@@ -663,6 +665,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                     _registrationClient.Object,
                     _catalogClient.Object,
                     _options.Object,
+                    _telemetryService.Object,
                     _logger);
             }
 

--- a/tests/NuGet.Services.AzureSearch.Tests/DatabaseOwnerFetcherFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/DatabaseOwnerFetcherFacts.cs
@@ -87,6 +87,7 @@ namespace NuGet.Services.AzureSearch
                 SqlConnectionFactory = new Mock<ISqlConnectionFactory<GalleryDbConfiguration>>();
                 EntitiesContextFactory = new Mock<IEntitiesContextFactory>();
                 EntitiesContext = new Mock<IEntitiesContext>();
+                TelemetryService = new Mock<IAzureSearchTelemetryService>();
                 Logger = output.GetLogger<DatabaseOwnerFetcher>();
 
                 PackageRegistrations = DbSetMockFactory.Create<PackageRegistration>();
@@ -101,12 +102,14 @@ namespace NuGet.Services.AzureSearch
                 Target = new DatabaseOwnerFetcher(
                     SqlConnectionFactory.Object,
                     EntitiesContextFactory.Object,
+                    TelemetryService.Object,
                     Logger);
             }
 
             public Mock<ISqlConnectionFactory<GalleryDbConfiguration>> SqlConnectionFactory { get; }
             public Mock<IEntitiesContextFactory> EntitiesContextFactory { get; }
             public Mock<IEntitiesContext> EntitiesContext { get; }
+            public Mock<IAzureSearchTelemetryService> TelemetryService { get; }
             public RecordingLogger<DatabaseOwnerFetcher> Logger { get; }
             public DbSet<PackageRegistration> PackageRegistrations { get; }
             public DatabaseOwnerFetcher Target { get; }

--- a/tests/NuGet.Services.AzureSearch.Tests/Owners2AzureSearch/OwnerDataClientFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Owners2AzureSearch/OwnerDataClientFacts.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Microsoft.WindowsAzure.Storage;
@@ -379,6 +378,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
                 CloudBlobContainer = new Mock<ICloudBlobContainer>();
                 CloudBlob = new Mock<ISimpleCloudBlob>();
                 Options = new Mock<IOptionsSnapshot<AzureSearchJobConfiguration>>();
+                TelemetryService = new Mock<IAzureSearchTelemetryService>();
                 Logger = output.GetLogger<OwnerDataClient>();
                 Config = new AzureSearchJobConfiguration
                 {
@@ -415,6 +415,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
                 Target = new OwnerDataClient(
                     CloudBlobClient.Object,
                     Options.Object,
+                    TelemetryService.Object,
                     Logger);
             }
 
@@ -422,6 +423,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
             public Mock<ICloudBlobContainer> CloudBlobContainer { get; }
             public Mock<ISimpleCloudBlob> CloudBlob { get; }
             public Mock<IOptionsSnapshot<AzureSearchJobConfiguration>> Options { get; }
+            public Mock<IAzureSearchTelemetryService> TelemetryService { get; }
             public RecordingLogger<OwnerDataClient> Logger { get; }
             public AzureSearchJobConfiguration Config { get; }
             public string ETag { get; }

--- a/tests/NuGet.Services.AzureSearch.Tests/Owners2AzureSearch/OwnerSetComparerFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Owners2AzureSearch/OwnerSetComparerFacts.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Moq;
 using NuGet.Services.AzureSearch.Support;
 using Xunit;
 using Xunit.Abstractions;
@@ -122,11 +123,15 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
         {
             public Facts(ITestOutputHelper output)
             {
+                TelemetryService = new Mock<IAzureSearchTelemetryService>();
                 Logger = output.GetLogger<OwnerSetComparer>();
 
-                Target = new OwnerSetComparer(Logger);
+                Target = new OwnerSetComparer(
+                    TelemetryService.Object,
+                    Logger);
             }
 
+            public Mock<IAzureSearchTelemetryService> TelemetryService { get; }
             public RecordingLogger<OwnerSetComparer> Logger { get; }
             public OwnerSetComparer Target { get; }
 

--- a/tests/NuGet.Services.AzureSearch.Tests/Owners2AzureSearch/Owners2AzureSearchCommandFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Owners2AzureSearch/Owners2AzureSearchCommandFacts.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Azure.Search.Models;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using NuGet.Services.AzureSearch.Support;
@@ -175,6 +172,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
                 OwnerIndexActionBuilder = new Mock<IOwnerIndexActionBuilder>();
                 Pusher = new Mock<IBatchPusher>();
                 Options = new Mock<IOptionsSnapshot<AzureSearchJobConfiguration>>();
+                TelemetryService = new Mock<IAzureSearchTelemetryService>();
                 Logger = output.GetLogger<Owners2AzureSearchCommand>();
 
                 Configuration = new AzureSearchJobConfiguration
@@ -218,6 +216,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
                     OwnerIndexActionBuilder.Object,
                     () => Pusher.Object,
                     Options.Object,
+                    TelemetryService.Object,
                     Logger);
             }
 
@@ -227,6 +226,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
             public Mock<IOwnerIndexActionBuilder> OwnerIndexActionBuilder { get; }
             public Mock<IBatchPusher> Pusher { get; }
             public Mock<IOptionsSnapshot<AzureSearchJobConfiguration>> Options { get; }
+            public Mock<IAzureSearchTelemetryService> TelemetryService { get; }
             public RecordingLogger<Owners2AzureSearchCommand> Logger { get; }
             public AzureSearchJobConfiguration Configuration { get; }
             public SortedDictionary<string, SortedSet<string>> DatabaseResult { get; }

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryDataCacheFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryDataCacheFacts.cs
@@ -162,6 +162,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         public abstract class BaseFacts
         {
             protected readonly Mock<IAuxiliaryFileClient> _client;
+            protected readonly Mock<IAzureSearchTelemetryService> _telemetryService;
             protected readonly RecordingLogger<AuxiliaryDataCache> _logger;
             protected readonly CancellationToken _token;
             protected readonly AuxiliaryFileResult<Downloads> _downloads;
@@ -171,6 +172,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             public BaseFacts(ITestOutputHelper output)
             {
                 _client = new Mock<IAuxiliaryFileClient>();
+                _telemetryService = new Mock<IAzureSearchTelemetryService>();
                 _logger = output.GetLogger<AuxiliaryDataCache>();
 
                 _token = CancellationToken.None;
@@ -202,6 +204,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 _target = new AuxiliaryDataCache(
                     _client.Object,
+                    _telemetryService.Object,
                     _logger);
             }
         }

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryFileClientFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryFileClientFacts.cs
@@ -161,6 +161,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             protected readonly Mock<ICloudBlobClient> _blobClient;
             protected readonly SearchServiceConfiguration _config;
             protected readonly Mock<IOptionsSnapshot<SearchServiceConfiguration>> _options;
+            protected readonly Mock<IAzureSearchTelemetryService> _telemetryService;
             protected readonly RecordingLogger<AuxiliaryFileClient> _logger;
             protected readonly Mock<ICloudBlobContainer> _container;
             protected readonly Mock<ISimpleCloudBlob> _blob;
@@ -172,6 +173,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 _blobClient = new Mock<ICloudBlobClient>();
                 _config = new SearchServiceConfiguration();
                 _options = new Mock<IOptionsSnapshot<SearchServiceConfiguration>>();
+                _telemetryService = new Mock<IAzureSearchTelemetryService>();
                 _logger = output.GetLogger<AuxiliaryFileClient>();
                 _container = new Mock<ICloudBlobContainer>();
                 _blob = new Mock<ISimpleCloudBlob>();
@@ -200,6 +202,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 _target = new AuxiliaryFileClient(
                     _blobClient.Object,
                     _options.Object,
+                    _telemetryService.Object,
                     _logger);
             }
         }

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryFileReloaderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryFileReloaderFacts.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/AzureSearchServiceFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/AzureSearchServiceFacts.cs
@@ -92,6 +92,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             protected readonly Mock<ISearchIndexClientWrapper> _hijackIndex;
             protected readonly Mock<IDocumentsOperationsWrapper> _hijackOperations;
             protected readonly Mock<ISearchResponseBuilder> _responseBuilder;
+            protected readonly Mock<IAzureSearchTelemetryService> _telemetryService;
             protected readonly V2SearchRequest _v2Request;
             protected readonly V3SearchRequest _v3Request;
             protected readonly string _v2Text;
@@ -113,6 +114,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 _hijackIndex = new Mock<ISearchIndexClientWrapper>();
                 _hijackOperations = new Mock<IDocumentsOperationsWrapper>();
                 _responseBuilder = new Mock<ISearchResponseBuilder>();
+                _telemetryService = new Mock<IAzureSearchTelemetryService>();
 
                 _v2Request = new V2SearchRequest();
                 _v3Request = new V3SearchRequest();
@@ -182,7 +184,8 @@ namespace NuGet.Services.AzureSearch.SearchService
                     _parametersBuilder.Object,
                     _searchIndex.Object,
                     _hijackIndex.Object,
-                    _responseBuilder.Object);
+                    _responseBuilder.Object,
+                    _telemetryService.Object);
             }
         }
     }

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchStatusServiceFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchStatusServiceFacts.cs
@@ -177,6 +177,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             protected readonly Mock<IAuxiliaryData> _auxiliaryData;
             protected readonly SearchServiceConfiguration _config;
             protected readonly Mock<IOptionsSnapshot<SearchServiceConfiguration>> _options;
+            protected readonly Mock<IAzureSearchTelemetryService> _telemetryService;
             protected readonly RecordingLogger<SearchStatusService> _logger;
             protected readonly AuxiliaryFilesMetadata _auxiliaryFilesMetadata;
             protected readonly Assembly _assembly;
@@ -191,6 +192,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 _auxiliaryDataCache = new Mock<IAuxiliaryDataCache>();
                 _auxiliaryData = new Mock<IAuxiliaryData>();
                 _options = new Mock<IOptionsSnapshot<SearchServiceConfiguration>>();
+                _telemetryService = new Mock<IAzureSearchTelemetryService>();
                 _logger = output.GetLogger<SearchStatusService>();
 
                 _auxiliaryFilesMetadata = new AuxiliaryFilesMetadata(
@@ -234,6 +236,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                     _hijackIndex.Object,
                     _auxiliaryDataCache.Object,
                     _options.Object,
+                    _telemetryService.Object,
                     _logger);
             }
         }


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/6664

I think the usefulness of unit tests on telemetry is less than the cost of implementing them. This is perhaps not true if we alert on the specific telemetry, but we have no plans at this time to alert on these. When we add an alert and have any concerns about telemetry reliability, we can add the tests at that point.

There is an "integration test" suite which uses a concrete implementation of `AzureSearchTelemetryService` so we have coverage there for the simplest of cases.

See unit tests for `ILogger` calls.