### PR TITLE
[Azure Search 2] Add UpdateDownloadCount search document

### DIFF
--- a/src/NuGet.Services.AzureSearch/ISearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/ISearchDocumentBuilder.cs
@@ -22,6 +22,11 @@ namespace NuGet.Services.AzureSearch
             SearchFilters searchFilters,
             string[] owners);
 
+        SearchDocument.UpdateDownloadCount UpdateDownloadCount(
+            string packageId,
+            SearchFilters searchFilters,
+            long totalDownloadCount);
+
         SearchDocument.UpdateVersionList UpdateVersionListFromCatalog(
             string packageId,
             SearchFilters searchFilters,

--- a/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
@@ -17,7 +17,7 @@ namespace NuGet.Services.AzureSearch
         /// download count).
         /// </summary>
         [SerializePropertyNamesAsCamelCase]
-        public class Full : UpdateLatest
+        public class Full : UpdateLatest, IDownloadCount
         {
             [IsFilterable]
             public long? TotalDownloadCount { get; set; }
@@ -81,6 +81,18 @@ namespace NuGet.Services.AzureSearch
         }
 
         /// <summary>
+        /// Used when updating just the fields related to the download count of a document. Note that this model does
+        /// not need any analyzer or other Azure Search attributes since it is not used for index creation. The
+        /// <see cref="Full"/> and its parent classes handle this.
+        /// </summary>
+        [SerializePropertyNamesAsCamelCase]
+        public class UpdateDownloadCount : CommittedDocument, IDownloadCount
+        {
+            public long? TotalDownloadCount { get; set; }
+            public double? DownloadScore { get; set; }
+        }
+
+        /// <summary>
         /// Allows index updating code to apply a new version list to a document.
         /// </summary>
         public interface IVersions : ICommittedDocument
@@ -96,6 +108,15 @@ namespace NuGet.Services.AzureSearch
         public interface IOwners : ICommittedDocument
         {
             string[] Owners { get; set; }
+        }
+
+        /// <summary>
+        /// Allows index updating code to apply new download count information to a document.
+        /// </summary>
+        public interface IDownloadCount : ICommittedDocument
+        {
+            long? TotalDownloadCount { get; set; }
+            double? DownloadScore { get; set; }
         }
 
         /// <summary>

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -212,8 +212,7 @@ namespace NuGet.Services.AzureSearch
                 fullVersion: fullVersion,
                 owners: owners);
             _baseDocumentBuilder.PopulateMetadata(document, packageId, package);
-            document.TotalDownloadCount = totalDownloadCount;
-            document.DownloadScore = DocumentUtilities.GetDownloadScore(totalDownloadCount);
+            PopulateDownloadCount(document, totalDownloadCount);
 
             return document;
         }
@@ -298,6 +297,32 @@ namespace NuGet.Services.AzureSearch
             PopulateOwners(document, owners);
 
             return document;
+        }
+
+        public SearchDocument.UpdateDownloadCount UpdateDownloadCount(
+            string packageId,
+            SearchFilters searchFilters,
+            long totalDownloadCount)
+        {
+            var document = new SearchDocument.UpdateDownloadCount();
+
+            PopulateKey(document, packageId, searchFilters);
+            _baseDocumentBuilder.PopulateCommitted(
+                document,
+                lastUpdatedFromCatalog: false,
+                lastCommitTimestamp: null,
+                lastCommitId: null);
+            PopulateDownloadCount(document, totalDownloadCount);
+
+            return document;
+        }
+
+        private static void PopulateDownloadCount<T>(
+            T document,
+            long totalDownloadCount) where T : KeyedDocument, SearchDocument.IDownloadCount
+        {
+            document.TotalDownloadCount = totalDownloadCount;
+            document.DownloadScore = DocumentUtilities.GetDownloadScore(totalDownloadCount);
         }
     }
 }

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
@@ -177,6 +177,40 @@ namespace NuGet.Services.AzureSearch
             }
         }
 
+        public class UpdateDownloadCount : BaseFacts
+        {
+            public UpdateDownloadCount(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task SetsExpectedProperties()
+            {
+                var document = _target.UpdateDownloadCount(
+                    Data.PackageId,
+                    Data.SearchFilters,
+                    Data.TotalDownloadCount);
+
+                SetDocumentLastUpdated(document);
+                var json = await SerializationUtilities.SerializeToJsonAsync(document);
+                Assert.Equal(@"{
+  ""value"": [
+    {
+      ""@search.action"": ""upload"",
+      ""totalDownloadCount"": 1001,
+      ""downloadScore"": 0.14381174563233068,
+      ""lastUpdatedDocument"": ""2018-12-14T09:30:00+00:00"",
+      ""lastDocumentType"": ""NuGet.Services.AzureSearch.SearchDocument+UpdateDownloadCount"",
+      ""lastUpdatedFromCatalog"": false,
+      ""lastCommitTimestamp"": null,
+      ""lastCommitId"": null,
+      ""key"": ""windowsazure_storage-d2luZG93c2F6dXJlLnN0b3JhZ2U1-IncludePrereleaseAndSemVer2""
+    }
+  ]
+}", json);
+            }
+        }
+
         public class UpdateVersionListFromCatalog : BaseFacts
         {
             public UpdateVersionListFromCatalog(ITestOutputHelper output) : base(output)


### PR DESCRIPTION
Depends on https://github.com/NuGet/NuGet.Services.Metadata/pull/583.
Progress on https://github.com/NuGet/NuGetGallery/issues/6447.

This document will be used by Auxiliary2AzureSearh to update just the download count fields in the search index.

