### PR TITLE
Generate license URL from gallery base for license expression and file

### DIFF
--- a/src/NuGet.Protocol.Catalog/Models/PackageDetailsCatalogLeaf.cs
+++ b/src/NuGet.Protocol.Catalog/Models/PackageDetailsCatalogLeaf.cs
@@ -79,6 +79,12 @@ namespace NuGet.Protocol.Catalog
         [JsonProperty("verbatimVersion")]
         public string VerbatimVersion { get; set; }
 
+        [JsonProperty("licenseExpression")]
+        public string LicenseExpression { get; set; }
+
+        [JsonProperty("licenseFile")]
+        public string LicenseFile { get; set; }
+
         [JsonProperty("iconFile")]
         public string IconFile { get; set; }
     }

--- a/src/NuGet.Services.AzureSearch/AzureSearchJobConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/AzureSearchJobConfiguration.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace NuGet.Services.AzureSearch
 {
     public class AzureSearchJobConfiguration : AzureSearchConfiguration
@@ -11,8 +13,14 @@ namespace NuGet.Services.AzureSearch
         public string StorageConnectionString { get; set; }
         public string StorageContainer { get; set; }
         public string StoragePath { get; set; }
+        public string GalleryBaseUrl { get; set; }
 
         public AzureSearchScoringConfiguration Scoring { get; set; }
+
+        public Uri ParseGalleryBaseUrl()
+        {
+            return new Uri(GalleryBaseUrl, UriKind.Absolute);
+        }
 
         public string NormalizeStoragePath()
         {

--- a/src/NuGet.Services.AzureSearch/HijackDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/HijackDocumentBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Extensions.Options;
 using NuGet.Protocol.Catalog;
 using NuGet.Services.Entities;
 
@@ -9,6 +10,13 @@ namespace NuGet.Services.AzureSearch
 {
     public class HijackDocumentBuilder : IHijackDocumentBuilder
     {
+        private readonly IOptionsSnapshot<AzureSearchJobConfiguration> _options;
+
+        public HijackDocumentBuilder(IOptionsSnapshot<AzureSearchJobConfiguration> options)
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+        }
+
         public KeyedDocument Keyed(
             string packageId,
             string normalizedVersion)
@@ -56,7 +64,7 @@ namespace NuGet.Services.AzureSearch
                 lastCommitTimestamp: leaf.CommitTimestamp,
                 lastCommitId: leaf.CommitId,
                 changes: changes);
-            DocumentUtilities.PopulateMetadata(document, normalizedVersion, leaf);
+            DocumentUtilities.PopulateMetadata(document, normalizedVersion, leaf, _options.Value.ParseGalleryBaseUrl());
             document.Listed = leaf.IsListed();
 
             return document;
@@ -77,7 +85,7 @@ namespace NuGet.Services.AzureSearch
                 lastCommitId: null,
                 normalizedVersion: package.NormalizedVersion,
                 changes: changes);
-            DocumentUtilities.PopulateMetadata(document, packageId, package);
+            DocumentUtilities.PopulateMetadata(document, packageId, package, _options.Value.ParseGalleryBaseUrl());
             document.Listed = package.Listed;
 
             return document;

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -177,7 +177,7 @@ namespace NuGet.Services.AzureSearch
                 isLatest: isLatest,
                 fullVersion: fullVersion,
                 owners: owners);
-            DocumentUtilities.PopulateMetadata(document, normalizedVersion, leaf);
+            DocumentUtilities.PopulateMetadata(document, normalizedVersion, leaf, _options.Value.ParseGalleryBaseUrl());
 
             return document;
         }
@@ -207,7 +207,7 @@ namespace NuGet.Services.AzureSearch
                 isLatest: isLatest,
                 fullVersion: fullVersion,
                 owners: owners);
-            DocumentUtilities.PopulateMetadata(document, packageId, package);
+            DocumentUtilities.PopulateMetadata(document, packageId, package, _options.Value.ParseGalleryBaseUrl());
             document.TotalDownloadCount = totalDownloadCount;
             document.LogOfDownloadCount = Math.Log(totalDownloadCount, _options.Value.Scoring.DownloadCountLogBase);
 

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/AzureSearchCollectorLogicIntegrationTests.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/AzureSearchCollectorLogicIntegrationTests.cs
@@ -58,6 +58,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
                 StorageContainer = "integration-tests-container",
                 StoragePath = "integration-tests-path",
                 RegistrationsBaseUrl = "https://example/registrations/",
+                GalleryBaseUrl = Data.GalleryBaseUrl,
 
                 Scoring = new AzureSearchScoringConfiguration()
             };
@@ -93,7 +94,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
                 _telemetryService,
                 output.GetLogger<CatalogLeafFetcher>());
             _search = new SearchDocumentBuilder(_options.Object);
-            _hijack = new HijackDocumentBuilder();
+            _hijack = new HijackDocumentBuilder(_options.Object);
             _builder = new CatalogIndexActionBuilder(
                 _versionListDataClient,
                 _leafFetcher,

--- a/tests/NuGet.Services.AzureSearch.Tests/DocumentUtilitiesFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/DocumentUtilitiesFacts.cs
@@ -12,6 +12,8 @@ namespace NuGet.Services.AzureSearch
 {
     public class DocumentUtilitiesFacts
     {
+        private static readonly Uri GalleryBaseUrl = new Uri(Data.GalleryBaseUrl, UriKind.Absolute);
+
         public class GetHijackDocumentKey
         {
             [Theory]
@@ -101,7 +103,7 @@ namespace NuGet.Services.AzureSearch
                 };
                 var full = new HijackDocument.Full();
 
-                DocumentUtilities.PopulateMetadata(full, NormalizedVersion, leaf);
+                DocumentUtilities.PopulateMetadata(full, NormalizedVersion, leaf, GalleryBaseUrl);
 
                 Assert.Equal("NuGet.Versioning:2.0.0|NuGet.Frameworks:3.0.0", full.FlattenedDependencies);
             }
@@ -127,7 +129,7 @@ namespace NuGet.Services.AzureSearch
                 };
                 var full = new HijackDocument.Full();
 
-                DocumentUtilities.PopulateMetadata(full, NormalizedVersion, leaf);
+                DocumentUtilities.PopulateMetadata(full, NormalizedVersion, leaf, GalleryBaseUrl);
 
                 Assert.Equal(expected, full.FlattenedDependencies);
             }
@@ -157,7 +159,7 @@ namespace NuGet.Services.AzureSearch
                 };
                 var full = new HijackDocument.Full();
 
-                DocumentUtilities.PopulateMetadata(full, NormalizedVersion, leaf);
+                DocumentUtilities.PopulateMetadata(full, NormalizedVersion, leaf, GalleryBaseUrl);
 
                 Assert.Equal("NuGet.Versioning::net40", full.FlattenedDependencies);
             }
@@ -193,7 +195,7 @@ namespace NuGet.Services.AzureSearch
                 };
                 var full = new HijackDocument.Full();
 
-                DocumentUtilities.PopulateMetadata(full, NormalizedVersion, leaf);
+                DocumentUtilities.PopulateMetadata(full, NormalizedVersion, leaf, GalleryBaseUrl);
 
                 Assert.Equal("NuGet.Versioning:" + expected + ":net40", full.FlattenedDependencies);
             }
@@ -209,7 +211,7 @@ namespace NuGet.Services.AzureSearch
                 };
                 var full = new HijackDocument.Full();
 
-                DocumentUtilities.PopulateMetadata(full, NormalizedVersion, leaf);
+                DocumentUtilities.PopulateMetadata(full, NormalizedVersion, leaf, GalleryBaseUrl);
 
                 Assert.Null(full.FlattenedDependencies);
             }

--- a/tests/NuGet.Services.AzureSearch.Tests/Support/Data.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Support/Data.cs
@@ -15,9 +15,11 @@ namespace NuGet.Services.AzureSearch.Support
 {
     public static class Data
     {
+        public const string GalleryBaseUrl = "https://example/";
         public const string PackageId = "WindowsAzure.Storage";
         public const string NormalizedVersion = "7.1.2-alpha";
         public const string FullVersion = "7.1.2-alpha+git";
+        public const string GalleryLicenseUrl = GalleryBaseUrl + "packages/" + PackageId + "/" + NormalizedVersion + "/license";
         public static readonly DateTimeOffset DocumentLastUpdated = new DateTimeOffset(2018, 12, 14, 9, 30, 0, TimeSpan.Zero);
         public static readonly DateTimeOffset CommitTimestamp = new DateTimeOffset(2018, 12, 13, 12, 30, 0, TimeSpan.Zero);
         public static readonly string CommitId = "6b9b24dd-7aec-48ae-afc1-2a117e3d50d1";
@@ -90,6 +92,7 @@ namespace NuGet.Services.AzureSearch.Support
                 var mock = new Mock<IOptionsSnapshot<AzureSearchJobConfiguration>>();
                 var config = new AzureSearchJobConfiguration
                 {
+                    GalleryBaseUrl = GalleryBaseUrl,
                     Scoring = new AzureSearchScoringConfiguration
                     {
                         DownloadCountLogBase = 2
@@ -121,7 +124,7 @@ namespace NuGet.Services.AzureSearch.Support
             latestStableSemVer2: false,
             latestSemVer2: true);
 
-        public static HijackDocument.Full HijackDocument => new HijackDocumentBuilder().FullFromDb(
+        public static HijackDocument.Full HijackDocument => new HijackDocumentBuilder(Options).FullFromDb(
             PackageId,
             HijackDocumentChanges,
             PackageEntity);


### PR DESCRIPTION
Address https://github.com/nuget/nugetgallery/issues/6759

Example license expression:
https://azuresearch-usnc.dev.nugettest.org/query?q=packageid:license-expression-test1&semVerLevel=2.0.0&prerelease=true

Example license file:
https://azuresearch-usnc.dev.nugettest.org/query?q=packageid:license-file-lucene-1&semVerLevel=2.0.0&prerelease=true