### PR TITLE
[Azure Search 3] Change OwnerIndexActionBuilder into a more generic SearchIndexActionBuilder

### DIFF
--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -245,11 +245,11 @@ namespace NuGet.Services.AzureSearch
             services.AddTransient<IHijackDocumentBuilder, HijackDocumentBuilder>();
             services.AddTransient<IIndexBuilder, IndexBuilder>();
             services.AddTransient<INewPackageRegistrationProducer, NewPackageRegistrationProducer>();
-            services.AddTransient<IOwnerIndexActionBuilder, OwnerIndexActionBuilder>();
             services.AddTransient<IOwnerSetComparer, OwnerSetComparer>();
             services.AddTransient<IPackageEntityIndexActionBuilder, PackageEntityIndexActionBuilder>();
             services.AddTransient<IRegistrationClient, RegistrationClient>();
             services.AddTransient<ISearchDocumentBuilder, SearchDocumentBuilder>();
+            services.AddTransient<ISearchIndexActionBuilder, SearchIndexActionBuilder>();
             services.AddTransient<ISearchParametersBuilder, SearchParametersBuilder>();
             services.AddTransient<ISearchResponseBuilder, SearchResponseBuilder>();
             services.AddTransient<ISearchServiceClientWrapper, SearchServiceClientWrapper>();

--- a/src/NuGet.Services.AzureSearch/ISearchIndexActionBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/ISearchIndexActionBuilder.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.AzureSearch
+{
+    /// <summary>
+    /// Builds a set of index actions for a specific package ID against the search index. No hijack index actions
+    /// should be returned by this interface.
+    /// </summary>
+    public interface ISearchIndexActionBuilder
+    {
+        /// <summary>
+        /// Generates a set of index actions for all search documents that exist for this package ID. The document
+        /// for each search filter that is sent to the search index is built by <paramref name="buildDocument"/>. It is
+        /// assumed that the caller's implementation of the delegate knows the <paramref name="packageId"/> by context.
+        /// </summary>
+        /// <param name="packageId">The package ID to produce documents for.</param>
+        /// <param name="buildDocument">A delegate used to initialize the document.</param>
+        /// <returns>The index actions.</returns>
+        Task<IndexActions> UpdateAsync(string packageId, Func<SearchFilters, KeyedDocument> buildDocument);
+    }
+}

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -56,9 +56,9 @@
     <Compile Include="IAzureSearchTelemetryService.cs" />
     <Compile Include="IBaseDocumentBuilder.cs" />
     <Compile Include="IDatabaseOwnerFetcher.cs" />
-    <Compile Include="Owners2AzureSearch\IOwnerIndexActionBuilder.cs" />
+    <Compile Include="ISearchIndexActionBuilder.cs" />
     <Compile Include="Owners2AzureSearch\IOwnerSetComparer.cs" />
-    <Compile Include="Owners2AzureSearch\OwnerIndexActionBuilder.cs" />
+    <Compile Include="SearchIndexActionBuilder.cs" />
     <Compile Include="Owners2AzureSearch\OwnerSetComparer.cs" />
     <Compile Include="PackageIdToOwnersBuilder.cs" />
     <Compile Include="IOwnerDataClient.cs" />

--- a/src/NuGet.Services.AzureSearch/Owners2AzureSearch/IOwnerIndexActionBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/Owners2AzureSearch/IOwnerIndexActionBuilder.cs
@@ -1,9 +1,0 @@
-﻿using System.Threading.Tasks;
-
-namespace NuGet.Services.AzureSearch.Owners2AzureSearch
-{
-    public interface IOwnerIndexActionBuilder
-    {
-        Task<IndexActions> UpdateOwnersAsync(string packageId, string[] owners);
-    }
-}

--- a/src/NuGet.Services.AzureSearch/Owners2AzureSearch/Owners2AzureSearchCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Owners2AzureSearch/Owners2AzureSearchCommand.cs
@@ -17,7 +17,8 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
         private readonly IDatabaseOwnerFetcher _databaseOwnerFetcher;
         private readonly IOwnerDataClient _ownerDataClient;
         private readonly IOwnerSetComparer _ownerSetComparer;
-        private readonly IOwnerIndexActionBuilder _indexActionBuilder;
+        private readonly ISearchDocumentBuilder _searchDocumentBuilder;
+        private readonly ISearchIndexActionBuilder _searchIndexActionBuilder;
         private readonly Func<IBatchPusher> _batchPusherFactory;
         private readonly IOptionsSnapshot<AzureSearchJobConfiguration> _options;
         private readonly IAzureSearchTelemetryService _telemetryService;
@@ -27,7 +28,8 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
             IDatabaseOwnerFetcher databaseOwnerFetcher,
             IOwnerDataClient ownerDataClient,
             IOwnerSetComparer ownerSetComparer,
-            IOwnerIndexActionBuilder indexActionBuilder,
+            ISearchDocumentBuilder searchDocumentBuilder,
+            ISearchIndexActionBuilder indexActionBuilder,
             Func<IBatchPusher> batchPusherFactory,
             IOptionsSnapshot<AzureSearchJobConfiguration> options,
             IAzureSearchTelemetryService telemetryService,
@@ -36,7 +38,8 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
             _databaseOwnerFetcher = databaseOwnerFetcher ?? throw new ArgumentNullException(nameof(databaseOwnerFetcher));
             _ownerDataClient = ownerDataClient ?? throw new ArgumentNullException(nameof(ownerDataClient));
             _ownerSetComparer = ownerSetComparer ?? throw new ArgumentNullException(nameof(ownerSetComparer));
-            _indexActionBuilder = indexActionBuilder ?? throw new ArgumentNullException(nameof(indexActionBuilder));
+            _searchDocumentBuilder = searchDocumentBuilder ?? throw new ArgumentNullException(nameof(searchDocumentBuilder));
+            _searchIndexActionBuilder = indexActionBuilder ?? throw new ArgumentNullException(nameof(indexActionBuilder));
             _batchPusherFactory = batchPusherFactory ?? throw new ArgumentNullException(nameof(batchPusherFactory));
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
@@ -102,7 +105,14 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
             var batchPusher = _batchPusherFactory();
             while (changesBag.TryTake(out var changes))
             {
-                var indexActions = await _indexActionBuilder.UpdateOwnersAsync(changes.Id, changes.Value);
+                // Note that the owner list passed in can be empty (e.g. if the last owner was deleted or removed from
+                // the package registration).
+                var indexActions = await _searchIndexActionBuilder.UpdateAsync(
+                    changes.Id,
+                    searchFilters => _searchDocumentBuilder.UpdateOwners(changes.Id, searchFilters, changes.Value));
+
+                // If no index actions are returned, this means that there are no listed packages or no
+                // packages at all.
                 if (indexActions.IsEmpty)
                 {
                     continue;

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -61,7 +61,7 @@
     <Compile Include="IndexBuilderFacts.cs" />
     <Compile Include="Models\CommittedDocumentFacts.cs" />
     <Compile Include="Owners2AzureSearch\OwnerDataClientFacts.cs" />
-    <Compile Include="Owners2AzureSearch\OwnerIndexActionBuilderFacts.cs" />
+    <Compile Include="SearchIndexActionBuilderFacts.cs" />
     <Compile Include="Owners2AzureSearch\Owners2AzureSearchCommandFacts.cs" />
     <Compile Include="Owners2AzureSearch\OwnerSetComparerFacts.cs" />
     <Compile Include="Registration\RegistrationUrlBuilderFacts.cs" />

--- a/tests/NuGet.Services.AzureSearch.Tests/Owners2AzureSearch/Owners2AzureSearchCommandFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Owners2AzureSearch/Owners2AzureSearchCommandFacts.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -169,7 +170,8 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
                 DatabaseOwnerFetcher = new Mock<IDatabaseOwnerFetcher>();
                 OwnerDataClient = new Mock<IOwnerDataClient>();
                 OwnerSetComparer = new Mock<IOwnerSetComparer>();
-                OwnerIndexActionBuilder = new Mock<IOwnerIndexActionBuilder>();
+                SearchDocumentBuilder = new Mock<ISearchDocumentBuilder>();
+                SearchIndexActionBuilder = new Mock<ISearchIndexActionBuilder>();
                 Pusher = new Mock<IBatchPusher>();
                 Options = new Mock<IOptionsSnapshot<AzureSearchJobConfiguration>>();
                 TelemetryService = new Mock<IAzureSearchTelemetryService>();
@@ -205,15 +207,16 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
                         It.IsAny<SortedDictionary<string, SortedSet<string>>>(),
                         It.IsAny<SortedDictionary<string, SortedSet<string>>>()))
                     .Returns(() => Changes);
-                OwnerIndexActionBuilder
-                    .Setup(x => x.UpdateOwnersAsync(It.IsAny<string>(), It.IsAny<string[]>()))
+                SearchIndexActionBuilder
+                    .Setup(x => x.UpdateAsync(It.IsAny<string>(), It.IsAny<Func<SearchFilters, KeyedDocument>>()))
                     .ReturnsAsync(() => IndexActions);
 
                 Target = new Owners2AzureSearchCommand(
                     DatabaseOwnerFetcher.Object,
                     OwnerDataClient.Object,
                     OwnerSetComparer.Object,
-                    OwnerIndexActionBuilder.Object,
+                    SearchDocumentBuilder.Object,
+                    SearchIndexActionBuilder.Object,
                     () => Pusher.Object,
                     Options.Object,
                     TelemetryService.Object,
@@ -223,7 +226,8 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
             public Mock<IDatabaseOwnerFetcher> DatabaseOwnerFetcher { get; }
             public Mock<IOwnerDataClient> OwnerDataClient { get; }
             public Mock<IOwnerSetComparer> OwnerSetComparer { get; }
-            public Mock<IOwnerIndexActionBuilder> OwnerIndexActionBuilder { get; }
+            public Mock<ISearchDocumentBuilder> SearchDocumentBuilder { get; }
+            public Mock<ISearchIndexActionBuilder> SearchIndexActionBuilder { get; }
             public Mock<IBatchPusher> Pusher { get; }
             public Mock<IOptionsSnapshot<AzureSearchJobConfiguration>> Options { get; }
             public Mock<IAzureSearchTelemetryService> TelemetryService { get; }

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchIndexActionBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchIndexActionBuilderFacts.cs
@@ -10,13 +10,13 @@ using NuGetGallery;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NuGet.Services.AzureSearch.Owners2AzureSearch
+namespace NuGet.Services.AzureSearch
 {
-    public class OwnerIndexActionBuilderFacts
+    public class SearchIndexActionBuilderFacts
     {
-        public class UpdateOwnersAsync : Facts
+        public class UpdateAsync : Facts
         {
-            public UpdateOwnersAsync(ITestOutputHelper output) : base(output)
+            public UpdateAsync(ITestOutputHelper output) : base(output)
             {
             }
 
@@ -33,9 +33,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
                     }),
                     AccessConditionWrapper.GenerateIfNotExistsCondition());
 
-                var indexActions = await Target.UpdateOwnersAsync(
-                    Data.PackageId,
-                    Data.Owners);
+                var indexActions = await Target.UpdateAsync(Data.PackageId, BuildDocument);
 
                 Assert.Same(VersionListDataResult, indexActions.VersionListDataResult);
                 Assert.Empty(indexActions.Hijack);
@@ -63,9 +61,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
                     }),
                     AccessConditionWrapper.GenerateIfNotExistsCondition());
 
-                var indexActions = await Target.UpdateOwnersAsync(
-                    Data.PackageId,
-                    Data.Owners);
+                var indexActions = await Target.UpdateAsync(Data.PackageId, BuildDocument);
 
                 Assert.Same(VersionListDataResult, indexActions.VersionListDataResult);
                 Assert.Empty(indexActions.Hijack);
@@ -91,9 +87,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
                     }),
                     AccessConditionWrapper.GenerateIfNotExistsCondition());
 
-                var indexActions = await Target.UpdateOwnersAsync(
-                    Data.PackageId,
-                    Data.Owners);
+                var indexActions = await Target.UpdateAsync(Data.PackageId, BuildDocument);
 
                 Assert.Same(VersionListDataResult, indexActions.VersionListDataResult);
                 Assert.Empty(indexActions.Hijack);
@@ -107,9 +101,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
                     new VersionListData(new Dictionary<string, VersionPropertiesData>()),
                     AccessConditionWrapper.GenerateIfNotExistsCondition());
 
-                var indexActions = await Target.UpdateOwnersAsync(
-                    Data.PackageId,
-                    Data.Owners);
+                var indexActions = await Target.UpdateAsync(Data.PackageId, BuildDocument);
 
                 Assert.Same(VersionListDataResult, indexActions.VersionListDataResult);
                 Assert.Empty(indexActions.Hijack);
@@ -123,7 +115,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
             {
                 VersionListDataClient = new Mock<IVersionListDataClient>();
                 Search = new Mock<ISearchDocumentBuilder>();
-                Logger = output.GetLogger<OwnerIndexActionBuilder>();
+                Logger = output.GetLogger<SearchIndexActionBuilder>();
 
                 VersionListDataResult = new ResultAndAccessCondition<VersionListData>(
                     new VersionListData(new Dictionary<string, VersionPropertiesData>()),
@@ -139,17 +131,23 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
                         Key = sf.ToString(),
                     });
 
-                Target = new OwnerIndexActionBuilder(
-                    VersionListDataClient.Object,
-                    Search.Object,
-                    Logger);
+                Target = new SearchIndexActionBuilder(VersionListDataClient.Object, Logger);
             }
 
             public Mock<IVersionListDataClient> VersionListDataClient { get; }
             public Mock<ISearchDocumentBuilder> Search { get; }
-            public RecordingLogger<OwnerIndexActionBuilder> Logger { get; }
+            public RecordingLogger<SearchIndexActionBuilder> Logger { get; }
             public ResultAndAccessCondition<VersionListData> VersionListDataResult { get; set; }
-            public OwnerIndexActionBuilder Target { get; }
+            public SearchIndexActionBuilder Target { get; }
+
+            /// <summary>
+            /// The <see cref="SearchDocument.UpdateOwners"/> document is used as a simple example but other documents
+            /// could be produced.
+            /// </summary>
+            public SearchDocument.UpdateOwners BuildDocument(SearchFilters sf)
+            {
+                return Search.Object.UpdateOwners(Data.PackageId, sf, Data.Owners);
+            }
         }
     }
 }

--- a/tests/NuGet.Services.AzureSearch.Tests/Wrappers/DocumentOperationsWrapperFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Wrappers/DocumentOperationsWrapperFacts.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Search;
 using Microsoft.Azure.Search.Models;
-using Microsoft.Rest.Azure;
 using Moq;
 using NuGet.Services.AzureSearch.Support;
 using Xunit;


### PR DESCRIPTION
Depends on https://github.com/NuGet/NuGet.Services.Metadata/pull/584.
Progress on https://github.com/NuGet/NuGetGallery/issues/6447.

This logic is already implemented for Owners2AzureSearch: get a package ID version list, find all of the applicable search filters, create a small document per search filter, yield the index actions. Any job that is just updated the search index can use this logic.