### PR TITLE
Use the global JSON serializer settings in Azure Search Service

### DIFF
--- a/src/NuGet.Services.SearchService/App_Start/WebApiConfig.cs
+++ b/src/NuGet.Services.SearchService/App_Start/WebApiConfig.cs
@@ -45,8 +45,7 @@ namespace NuGet.Services.SearchService
         public static void Register(HttpConfiguration config)
         {
             config.Formatters.Remove(config.Formatters.XmlFormatter);
-            config.Formatters.JsonFormatter.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
-            config.Formatters.JsonFormatter.SerializerSettings.Converters.Add(new StringEnumConverter());
+            SetSerializerSettings(config.Formatters.JsonFormatter.SerializerSettings);
 
             var dependencyResolver = GetDependencyResolver(config);
             config.DependencyResolver = dependencyResolver;
@@ -108,6 +107,12 @@ namespace NuGet.Services.SearchService
                 .Value;
 
             HostingEnvironment.QueueBackgroundWorkItem(token => ReloadAuxiliaryFilesAsync(dependencyResolver.Container, token));
+        }
+
+        public static void SetSerializerSettings(JsonSerializerSettings settings)
+        {
+            settings.NullValueHandling = NullValueHandling.Ignore;
+            settings.Converters.Add(new StringEnumConverter());
         }
 
         private static async Task ReloadAuxiliaryFilesAsync(ILifetimeScope serviceProvider, CancellationToken token)

--- a/src/NuGet.Services.SearchService/Controllers/SearchController.cs
+++ b/src/NuGet.Services.SearchService/Controllers/SearchController.cs
@@ -197,7 +197,7 @@ namespace NuGet.Services.SearchService.Controllers
         {
             try
             {
-                return Json(await searchAction());
+                return Json(await searchAction(), Configuration.Formatters.JsonFormatter.SerializerSettings);
             }
             catch (InvalidSearchRequestException e)
             {

--- a/tests/NuGet.Services.SearchService.Tests/Controllers/SearchControllerFacts.cs
+++ b/tests/NuGet.Services.SearchService.Tests/Controllers/SearchControllerFacts.cs
@@ -239,6 +239,23 @@ namespace NuGet.Services.SearchService.Controllers
                 Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
                 Assert.Equal("{\"Message\":\"Foo\"}", await response.Content.ReadAsStringAsync());
             }
+
+            [Fact]
+            public async Task IgnoresNullValues()
+            {
+                _searchService
+                    .Setup(x => x.V2SearchAsync(It.IsAny<V2SearchRequest>()))
+                    .ReturnsAsync(new V2SearchResponse
+                    {
+                        TotalHits = 0,
+                        Data = new List<V2SearchPackage>(),
+                    });
+
+                var result = await _target.V2SearchAsync();
+                var response = await result.ExecuteAsync(CancellationToken.None);
+
+                Assert.Equal("{\"totalHits\":0,\"data\":[]}", await response.Content.ReadAsStringAsync());
+            }
         }
 
         public class V3SearchAsync : BaseFacts
@@ -323,6 +340,23 @@ namespace NuGet.Services.SearchService.Controllers
                 Assert.False(response.IsSuccessStatusCode);
                 Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
                 Assert.Equal("{\"Message\":\"Foo\"}", await response.Content.ReadAsStringAsync());
+            }
+
+            [Fact]
+            public async Task IgnoresNullValues()
+            {
+                _searchService
+                    .Setup(x => x.V3SearchAsync(It.IsAny<V3SearchRequest>()))
+                    .ReturnsAsync(new V3SearchResponse
+                    {
+                        TotalHits = 0,
+                        Data = new List<V3SearchPackage>(),
+                    });
+
+                var result = await _target.V3SearchAsync();
+                var response = await result.ExecuteAsync(CancellationToken.None);
+
+                Assert.Equal("{\"totalHits\":0,\"data\":[]}", await response.Content.ReadAsStringAsync());
             }
         }
 
@@ -468,8 +502,24 @@ namespace NuGet.Services.SearchService.Controllers
                 Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
                 Assert.Equal("{\"Message\":\"Foo\"}", await response.Content.ReadAsStringAsync());
             }
-        }
 
+            [Fact]
+            public async Task IgnoresNullValues()
+            {
+                _searchService
+                    .Setup(x => x.AutocompleteAsync(It.IsAny<AutocompleteRequest>()))
+                    .ReturnsAsync(new AutocompleteResponse
+                    {
+                        TotalHits = 0,
+                        Data = new List<string>(),
+                    });
+
+                var result = await _target.AutocompleteAsync();
+                var response = await result.ExecuteAsync(CancellationToken.None);
+
+                Assert.Equal("{\"totalHits\":0,\"data\":[]}", await response.Content.ReadAsStringAsync());
+            }
+        }
 
         public abstract class BaseFacts
         {
@@ -523,6 +573,7 @@ namespace NuGet.Services.SearchService.Controllers
 
                 _target.Request = new HttpRequestMessage();
                 _target.Configuration = new HttpConfiguration();
+                WebApiConfig.SetSerializerSettings(_target.Configuration.Formatters.JsonFormatter.SerializerSettings);
             }
         }
     }


### PR DESCRIPTION
Currently `"Debug": null` shows up on all of the responses. This is because the `Json` method uses the default serializer settings, not the ones we set on app start.

Addresses https://github.com/NuGet/Engineering/issues/2513