### PR TITLE
 Parallelize the catalog leaf download differently than batches

### DIFF
--- a/src/NuGet.Services.AzureSearch/AzureSearchJobConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/AzureSearchJobConfiguration.cs
@@ -7,9 +7,9 @@ namespace NuGet.Services.AzureSearch
 {
     public class AzureSearchJobConfiguration : AzureSearchConfiguration
     {
-        public int AzureSearchBatchSize { get; set; }
-        public int MaxConcurrentBatches { get; set; }
-        public int MaxConcurrentVersionListWriters { get; set; }
+        public int AzureSearchBatchSize { get; set; } = 1000;
+        public int MaxConcurrentBatches { get; set; } = 4;
+        public int MaxConcurrentVersionListWriters { get; set; } = 8;
         public string StorageConnectionString { get; set; }
         public string StorageContainer { get; set; }
         public string StoragePath { get; set; }

--- a/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
@@ -240,5 +240,15 @@ namespace NuGet.Services.AzureSearch
                     { "Success", success.ToString() },
                 });
         }
+
+        public IDisposable TrackCatalogLeafDownloadBatch(int count)
+        {
+            return _telemetryClient.TrackDuration(
+                Prefix + "CatalogLeafDownloadBatchSeconds",
+                new Dictionary<string, string>
+                {
+                    { "Count", count.ToString() },
+                });
+        }
     }
 }

--- a/src/NuGet.Services.AzureSearch/BatchPusher.cs
+++ b/src/NuGet.Services.AzureSearch/BatchPusher.cs
@@ -52,16 +52,16 @@ namespace NuGet.Services.AzureSearch
 
             if (_options.Value.MaxConcurrentVersionListWriters <= 0)
             {
-                throw new ArgumentException(
-                    $"The {nameof(AzureSearchJobConfiguration.MaxConcurrentVersionListWriters)} must be greater than zero.",
-                    nameof(options));
+                throw new ArgumentOutOfRangeException(
+                    nameof(options),
+                    $"The {nameof(AzureSearchJobConfiguration.MaxConcurrentVersionListWriters)} must be greater than zero.");
             }
 
             if (_options.Value.AzureSearchBatchSize <= 0)
             {
-                throw new ArgumentException(
-                    $"The {nameof(AzureSearchJobConfiguration.AzureSearchBatchSize)} must be greater than zero.",
-                    nameof(options));
+                throw new ArgumentOutOfRangeException(
+                    nameof(options),
+                    $"The {nameof(AzureSearchJobConfiguration.AzureSearchBatchSize)} must be greater than zero.");
             }
         }
 

--- a/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/Catalog2AzureSearchConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/Catalog2AzureSearchConfiguration.cs
@@ -8,9 +8,10 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 {
     public class Catalog2AzureSearchConfiguration : AzureSearchJobConfiguration
     {
+        public int MaxConcurrentCatalogLeafDownloads { get; set; } = 64;
         public bool CreateContainersAndIndexes { get; set; }
         public string Source { get; set; }
-        public TimeSpan HttpClientTimeout { get; set; }
+        public TimeSpan HttpClientTimeout { get; set; } = TimeSpan.FromMinutes(10);
         public List<string> DependencyCursorUrls { get; set; }
         public string RegistrationsBaseUrl { get; set; }
     }

--- a/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/CatalogLeafFetcher.cs
+++ b/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/CatalogLeafFetcher.cs
@@ -37,9 +37,9 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
             if (_options.Value.MaxConcurrentBatches <= 0)
             {
-                throw new ArgumentException(
-                    $"The {nameof(AzureSearchJobConfiguration.MaxConcurrentBatches)} must be greater than zero.",
-                    nameof(options));
+                throw new ArgumentOutOfRangeException(
+                    nameof(options),
+                    $"The {nameof(AzureSearchJobConfiguration.MaxConcurrentBatches)} must be greater than zero.");
             }
 
             if (_options.Value.RegistrationsBaseUrl == null)

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchCommand.cs
@@ -55,9 +55,9 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
 
             if (_options.Value.MaxConcurrentBatches <= 0)
             {
-                throw new ArgumentException(
-                    $"The {nameof(AzureSearchJobConfiguration.MaxConcurrentBatches)} must be greater than zero.",
-                    nameof(options));
+                throw new ArgumentOutOfRangeException(
+                    nameof(options),
+                    $"The {nameof(AzureSearchJobConfiguration.MaxConcurrentBatches)} must be greater than zero.");
             }
         }
 

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchConfiguration.cs
@@ -5,7 +5,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
 {
     public class Db2AzureSearchConfiguration : AzureSearchJobConfiguration
     {
-        public int DatabaseBatchSize { get; set; }
+        public int DatabaseBatchSize { get; set; } = 10000;
         public bool ReplaceContainersAndIndexes { get; set; }
         public string CatalogIndexUrl { get; set; }
     }

--- a/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
@@ -30,5 +30,6 @@ namespace NuGet.Services.AzureSearch
         void TrackAutocompleteQuery(TimeSpan duration);
         void TrackV3SearchQuery(TimeSpan duration);
         void TrackGetSearchServiceStatus(SearchStatusOptions options, bool success, TimeSpan duration);
+        IDisposable TrackCatalogLeafDownloadBatch(int count);
     }
 }

--- a/src/NuGet.Services.AzureSearch/Owners2AzureSearch/Owners2AzureSearchCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Owners2AzureSearch/Owners2AzureSearchCommand.cs
@@ -44,9 +44,9 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
 
             if (_options.Value.MaxConcurrentBatches <= 0)
             {
-                throw new ArgumentException(
-                    $"The {nameof(AzureSearchJobConfiguration.MaxConcurrentBatches)} must be greater than zero.",
-                    nameof(options));
+                throw new ArgumentOutOfRangeException(
+                    nameof(options),
+                    $"The {nameof(AzureSearchJobConfiguration.MaxConcurrentBatches)} must be greater than zero.");
             }
         }
 

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
@@ -13,8 +13,8 @@ namespace NuGet.Services.AzureSearch.SearchService
         public string AuxiliaryDataStorageContainer { get; set; }
         public string AuxiliaryDataStorageDownloadsPath { get; set; }
         public string AuxiliaryDataStorageVerifiedPackagesPath { get; set; }
-        public TimeSpan AuxiliaryDataReloadFrequency { get; set; }
-        public TimeSpan AuxiliaryDataReloadFailureRetryFrequency { get; set; }
+        public TimeSpan AuxiliaryDataReloadFrequency { get; set; } = TimeSpan.FromHours(1);
+        public TimeSpan AuxiliaryDataReloadFailureRetryFrequency { get; set; } = TimeSpan.FromSeconds(30);
         public string DeploymentLabel { get; set; }
     }
 }

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/AzureSearchCollectorLogicFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/AzureSearchCollectorLogicFacts.cs
@@ -256,6 +256,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
                 _options.Setup(x => x.Value).Returns(() => _config);
                 _config.MaxConcurrentBatches = 1;
+                _config.MaxConcurrentCatalogLeafDownloads = 1;
 
                 _target = new AzureSearchCollectorLogic(
                     _catalogClient.Object,

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/AzureSearchCollectorLogicIntegrationTests.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/AzureSearchCollectorLogicIntegrationTests.cs
@@ -54,7 +54,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
             {
                 MaxConcurrentBatches = 1,
                 MaxConcurrentVersionListWriters = 1,
-                AzureSearchBatchSize = 1000,
+                MaxConcurrentCatalogLeafDownloads = 1,
                 StorageContainer = "integration-tests-container",
                 StoragePath = "integration-tests-path",
                 RegistrationsBaseUrl = "https://example/registrations/",


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/7265

USSC and SEA have the fix. USNC and EA do not.

instanceName | name | value (seconds)
-- | -- | --
Catalog2AzureSearch-ussc-a | ProcessBatchSeconds | 53.10917
Catalog2AzureSearch-usnc-a | ProcessBatchSeconds | 341.2235
Catalog2AzureSearch-sea-a | ProcessBatchSeconds | 131.307
Catalog2AzureSearch-ea-a | ProcessBatchSeconds | 2,089.71



Also add some sane defaults to the Azure Search configs.