### PR TITLE
[Azure Search 1] Move auxiliary file client to a shared location

### DIFF
--- a/src/NuGet.Jobs.Auxiliary2AzureSearch/Job.cs
+++ b/src/NuGet.Jobs.Auxiliary2AzureSearch/Job.cs
@@ -6,8 +6,10 @@ using System.Threading.Tasks;
 using Autofac;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using NuGet.Services.AzureSearch;
 using NuGet.Services.AzureSearch.Auxiliary2AzureSearch;
+using NuGet.Services.AzureSearch.AuxiliaryFiles;
 
 namespace NuGet.Jobs
 {
@@ -35,6 +37,8 @@ namespace NuGet.Jobs
             services.AddAzureSearch();
 
             services.Configure<Auxiliary2AzureSearchConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));
+            services.AddTransient<IOptionsSnapshot<IAuxiliaryDataStorageConfiguration>>(
+                p => p.GetRequiredService<IOptionsSnapshot<Auxiliary2AzureSearchConfiguration>>());
             services.Configure<AzureSearchJobConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));
             services.Configure<AzureSearchConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));
         }

--- a/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchConfiguration.cs
@@ -1,12 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using NuGet.Services.AzureSearch.AuxiliaryFiles;
+
 namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
 {
-    public class Auxiliary2AzureSearchConfiguration : AzureSearchJobConfiguration
+    public class Auxiliary2AzureSearchConfiguration : AzureSearchJobConfiguration, IAuxiliaryDataStorageConfiguration
     {
         public string AuxiliaryDataStorageConnectionString { get; set; }
         public string AuxiliaryDataStorageContainer { get; set; }
         public string AuxiliaryDataStorageDownloadsPath { get; set; }
+        public string AuxiliaryDataStorageVerifiedPackagesPath { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryFileClient.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryFileClient.cs
@@ -14,19 +14,19 @@ using Newtonsoft.Json;
 using NuGet.Indexing;
 using NuGetGallery;
 
-namespace NuGet.Services.AzureSearch.SearchService
+namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 {
     public class AuxiliaryFileClient : IAuxiliaryFileClient
     {
         private readonly ICloudBlobClient _cloudBlobClient;
-        private readonly IOptionsSnapshot<SearchServiceConfiguration> _options;
+        private readonly IOptionsSnapshot<IAuxiliaryDataStorageConfiguration> _options;
         private readonly IAzureSearchTelemetryService _telemetryService;
         private readonly ILogger<AuxiliaryFileClient> _logger;
         private readonly Lazy<ICloudBlobContainer> _lazyContainer;
 
         public AuxiliaryFileClient(
             ICloudBlobClient cloudBlobClient,
-            IOptionsSnapshot<SearchServiceConfiguration> options,
+            IOptionsSnapshot<IAuxiliaryDataStorageConfiguration> options,
             IAzureSearchTelemetryService telemetryService,
             ILogger<AuxiliaryFileClient> logger)
         {

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryFileMetadata.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryFileMetadata.cs
@@ -4,7 +4,7 @@
 using System;
 using Newtonsoft.Json;
 
-namespace NuGet.Services.AzureSearch.SearchService
+namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 {
     public class AuxiliaryFileMetadata
     {

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryFileResult.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryFileResult.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace NuGet.Services.AzureSearch.SearchService
+namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 {
     public class AuxiliaryFileResult<T> where T : class
     {

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryDataStorageConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryDataStorageConfiguration.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.AzureSearch.AuxiliaryFiles
+{
+    public interface IAuxiliaryDataStorageConfiguration
+    {
+        string AuxiliaryDataStorageConnectionString { get; }
+        string AuxiliaryDataStorageContainer { get; }
+        string AuxiliaryDataStorageDownloadsPath { get; }
+        string AuxiliaryDataStorageVerifiedPackagesPath { get; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryFileClient.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryFileClient.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuGet.Indexing;
 
-namespace NuGet.Services.AzureSearch.SearchService
+namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 {
     public interface IAuxiliaryFileClient
     {

--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -15,6 +15,7 @@ using NuGet.Protocol;
 using NuGet.Protocol.Catalog;
 using NuGet.Protocol.Registration;
 using NuGet.Services.AzureSearch.Auxiliary2AzureSearch;
+using NuGet.Services.AzureSearch.AuxiliaryFiles;
 using NuGet.Services.AzureSearch.Catalog2AzureSearch;
 using NuGet.Services.AzureSearch.Db2AzureSearch;
 using NuGet.Services.AzureSearch.Owners2AzureSearch;
@@ -181,7 +182,7 @@ namespace NuGet.Services.AzureSearch
             containerBuilder
                 .Register<ICloudBlobClient>(c =>
                 {
-                    var options = c.Resolve<IOptionsSnapshot<SearchServiceConfiguration>>();
+                    var options = c.Resolve<IOptionsSnapshot<IAuxiliaryDataStorageConfiguration>>();
                     return new CloudBlobClientWrapper(
                         options.Value.AuxiliaryDataStorageConnectionString,
                         readAccessGeoRedundant: true);
@@ -191,7 +192,7 @@ namespace NuGet.Services.AzureSearch
             containerBuilder
                 .Register<IAuxiliaryFileClient>(c => new AuxiliaryFileClient(
                     c.ResolveKeyed<ICloudBlobClient>(key),
-                    c.Resolve<IOptionsSnapshot<SearchServiceConfiguration>>(),
+                    c.Resolve<IOptionsSnapshot<IAuxiliaryDataStorageConfiguration>>(),
                     c.Resolve<IAzureSearchTelemetryService>(),
                     c.Resolve<ILogger<AuxiliaryFileClient>>()));
         }

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Analysis\PackageIdCustomTokenizer.cs" />
     <Compile Include="Auxiliary2AzureSearch\Auxiliary2AzureSearchCommand.cs" />
     <Compile Include="Auxiliary2AzureSearch\Auxiliary2AzureSearchConfiguration.cs" />
+    <Compile Include="AuxiliaryFiles\IAuxiliaryDataStorageConfiguration.cs" />
     <Compile Include="AzureSearchScoringConfiguration.cs" />
     <Compile Include="BaseDocumentBuilder.cs" />
     <Compile Include="DatabaseOwnerFetcher.cs" />
@@ -71,7 +72,7 @@
     <Compile Include="DurationMeasurement.cs" />
     <Compile Include="Analysis\ExactMatchCustomAnalyzer.cs" />
     <Compile Include="SearchService\AuxiliaryDataCache.cs" />
-    <Compile Include="SearchService\AuxiliaryFileClient.cs" />
+    <Compile Include="AuxiliaryFiles\AuxiliaryFileClient.cs" />
     <Compile Include="SearchService\AuxiliaryFileReloader.cs" />
     <Compile Include="AzureSearchConfiguration.cs" />
     <Compile Include="AzureSearchJobConfiguration.cs" />
@@ -127,9 +128,9 @@
     <Compile Include="Registration\RegistrationUrlBuilder.cs" />
     <Compile Include="SearchDocumentBuilder.cs" />
     <Compile Include="SearchService\AuxiliaryData.cs" />
-    <Compile Include="SearchService\AuxiliaryFileResult.cs" />
+    <Compile Include="AuxiliaryFiles\AuxiliaryFileResult.cs" />
     <Compile Include="SearchService\IAuxiliaryDataCache.cs" />
-    <Compile Include="SearchService\IAuxiliaryFileClient.cs" />
+    <Compile Include="AuxiliaryFiles\IAuxiliaryFileClient.cs" />
     <Compile Include="SearchService\IAuxiliaryFileReloader.cs" />
     <Compile Include="SearchService\ISearchStatusService.cs" />
     <Compile Include="SearchService\ISearchTextBuilder.cs" />
@@ -138,7 +139,7 @@
     <Compile Include="SearchService\Models\AutocompleteRequest.cs" />
     <Compile Include="SearchService\Models\AutocompleteResponse.cs" />
     <Compile Include="SearchService\Models\AutocompleteRequestType.cs" />
-    <Compile Include="SearchService\Models\AuxiliaryFileMetadata.cs" />
+    <Compile Include="AuxiliaryFiles\AuxiliaryFileMetadata.cs" />
     <Compile Include="SearchService\Models\AuxiliaryFilesMetadata.cs" />
     <Compile Include="SearchService\AzureSearchService.cs" />
     <Compile Include="SearchService\IAuxiliaryData.cs" />

--- a/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryData.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryData.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using NuGet.Indexing;
+using NuGet.Services.AzureSearch.AuxiliaryFiles;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {

--- a/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryDataCache.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryDataCache.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using NuGet.Services.AzureSearch.AuxiliaryFiles;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/AuxiliaryFilesMetadata.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/AuxiliaryFilesMetadata.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Newtonsoft.Json;
+using NuGet.Services.AzureSearch.AuxiliaryFiles;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
@@ -2,10 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using NuGet.Services.AzureSearch.AuxiliaryFiles;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
-    public class SearchServiceConfiguration : AzureSearchConfiguration
+    public class SearchServiceConfiguration : AzureSearchConfiguration, IAuxiliaryDataStorageConfiguration
     {
         public string SemVer1RegistrationsBaseUrl { get; set; }
         public string SemVer2RegistrationsBaseUrl { get; set; }

--- a/src/NuGet.Services.SearchService/App_Start/WebApiConfig.cs
+++ b/src/NuGet.Services.SearchService/App_Start/WebApiConfig.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using NuGet.Services.AzureSearch;
+using NuGet.Services.AzureSearch.AuxiliaryFiles;
 using NuGet.Services.AzureSearch.SearchService;
 using NuGet.Services.Configuration;
 using NuGet.Services.KeyVault;
@@ -139,6 +140,8 @@ namespace NuGet.Services.SearchService
             services.Add(ServiceDescriptor.Scoped(typeof(IOptionsSnapshot<>), typeof(NonCachingOptionsSnapshot<>)));
             services.Configure<AzureSearchConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));
             services.Configure<SearchServiceConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));
+            services.AddScoped<IOptionsSnapshot<IAuxiliaryDataStorageConfiguration>>(
+                p => p.GetRequiredService<IOptionsSnapshot<SearchServiceConfiguration>>());
             services.AddAzureSearch();
             services.AddSingleton(new TelemetryClient());
             services.AddTransient<ITelemetryClient, TelemetryClientWrapper>();

--- a/tests/NuGet.Services.AzureSearch.Tests/AuxiliaryFiles/AuxiliaryFileClientFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/AuxiliaryFiles/AuxiliaryFileClientFacts.cs
@@ -10,12 +10,13 @@ using Microsoft.Extensions.Options;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Moq;
+using NuGet.Services.AzureSearch.SearchService;
 using NuGet.Services.AzureSearch.Support;
 using NuGetGallery;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NuGet.Services.AzureSearch.SearchService
+namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 {
     public class AuxiliaryFileClientFacts
     {

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -69,7 +69,7 @@
     <Compile Include="Registration\RegistrationClientFacts.cs" />
     <Compile Include="SearchService\AuxiliaryDataCacheFacts.cs" />
     <Compile Include="SearchService\AuxiliaryDataFacts.cs" />
-    <Compile Include="SearchService\AuxiliaryFileClientFacts.cs" />
+    <Compile Include="AuxiliaryFiles\AuxiliaryFileClientFacts.cs" />
     <Compile Include="SearchService\AuxiliaryFileReloaderFacts.cs" />
     <Compile Include="SearchService\AzureSearchServiceFacts.cs" />
     <Compile Include="SearchService\SearchParametersBuilderFacts.cs" />

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryDataCacheFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryDataCacheFacts.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using NuGet.Indexing;
+using NuGet.Services.AzureSearch.AuxiliaryFiles;
 using NuGet.Services.AzureSearch.Support;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryDataFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryDataFacts.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using NuGet.Indexing;
+using NuGet.Services.AzureSearch.AuxiliaryFiles;
 using Xunit;
 
 namespace NuGet.Services.AzureSearch.SearchService

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using NuGet.Services.AzureSearch.AuxiliaryFiles;
 using NuGet.Services.AzureSearch.Support;
 using NuGet.Versioning;
 using Xunit;

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchStatusServiceFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchStatusServiceFacts.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.Search.Models;
 using Microsoft.Extensions.Options;
 using Moq;
+using NuGet.Services.AzureSearch.AuxiliaryFiles;
 using NuGet.Services.AzureSearch.Support;
 using NuGet.Services.AzureSearch.Wrappers;
 using Xunit;


### PR DESCRIPTION
`AuxiliaryFileClient` is currently only used by search service. Now it will be used by `Auxiliary2AzureSearch` as well.

Progress on https://github.com/NuGet/NuGetGallery/issues/6447.