### PR TITLE
[Azure Search] Update download boost algorithm

### DIFF
--- a/src/NuGet.Services.AzureSearch/AzureSearchScoringConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/AzureSearchScoringConfiguration.cs
@@ -9,13 +9,6 @@ namespace NuGet.Services.AzureSearch
     public class AzureSearchScoringConfiguration
     {
         /// <summary>
-        /// Controls the log base of <see cref="SearchDocument.Full.LogOfDownloadCount"/>.
-        /// Decreasing the base increases the range of values, thereby increasing the boost
-        /// for packages with high download counts.
-        /// </summary>
-        public double DownloadCountLogBase { get; set; }
-
-        /// <summary>
         /// Weights to increase the importance of matches on specific fields. The keys are
         /// the names of the field whose weights should be modified, listed in <see cref="SearchService.IndexFields"/>.
         /// The values are the weight of that field.
@@ -23,10 +16,10 @@ namespace NuGet.Services.AzureSearch
         public Dictionary<string, double> FieldWeights { get; set; }
 
         /// <summary>
-        /// The <see cref="SearchDocument.Full.LogOfDownloadCount"/> magnitude boost.
+        /// The <see cref="SearchDocument.Full.DownloadScore"/> magnitude boost.
         /// This boosts packages with many downloads.
         /// </summary>
-        public double LogOfDownloadCountMagnitudeBoost { get; set; }
+        public double DownloadScoreBoost { get; set; }
 
         /// <summary>
         /// The <see cref="BaseMetadataDocument.Published"/> freshness boost.

--- a/src/NuGet.Services.AzureSearch/DocumentUtilities.cs
+++ b/src/NuGet.Services.AzureSearch/DocumentUtilities.cs
@@ -29,6 +29,14 @@ namespace NuGet.Services.AzureSearch
             return EncodeKey($"{lowerId}/{lowerVersion}");
         }
 
+        public static double GetDownloadScore(double totalDownloadCount)
+        {
+            // This score ranges from 0 to less than 100, assuming that the most downloaded
+            // package has less than 500 million downloads. This scoring function increases
+            // quickly at first and then becomes approximately linear near the upper bound.
+            return Math.Sqrt(totalDownloadCount) / 220;
+        }
+
         private static string EncodeKey(string rawKey)
         {
             // First, encode the raw value for uniqueness.

--- a/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
@@ -23,7 +23,7 @@ namespace NuGet.Services.AzureSearch
             public long? TotalDownloadCount { get; set; }
 
             [IsFilterable]
-            public double? LogOfDownloadCount { get; set; }
+            public double? DownloadScore { get; set; }
         }
 
         /// <summary>

--- a/src/NuGet.Services.AzureSearch/ScoringProfiles/DefaultScoringProfile.cs
+++ b/src/NuGet.Services.AzureSearch/ScoringProfiles/DefaultScoringProfile.cs
@@ -40,14 +40,9 @@ namespace NuGet.Services.AzureSearch.ScoringProfiles
                 throw new ArgumentNullException(nameof(config));
             }
 
-            if (config.DownloadCountLogBase <= 1)
+            if (config.DownloadScoreBoost <= 1)
             {
-                throw new ArgumentOutOfRangeException(nameof(config.DownloadCountLogBase));
-            }
-
-            if (config.LogOfDownloadCountMagnitudeBoost <= 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(config.LogOfDownloadCountMagnitudeBoost));
+                throw new ArgumentOutOfRangeException(nameof(config.DownloadScoreBoost));
             }
 
             if (config.PublishedFreshnessBoost <= 1)
@@ -86,11 +81,11 @@ namespace NuGet.Services.AzureSearch.ScoringProfiles
                     // use the raw download count with a log interpolation as that would result in a large boosting
                     // range, which would need to be offset by an unmanageably high boosting factor.
                     new MagnitudeScoringFunction(
-                        fieldName: IndexFields.Search.LogOfDownloadCount,
-                        boost: config.LogOfDownloadCountMagnitudeBoost,
+                        fieldName: IndexFields.Search.DownloadScore,
+                        boost: config.DownloadScoreBoost,
                         parameters: new MagnitudeScoringParameters(
                             boostingRangeStart: 0,
-                            boostingRangeEnd: Math.Log(999_999_999_999, config.DownloadCountLogBase),
+                            boostingRangeEnd: DocumentUtilities.GetDownloadScore(999_999_999_999),
                             shouldBoostBeyondRangeByConstant: true),
                         interpolation: ScoringFunctionInterpolation.Linear),
 

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -213,7 +213,7 @@ namespace NuGet.Services.AzureSearch
                 owners: owners);
             _baseDocumentBuilder.PopulateMetadata(document, packageId, package);
             document.TotalDownloadCount = totalDownloadCount;
-            document.LogOfDownloadCount = Math.Log(totalDownloadCount, _options.Value.Scoring.DownloadCountLogBase);
+            document.DownloadScore = DocumentUtilities.GetDownloadScore(totalDownloadCount);
 
             return document;
         }

--- a/src/NuGet.Services.AzureSearch/SearchService/IndexFields.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IndexFields.cs
@@ -33,7 +33,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             public static readonly string Owners = Name(nameof(SearchDocument.Full.Owners));
             public static readonly string SearchFilters = Name(nameof(SearchDocument.UpdateLatest.SearchFilters));
             public static readonly string TotalDownloadCount = Name(nameof(SearchDocument.Full.TotalDownloadCount));
-            public static readonly string LogOfDownloadCount = Name(nameof(SearchDocument.Full.LogOfDownloadCount));
+            public static readonly string DownloadScore = Name(nameof(SearchDocument.Full.DownloadScore));
             public static readonly string Versions = Name(nameof(SearchDocument.UpdateLatest.Versions));
         }
     }

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/Config/Dev.json
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/Config/Dev.json
@@ -1,0 +1,18 @@
+﻿{
+  "TestSettings": {
+    "RunAzureSearchAnalysisTests": false,
+
+    "AzureSearchIndexName": "",
+    "AzureSearchIndexUrl": "",
+    "AzureSearchIndexAdminApiKey": "",
+
+    "AzureSearchAppServiceUrl": ""
+  },
+
+  "KeyVault_VaultName": "",
+  "KeyVault_ClientId": "",
+  "KeyVault_CertificateThumbprint": "",
+  "KeyVault_StoreName": "",
+  "KeyVault_StoreLocation": "",
+  "KeyVault_ValidateCertificate": ""
+}

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/Relevancy/V3RelevancyFunctionalTests.cs
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/Relevancy/V3RelevancyFunctionalTests.cs
@@ -52,8 +52,7 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
         {
             var results = await SearchAsync("EntityFrameworkCore");
 
-            // TODO: This should be on the first page!
-            //Assert.Contains("microsoft.entityframeworkcore", results);
+            Assert.Equal("microsoft.entityframeworkcore", results[0]);
         }
 
         [RelevancyFact]
@@ -61,10 +60,9 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
         {
             var results = await SearchAsync("Microsoft.Extensions");
 
-            // TODO: This should be on the first page!
-            //Assert.Contains("microsoft.extensions.logging", results);
-            //Assert.Contains("microsoft.extensions.configuration", results);
-            //Assert.Contains("microsoft.extensions.dependencyinjection", results);
+            Assert.Contains("microsoft.extensions.logging", results);
+            Assert.Contains("microsoft.extensions.configuration", results);
+            Assert.Contains("microsoft.extensions.dependencyinjection", results);
         }
 
         [RelevancyFact]
@@ -74,9 +72,7 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
 
             Assert.NotEmpty(results);
             Assert.Equal("microsoft.aspnet.mvc", results[0]);
-
-            // TODO: This should be on the first page!
-            // Assert.Contains("Microsoft.AspNetCore.Mvc", results);
+            Assert.Contains("microsoft.aspnetcore.mvc", results);
         }
     }
 }

--- a/tests/NuGet.Services.AzureSearch.Tests/IndexBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/IndexBuilderFacts.cs
@@ -244,7 +244,7 @@ namespace NuGet.Services.AzureSearch
                 Assert.Equal(2, result.Functions.Count);
                 var downloadsBoost = result
                     .Functions
-                    .Where(f => f.FieldName == IndexFields.Search.LogOfDownloadCount)
+                    .Where(f => f.FieldName == IndexFields.Search.DownloadScore)
                     .FirstOrDefault();
                 var freshnessBoost = result
                     .Functions
@@ -477,15 +477,13 @@ namespace NuGet.Services.AzureSearch
 
                     Scoring = new AzureSearchScoringConfiguration
                     {
-                        DownloadCountLogBase = 2.0,
-
                         FieldWeights = new Dictionary<string, double>
                         {
                             { nameof(IndexFields.PackageId), 3.0 },
                             { nameof(IndexFields.TokenizedPackageId), 4.0 },
                         },
 
-                        LogOfDownloadCountMagnitudeBoost = 5.0,
+                        DownloadScoreBoost = 5.0,
                         PublishedFreshnessBoost = 6.0
                     }
                 };

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
@@ -574,7 +574,7 @@ namespace NuGet.Services.AzureSearch
     {
       ""@search.action"": ""upload"",
       ""totalDownloadCount"": 1001,
-      ""logOfDownloadCount"": 9.9672262588359928,
+      ""downloadScore"": 0.14381174563233068,
       ""owners"": [
         ""Microsoft"",
         ""azure-sdk""
@@ -749,10 +749,7 @@ namespace NuGet.Services.AzureSearch
                     GalleryBaseUrl = Data.GalleryBaseUrl,
                     FlatContainerBaseUrl = Data.FlatContainerBaseUrl,
                     FlatContainerContainerName = Data.FlatContainerContainerName,
-                    Scoring = new AzureSearchScoringConfiguration
-                    {
-                        DownloadCountLogBase = 2.0
-                    }
+                    Scoring = new AzureSearchScoringConfiguration(),
                 };
 
                 _options.Setup(o => o.Value).Returns(() => _config);

--- a/tests/NuGet.Services.AzureSearch.Tests/Support/Data.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Support/Data.cs
@@ -88,7 +88,7 @@ namespace NuGet.Services.AzureSearch.Support
 
         public static readonly AzureSearchScoringConfiguration Config = new AzureSearchScoringConfiguration
         {
-            LogOfDownloadCountMagnitudeBoost = 2
+            DownloadScoreBoost = 2
         };
 
         private static IOptionsSnapshot<AzureSearchJobConfiguration> Options
@@ -101,10 +101,7 @@ namespace NuGet.Services.AzureSearch.Support
                     GalleryBaseUrl = GalleryBaseUrl,
                     FlatContainerBaseUrl = FlatContainerBaseUrl,
                     FlatContainerContainerName = FlatContainerContainerName,
-                    Scoring = new AzureSearchScoringConfiguration
-                    {
-                        DownloadCountLogBase = 2
-                    }
+                    Scoring = new AzureSearchScoringConfiguration(),
                 };
 
                 mock.Setup(o => o.Value).Returns(config);


### PR DESCRIPTION
# Intro

The new download boost uses a square root function instead of a log function as the latter's slope flattened quickly at high values (blue is square root, red is log):

![image](https://user-images.githubusercontent.com/737941/60058980-5ca82280-969f-11e9-9487-9fc56244a2e2.png)

Also see: [NuGetDeployment#974](https://nuget.visualstudio.com/NuGetMicrosoft/_git/NuGetDeployment/pullrequest/974?_a=files)
This work is part of: https://github.com/nuget/nugetgallery/issues/7296

# Test

Run the gallery locally with the following `Web.config` settings:

```xml
    <add key="Gallery.SearchServiceUriPrimary" value="https://nuget-prod-usnc-azuresearch.azurewebsites.net"/>
    <add key="Gallery.SearchServiceUriSecondary" value="https://nuget-prod-ussc-azuresearch.azurewebsites.net"/>
    <add key="Gallery.PreviewSearchServiceUriPrimary" value="https://loshar-dev-ussc-azuresearch.azurewebsites.net"/>
    <add key="Gallery.PreviewSearchServiceUriSecondary" value="https://loshar-dev-ussc-azuresearch.azurewebsites.net"/>
```

Alternatively, navigate to the `loshar-search` Azure Search service and the `search-007` index and run the following query:

```
search=<QUERY HERE>&queryType=full&$filter=searchFilters eq 'IncludePrereleaseAndSemVer2'&$select=totalDownloadCount,logOfDownloadCount,packageId
```

 Note that this index was built before the fields were renamed.

# Results

The following search queries have been improved:

* `azure active directory` - Most relevant result is correct now: "Microsoft.IdentityModel.Clients.ActiveDirectory" 
* `mah apps` - Most relevant result is correct now: "MahApps.Metro"
* `newtonsoft json` - Most relevant result is correct now: "Newtonsoft.Json"
* `razor` - Most relevant result is correct now: "Microsoft.AspNet.Razor"
* `aspnet` - Most relevant results are "Microsoft.AspNet.Razor" and "Microsoft.AspNet.Mvc" now.
* `Microsoft.NETCore.Platform` - Most relevant result is correct now: "Microsoft.NETCore.Platforms"
* `microsoft.netcore.platform` - Most relevant result is correct now: "Microsoft.NETCore.Platforms"
* `xamarin` - Most relevant result is correct now: "Xamarin.Forms"
* `prism` - Most relevant results are now "Prism.Core", "Prism.Wpf", and "Prism.Forms" 

The following search queries have regressed:

* `Microsoft toolkit`
* `newtonsoft wamp`
  * We need to penalize results that match fewer tokens even if they have high download counts. Increasing the tokenized package id weight may improve results here.
* `Build.Extensions` - The expected result, `Microsoft.NET.Build.Extensions`, doesn't have many downloads. This is expected behavior in my opinion...

The following search queries were not improved by this change and still need work:

* `ORM` - Dapper should be near the top
* `FxCop` and `ilmerge` - It seems that this new scoring algorithm clusters low download counts too closely together.
* `wilderness labs` - This may require boosting on the owners?
* `AWS` and `microsoft.bot.con` - This requires tokenization/querying changes, likely prefix search
* `Entity`, `Logging`, `netcore` - Exact match overrides high download count. This is the correct behavior in my opinion.

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2801551
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2801552