### PR TITLE
Don't clear catalog commit information in search documents

### DIFF
--- a/src/NuGet.Services.AzureSearch/BaseDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/BaseDocumentBuilder.cs
@@ -36,6 +36,15 @@ namespace NuGet.Services.AzureSearch
             _options = options ?? throw new ArgumentNullException(nameof(options));
         }
 
+        public void PopulateUpdated(
+            IUpdatedDocument document,
+            bool lastUpdatedFromCatalog)
+        {
+            document.SetLastUpdatedDocumentOnNextRead();
+            document.LastDocumentType = document.GetType().FullName;
+            document.LastUpdatedFromCatalog = lastUpdatedFromCatalog;
+        }
+
         public void PopulateCommitted(
             ICommittedDocument document,
             bool lastUpdatedFromCatalog,
@@ -67,9 +76,7 @@ namespace NuGet.Services.AzureSearch
                 }
             }
 
-            document.SetLastUpdatedDocumentOnNextRead();
-            document.LastDocumentType = document.GetType().FullName;
-            document.LastUpdatedFromCatalog = lastUpdatedFromCatalog;
+            PopulateUpdated(document, lastUpdatedFromCatalog);
             document.LastCommitTimestamp = lastCommitTimestamp;
             document.LastCommitId = lastCommitId;
         }

--- a/src/NuGet.Services.AzureSearch/IBaseDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/IBaseDocumentBuilder.cs
@@ -9,6 +9,9 @@ namespace NuGet.Services.AzureSearch
 {
     public interface IBaseDocumentBuilder
     {
+        void PopulateUpdated(
+            IUpdatedDocument document,
+            bool lastUpdatedFromCatalog);
         void PopulateCommitted(
             ICommittedDocument document,
             bool lastUpdatedFromCatalog,

--- a/src/NuGet.Services.AzureSearch/Models/CommittedDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/CommittedDocument.cs
@@ -7,33 +7,13 @@ using Newtonsoft.Json;
 
 namespace NuGet.Services.AzureSearch
 {
-    public abstract class CommittedDocument : KeyedDocument, ICommittedDocument
+    public abstract class CommittedDocument : UpdatedDocument, ICommittedDocument
     {
-        private readonly CurrentTimestamp _lastUpdatedDocument = new CurrentTimestamp();
-
-        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
-        public DateTimeOffset? LastUpdatedDocument
-        {
-            get => _lastUpdatedDocument.Value;
-            set => _lastUpdatedDocument.Value = value;
-        }
-
-        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
-        public string LastDocumentType { get; set; }
-
-        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
-        public bool? LastUpdatedFromCatalog { get; set; }
-
         [IsSortable]
         [JsonProperty(NullValueHandling = NullValueHandling.Include)]
         public DateTimeOffset? LastCommitTimestamp { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Include)]
         public string LastCommitId { get; set; }
-
-        public void SetLastUpdatedDocumentOnNextRead()
-        {
-            _lastUpdatedDocument.SetOnNextRead();
-        }
     }
 }

--- a/src/NuGet.Services.AzureSearch/Models/ICommittedDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/ICommittedDocument.cs
@@ -8,13 +8,9 @@ namespace NuGet.Services.AzureSearch
     /// <summary>
     /// A document that has data committed from the catalog.
     /// </summary>
-    public interface ICommittedDocument : IKeyedDocument
+    public interface ICommittedDocument : IUpdatedDocument
     {
-        DateTimeOffset? LastUpdatedDocument { get; set; }
-        string LastDocumentType { get; set; }
-        bool? LastUpdatedFromCatalog { get; set; }
         DateTimeOffset? LastCommitTimestamp { get; set; }
         string LastCommitId { get; set; }
-        void SetLastUpdatedDocumentOnNextRead();
     }
 }

--- a/src/NuGet.Services.AzureSearch/Models/IUpdatedDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/IUpdatedDocument.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.AzureSearch
+{
+    /// <summary>
+    /// A document that been updated.
+    /// </summary>
+    public interface IUpdatedDocument : IKeyedDocument
+    {
+        DateTimeOffset? LastUpdatedDocument { get; set; }
+        string LastDocumentType { get; set; }
+        bool? LastUpdatedFromCatalog { get; set; }
+        void SetLastUpdatedDocumentOnNextRead();
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
@@ -75,7 +75,7 @@ namespace NuGet.Services.AzureSearch
         /// parent classes handle this.
         /// </summary>
         [SerializePropertyNamesAsCamelCase]
-        public class UpdateOwners : CommittedDocument, IOwners
+        public class UpdateOwners : UpdatedDocument, IOwners
         {
             public string[] Owners { get; set; }
         }
@@ -86,7 +86,7 @@ namespace NuGet.Services.AzureSearch
         /// <see cref="Full"/> and its parent classes handle this.
         /// </summary>
         [SerializePropertyNamesAsCamelCase]
-        public class UpdateDownloadCount : CommittedDocument, IDownloadCount
+        public class UpdateDownloadCount : UpdatedDocument, IDownloadCount
         {
             public long? TotalDownloadCount { get; set; }
             public double? DownloadScore { get; set; }
@@ -105,7 +105,7 @@ namespace NuGet.Services.AzureSearch
         /// <summary>
         /// Allows index updating code to apply a new list of owners to a document.
         /// </summary>
-        public interface IOwners : ICommittedDocument
+        public interface IOwners : IUpdatedDocument
         {
             string[] Owners { get; set; }
         }
@@ -113,7 +113,7 @@ namespace NuGet.Services.AzureSearch
         /// <summary>
         /// Allows index updating code to apply new download count information to a document.
         /// </summary>
-        public interface IDownloadCount : ICommittedDocument
+        public interface IDownloadCount : IUpdatedDocument
         {
             long? TotalDownloadCount { get; set; }
             double? DownloadScore { get; set; }

--- a/src/NuGet.Services.AzureSearch/Models/UpdatedDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/UpdatedDocument.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Newtonsoft.Json;
+
+namespace NuGet.Services.AzureSearch
+{
+    public abstract class UpdatedDocument : KeyedDocument
+    {
+        private readonly CurrentTimestamp _lastUpdatedDocument = new CurrentTimestamp();
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
+        public DateTimeOffset? LastUpdatedDocument
+        {
+            get => _lastUpdatedDocument.Value;
+            set => _lastUpdatedDocument.Value = value;
+        }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
+        public string LastDocumentType { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
+        public bool? LastUpdatedFromCatalog { get; set; }
+
+        public void SetLastUpdatedDocumentOnNextRead()
+        {
+            _lastUpdatedDocument.SetOnNextRead();
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -57,6 +57,8 @@
     <Compile Include="IBaseDocumentBuilder.cs" />
     <Compile Include="IDatabaseOwnerFetcher.cs" />
     <Compile Include="ISearchIndexActionBuilder.cs" />
+    <Compile Include="Models\IUpdatedDocument.cs" />
+    <Compile Include="Models\UpdatedDocument.cs" />
     <Compile Include="Owners2AzureSearch\IOwnerSetComparer.cs" />
     <Compile Include="SearchIndexActionBuilder.cs" />
     <Compile Include="Owners2AzureSearch\OwnerSetComparer.cs" />

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -289,11 +289,9 @@ namespace NuGet.Services.AzureSearch
             var document = new SearchDocument.UpdateOwners();
 
             PopulateKey(document, packageId, searchFilters);
-            _baseDocumentBuilder.PopulateCommitted(
+            _baseDocumentBuilder.PopulateUpdated(
                 document,
-                lastUpdatedFromCatalog: false,
-                lastCommitTimestamp: null,
-                lastCommitId: null);
+                lastUpdatedFromCatalog: false);
             PopulateOwners(document, owners);
 
             return document;
@@ -307,11 +305,9 @@ namespace NuGet.Services.AzureSearch
             var document = new SearchDocument.UpdateDownloadCount();
 
             PopulateKey(document, packageId, searchFilters);
-            _baseDocumentBuilder.PopulateCommitted(
+            _baseDocumentBuilder.PopulateUpdated(
                 document,
-                lastUpdatedFromCatalog: false,
-                lastCommitTimestamp: null,
-                lastCommitId: null);
+                lastUpdatedFromCatalog: false);
             PopulateDownloadCount(document, totalDownloadCount);
 
             return document;

--- a/tests/NuGet.Services.AzureSearch.Tests/HijackDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/HijackDocumentBuilderFacts.cs
@@ -65,11 +65,11 @@ namespace NuGet.Services.AzureSearch
       ""isLatestSemVer1"": true,
       ""isLatestStableSemVer2"": false,
       ""isLatestSemVer2"": true,
+      ""lastCommitTimestamp"": ""2018-12-13T12:30:00+00:00"",
+      ""lastCommitId"": ""6b9b24dd-7aec-48ae-afc1-2a117e3d50d1"",
       ""lastUpdatedDocument"": ""2018-12-14T09:30:00+00:00"",
       ""lastDocumentType"": ""NuGet.Services.AzureSearch.HijackDocument+Latest"",
       ""lastUpdatedFromCatalog"": true,
-      ""lastCommitTimestamp"": ""2018-12-13T12:30:00+00:00"",
-      ""lastCommitId"": ""6b9b24dd-7aec-48ae-afc1-2a117e3d50d1"",
       ""key"": ""windowsazure_storage_7_1_2-alpha-d2luZG93c2F6dXJlLnN0b3JhZ2UvNy4xLjItYWxwaGE1""
     }
   ]
@@ -159,11 +159,11 @@ namespace NuGet.Services.AzureSearch
       ],
       ""title"": ""Windows Azure Storage"",
       ""tokenizedPackageId"": ""WindowsAzure.Storage"",
+      ""lastCommitTimestamp"": null,
+      ""lastCommitId"": null,
       ""lastUpdatedDocument"": ""2018-12-14T09:30:00+00:00"",
       ""lastDocumentType"": ""NuGet.Services.AzureSearch.HijackDocument+Full"",
       ""lastUpdatedFromCatalog"": false,
-      ""lastCommitTimestamp"": null,
-      ""lastCommitId"": null,
       ""key"": ""windowsazure_storage_7_1_2-alpha-d2luZG93c2F6dXJlLnN0b3JhZ2UvNy4xLjItYWxwaGE1""
     }
   ]
@@ -317,11 +317,11 @@ namespace NuGet.Services.AzureSearch
       ],
       ""title"": ""Windows Azure Storage"",
       ""tokenizedPackageId"": ""WindowsAzure.Storage"",
+      ""lastCommitTimestamp"": ""2018-12-13T12:30:00+00:00"",
+      ""lastCommitId"": ""6b9b24dd-7aec-48ae-afc1-2a117e3d50d1"",
       ""lastUpdatedDocument"": ""2018-12-14T09:30:00+00:00"",
       ""lastDocumentType"": ""NuGet.Services.AzureSearch.HijackDocument+Full"",
       ""lastUpdatedFromCatalog"": true,
-      ""lastCommitTimestamp"": ""2018-12-13T12:30:00+00:00"",
-      ""lastCommitId"": ""6b9b24dd-7aec-48ae-afc1-2a117e3d50d1"",
       ""key"": ""windowsazure_storage_7_1_2-alpha-d2luZG93c2F6dXJlLnN0b3JhZ2UvNy4xLjItYWxwaGE1""
     }
   ]
@@ -437,7 +437,7 @@ namespace NuGet.Services.AzureSearch
                 new object[] { " \t"},
             };
 
-            public void SetDocumentLastUpdated(ICommittedDocument document)
+            public void SetDocumentLastUpdated(IUpdatedDocument document)
             {
                 Data.SetDocumentLastUpdated(document, _output);
             }

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
@@ -168,8 +168,6 @@ namespace NuGet.Services.AzureSearch
       ""lastUpdatedDocument"": ""2018-12-14T09:30:00+00:00"",
       ""lastDocumentType"": ""NuGet.Services.AzureSearch.SearchDocument+UpdateOwners"",
       ""lastUpdatedFromCatalog"": false,
-      ""lastCommitTimestamp"": null,
-      ""lastCommitId"": null,
       ""key"": ""windowsazure_storage-d2luZG93c2F6dXJlLnN0b3JhZ2U1-IncludePrereleaseAndSemVer2""
     }
   ]
@@ -202,8 +200,6 @@ namespace NuGet.Services.AzureSearch
       ""lastUpdatedDocument"": ""2018-12-14T09:30:00+00:00"",
       ""lastDocumentType"": ""NuGet.Services.AzureSearch.SearchDocument+UpdateDownloadCount"",
       ""lastUpdatedFromCatalog"": false,
-      ""lastCommitTimestamp"": null,
-      ""lastCommitId"": null,
       ""key"": ""windowsazure_storage-d2luZG93c2F6dXJlLnN0b3JhZ2U1-IncludePrereleaseAndSemVer2""
     }
   ]
@@ -247,11 +243,11 @@ namespace NuGet.Services.AzureSearch
       ],
       ""isLatestStable"": " + isLatestStable.ToString().ToLowerInvariant() + @",
       ""isLatest"": " + isLatest.ToString().ToLowerInvariant() + @",
+      ""lastCommitTimestamp"": ""2018-12-13T12:30:00+00:00"",
+      ""lastCommitId"": ""6b9b24dd-7aec-48ae-afc1-2a117e3d50d1"",
       ""lastUpdatedDocument"": ""2018-12-14T09:30:00+00:00"",
       ""lastDocumentType"": ""NuGet.Services.AzureSearch.SearchDocument+UpdateVersionList"",
       ""lastUpdatedFromCatalog"": true,
-      ""lastCommitTimestamp"": ""2018-12-13T12:30:00+00:00"",
-      ""lastCommitId"": ""6b9b24dd-7aec-48ae-afc1-2a117e3d50d1"",
       ""key"": ""windowsazure_storage-d2luZG93c2F6dXJlLnN0b3JhZ2U1-IncludePrereleaseAndSemVer2""
     }
   ]
@@ -300,11 +296,11 @@ namespace NuGet.Services.AzureSearch
       ],
       ""isLatestStable"": " + isLatestStable.ToString().ToLowerInvariant() + @",
       ""isLatest"": " + isLatest.ToString().ToLowerInvariant() + @",
+      ""lastCommitTimestamp"": ""2018-12-13T12:30:00+00:00"",
+      ""lastCommitId"": ""6b9b24dd-7aec-48ae-afc1-2a117e3d50d1"",
       ""lastUpdatedDocument"": ""2018-12-14T09:30:00+00:00"",
       ""lastDocumentType"": ""NuGet.Services.AzureSearch.SearchDocument+UpdateVersionListAndOwners"",
       ""lastUpdatedFromCatalog"": true,
-      ""lastCommitTimestamp"": ""2018-12-13T12:30:00+00:00"",
-      ""lastCommitId"": ""6b9b24dd-7aec-48ae-afc1-2a117e3d50d1"",
       ""key"": ""windowsazure_storage-d2luZG93c2F6dXJlLnN0b3JhZ2U1-IncludePrereleaseAndSemVer2""
     }
   ]
@@ -409,11 +405,11 @@ namespace NuGet.Services.AzureSearch
       ],
       ""title"": ""Windows Azure Storage"",
       ""tokenizedPackageId"": ""WindowsAzure.Storage"",
+      ""lastCommitTimestamp"": ""2018-12-13T12:30:00+00:00"",
+      ""lastCommitId"": ""6b9b24dd-7aec-48ae-afc1-2a117e3d50d1"",
       ""lastUpdatedDocument"": ""2018-12-14T09:30:00+00:00"",
       ""lastDocumentType"": ""NuGet.Services.AzureSearch.SearchDocument+UpdateLatest"",
       ""lastUpdatedFromCatalog"": true,
-      ""lastCommitTimestamp"": ""2018-12-13T12:30:00+00:00"",
-      ""lastCommitId"": ""6b9b24dd-7aec-48ae-afc1-2a117e3d50d1"",
       ""key"": ""windowsazure_storage-d2luZG93c2F6dXJlLnN0b3JhZ2U1-" + expected + @"""
     }
   ]
@@ -660,11 +656,11 @@ namespace NuGet.Services.AzureSearch
       ],
       ""title"": ""Windows Azure Storage"",
       ""tokenizedPackageId"": ""WindowsAzure.Storage"",
+      ""lastCommitTimestamp"": null,
+      ""lastCommitId"": null,
       ""lastUpdatedDocument"": ""2018-12-14T09:30:00+00:00"",
       ""lastDocumentType"": ""NuGet.Services.AzureSearch.SearchDocument+Full"",
       ""lastUpdatedFromCatalog"": false,
-      ""lastCommitTimestamp"": null,
-      ""lastCommitId"": null,
       ""key"": ""windowsazure_storage-d2luZG93c2F6dXJlLnN0b3JhZ2U1-" + expected + @"""
     }
   ]
@@ -768,7 +764,7 @@ namespace NuGet.Services.AzureSearch
                 Assert.Empty(allSearchFilters.Except(testedSearchFilters));
             }
 
-            public void SetDocumentLastUpdated(ICommittedDocument document)
+            public void SetDocumentLastUpdated(IUpdatedDocument document)
             {
                 Data.SetDocumentLastUpdated(document, _output);
             }

--- a/tests/NuGet.Services.AzureSearch.Tests/Support/Data.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Support/Data.cs
@@ -30,7 +30,7 @@ namespace NuGet.Services.AzureSearch.Support
         public static readonly DateTimeOffset CommitTimestamp = new DateTimeOffset(2018, 12, 13, 12, 30, 0, TimeSpan.Zero);
         public static readonly string CommitId = "6b9b24dd-7aec-48ae-afc1-2a117e3d50d1";
 
-        public static void SetDocumentLastUpdated(ICommittedDocument document, ITestOutputHelper output)
+        public static void SetDocumentLastUpdated(IUpdatedDocument document, ITestOutputHelper output)
         {
             var currentTimestamp = document.LastUpdatedDocument;
             output.WriteLine(


### PR DESCRIPTION
This is necessary because the Auxiliary2AzureSearch job could potentially clear all last commit timestamps on all documents which would lead to an alert being fired on missing last commit timestamp in /search/diag. As a side effect, this also leads to better traceability on the changes made to search documents.
Progress on https://github.com/NuGet/NuGetGallery/issues/6458