### PR TITLE
[Azure Search 2] Add DownloadSetComparer to detect download count changes

### DIFF
--- a/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/DownloadSetComparer.cs
+++ b/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/DownloadSetComparer.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using NuGet.Services.AzureSearch.AuxiliaryFiles;
+
+namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
+{
+    public class DownloadSetComparer : IDownloadSetComparer
+    {
+        private readonly IAzureSearchTelemetryService _telemetryService;
+        private readonly ILogger<DownloadSetComparer> _logger;
+
+        public DownloadSetComparer(
+            IAzureSearchTelemetryService telemetryService,
+            ILogger<DownloadSetComparer> logger)
+        {
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public SortedDictionary<string, long> Compare(
+            DownloadData oldData,
+            DownloadData newData)
+        {
+            var stopwatch = Stopwatch.StartNew();
+
+            // We use a very simplistic algorithm here. Find the union of both ID sets and compare each download count.
+            var uniqueIds = new HashSet<string>(
+                oldData.Keys.Concat(newData.Keys),
+                StringComparer.OrdinalIgnoreCase);
+
+            _logger.LogInformation(
+                "There are {OldCount} IDs in the old data, {NewCount} IDs in the new data, and {TotalCount} IDs in total.",
+                oldData.Count,
+                newData.Count,
+                uniqueIds.Count);
+
+            var result = new SortedDictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+            foreach (var id in uniqueIds)
+            {
+                // Detect download count decreases and emit a metric. This is not necessarily wrong because there have
+                // been times that we manually delete spoofed download counts.
+                DetectDownloadCountDescreases(oldData, newData, id);
+
+                var oldCount = oldData.GetDownloadCount(id);
+                var newCount = newData.GetDownloadCount(id);
+                if (oldCount != newCount)
+                {
+                    result.Add(id, newCount);
+                }
+            }
+
+            _logger.LogInformation("There are {Count} package IDs with download count changes.", result.Count);
+
+            stopwatch.Stop();
+            _telemetryService.TrackDownloadSetComparison(oldData.Count, newData.Count, result.Count, stopwatch.Elapsed);
+
+            return result;
+        }
+
+        private void DetectDownloadCountDescreases(DownloadData oldData, DownloadData newData, string id)
+        {
+            var oldHasId = oldData.TryGetValue(id, out var oldDownloads);
+            if (!oldHasId)
+            {
+                oldDownloads = new DownloadByVersionData();
+            }
+
+            var newHasId = newData.TryGetValue(id, out var newDownloads);
+            if (!newHasId)
+            {
+                newDownloads = new DownloadByVersionData();
+            }
+
+            var uniqueVersions = new HashSet<string>(
+                oldDownloads.Keys.Concat(newDownloads.Keys),
+                StringComparer.OrdinalIgnoreCase);
+
+            foreach (var version in uniqueVersions)
+            {
+                var oldHasVersion = oldDownloads.TryGetValue(version, out var oldCount);
+                var newHasVersion = newDownloads.TryGetValue(version, out var newCount);
+
+                if (newCount < oldCount)
+                {
+                    _telemetryService.TrackDownloadCountDecrease(
+                        id,
+                        version,
+                        oldHasId,
+                        oldHasVersion,
+                        oldCount,
+                        newHasId,
+                        newHasVersion,
+                        newCount);
+                }
+            }
+        }
+    }
+}
+

--- a/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/IDownloadSetComparer.cs
+++ b/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/IDownloadSetComparer.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Services.AzureSearch.AuxiliaryFiles;
+
+namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
+{
+    public interface IDownloadSetComparer
+    {
+        /// <summary>
+        /// Compares the old download count data with the new download count data and returns the changes.
+        /// </summary>
+        /// <param name="oldData">The old data.</param>
+        /// <param name="newData">The new data.</param>
+        /// <returns>The changes where the key is the package ID and the value is the new download count.</returns>
+        SortedDictionary<string, long> Compare(DownloadData oldData, DownloadData newData);
+    }
+}

--- a/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
@@ -306,5 +306,44 @@ namespace NuGet.Services.AzureSearch
                     { "PackageIdCount", packageIdCount.ToString() },
                 });
         }
+
+        public void TrackDownloadSetComparison(int oldCount, int newCount, int changeCount, TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "DownloadSetComparisonSeconds",
+                elapsed.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { "OldCount", oldCount.ToString() },
+                    { "NewCount", newCount.ToString() },
+                    { "ChangeCount", changeCount.ToString() },
+                });
+        }
+
+        public void TrackDownloadCountDecrease(
+            string packageId,
+            string version,
+            bool oldHasId,
+            bool oldHasVersion,
+            long oldDownloads,
+            bool newHasId,
+            bool newHasVersion,
+            long newDownloads)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "DownloadCountDecrease",
+                1,
+                new Dictionary<string, string>
+                {
+                    { "PackageId", packageId },
+                    { "Version", version },
+                    { "OldHasId", oldHasId.ToString() },
+                    { "OldHasVersion", oldHasVersion.ToString() },
+                    { "OldDownloads", oldDownloads.ToString() },
+                    { "NewHasId", newHasId.ToString() },
+                    { "NewHasVersion", newHasVersion.ToString() },
+                    { "NewDownloads", newDownloads.ToString() },
+                });
+        }
     }
 }

--- a/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
@@ -28,9 +28,19 @@ namespace NuGet.Services.AzureSearch
         void TrackV2SearchQueryWithSearchIndex(TimeSpan elapsed);
         void TrackV2SearchQueryWithHijackIndex(TimeSpan elapsed);
         void TrackAutocompleteQuery(TimeSpan elapsed);
+        void TrackDownloadSetComparison(int oldCount, int newCount, int changeCount, TimeSpan elapsed);
         void TrackV3SearchQuery(TimeSpan elapsed);
         void TrackGetSearchServiceStatus(SearchStatusOptions options, bool success, TimeSpan elapsed);
         void TrackDocumentCountQuery(string indexName, long count, TimeSpan elapsed);
+        void TrackDownloadCountDecrease(
+            string packageId,
+            string version,
+            bool oldHasId,
+            bool oldHasVersion,
+            long oldDownloads,
+            bool newHasId,
+            bool newHasVersion,
+            long newDownloads);
         void TrackWarmQuery(string indexName, TimeSpan elapsed);
         void TrackLastCommitTimestampQuery(string indexName, DateTimeOffset? lastCommitTimestamp, TimeSpan elapsed);
         IDisposable TrackCatalogLeafDownloadBatch(int count);

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -49,6 +49,8 @@
     <Compile Include="Analysis\PackageIdCustomTokenizer.cs" />
     <Compile Include="Auxiliary2AzureSearch\Auxiliary2AzureSearchCommand.cs" />
     <Compile Include="Auxiliary2AzureSearch\Auxiliary2AzureSearchConfiguration.cs" />
+    <Compile Include="Auxiliary2AzureSearch\DownloadSetComparer.cs" />
+    <Compile Include="Auxiliary2AzureSearch\IDownloadSetComparer.cs" />
     <Compile Include="AuxiliaryFiles\DownloadByVersionData.cs" />
     <Compile Include="AuxiliaryFiles\DownloadData.cs" />
     <Compile Include="AuxiliaryFiles\DownloadDataClient.cs" />

--- a/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/DownloadSetComparerFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/DownloadSetComparerFacts.cs
@@ -1,0 +1,235 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using NuGet.Services.AzureSearch.AuxiliaryFiles;
+using NuGet.Services.AzureSearch.Support;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
+{
+    public class DownloadSetComparerFacts
+    {
+        public class Compare : Facts
+        {
+            public Compare(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public void DetectsNoChange()
+            {
+                var oldData = new DownloadData();
+                oldData.SetDownloadCount(IdA, V1, 5);
+                oldData.SetDownloadCount(IdB, V1, 1);
+                var newData = new DownloadData();
+                newData.SetDownloadCount(IdA, V1, 5);
+                newData.SetDownloadCount(IdB, V1, 1);
+
+                var delta = Target.Compare(oldData, newData);
+
+                Assert.Empty(delta);
+                VerifyDecreaseTelemetry(Times.Never());
+            }
+
+            [Fact]
+            public void DetectsIncreaseDueToRealIncrease()
+            {
+                var oldData = new DownloadData();
+                oldData.SetDownloadCount(IdA, V1, 5);
+                oldData.SetDownloadCount(IdB, V1, 1);
+                var newData = new DownloadData();
+                newData.SetDownloadCount(IdA, V1, 7); // Increase
+                newData.SetDownloadCount(IdB, V1, 1); // No change
+
+                var delta = Target.Compare(oldData, newData);
+
+                Assert.Equal(KeyValuePair.Create(IdA, 7L), Assert.Single(delta));
+                VerifyDecreaseTelemetry(Times.Never());
+            }
+
+            [Fact]
+            public void DetectsIncreaseDueToAddedVersion()
+            {
+                var oldData = new DownloadData();
+                oldData.SetDownloadCount(IdA, V1, 5);
+                var newData = new DownloadData();
+                newData.SetDownloadCount(IdA, V1, 5); // No change
+                newData.SetDownloadCount(IdA, V2, 2); // Added
+
+                var delta = Target.Compare(oldData, newData);
+
+                Assert.Equal(KeyValuePair.Create(IdA, 7L), Assert.Single(delta));
+                VerifyDecreaseTelemetry(Times.Never());
+            }
+
+            [Fact]
+            public void DetectsIncreaseDueToAddedId()
+            {
+                var oldData = new DownloadData();
+                var newData = new DownloadData();
+                newData.SetDownloadCount(IdA, V1, 5); // Added
+                newData.SetDownloadCount(IdA, V2, 2); // Added
+
+                var delta = Target.Compare(oldData, newData);
+
+                Assert.Equal(KeyValuePair.Create(IdA, 7L), Assert.Single(delta));
+                VerifyDecreaseTelemetry(Times.Never());
+            }
+
+            [Fact]
+            public void DetectsDecreaseWhenTotalRemainsTheSame()
+            {
+                var oldData = new DownloadData();
+                oldData.SetDownloadCount(IdA, V1, 7);
+                oldData.SetDownloadCount(IdA, V2, 1);
+                var newData = new DownloadData();
+                newData.SetDownloadCount(IdA, V1, 5);
+                newData.SetDownloadCount(IdA, V2, 3);
+
+                var delta = Target.Compare(oldData, newData);
+
+                Assert.Empty(delta);
+                VerifyDecreaseTelemetry(Times.Once());
+                TelemetryService.Verify(
+                    x => x.TrackDownloadCountDecrease(
+                        IdA,
+                        V1,
+                        true,
+                        true,
+                        7,
+                        true,
+                        true,
+                        5),
+                    Times.Once);
+            }
+
+            [Fact]
+            public void DetectsDecreaseDueToRealDecrease()
+            {
+                var oldData = new DownloadData();
+                oldData.SetDownloadCount(IdA, V1, 7);
+                oldData.SetDownloadCount(IdA, V2, 1);
+                var newData = new DownloadData();
+                newData.SetDownloadCount(IdA, V1, 5);
+                newData.SetDownloadCount(IdA, V2, 1);
+
+                var delta = Target.Compare(oldData, newData);
+
+                Assert.Equal(KeyValuePair.Create(IdA, 6L), Assert.Single(delta));
+                VerifyDecreaseTelemetry(Times.Once());
+                TelemetryService.Verify(
+                    x => x.TrackDownloadCountDecrease(
+                        IdA,
+                        V1,
+                        true,
+                        true,
+                        7,
+                        true,
+                        true,
+                        5),
+                    Times.Once);
+            }
+
+            [Fact]
+            public void DetectsDecreaseDueToMissingVersion()
+            {
+                var oldData = new DownloadData();
+                oldData.SetDownloadCount(IdA, V1, 7);
+                oldData.SetDownloadCount(IdA, V2, 1);
+                var newData = new DownloadData();
+                newData.SetDownloadCount(IdA, V2, 1);
+
+                var delta = Target.Compare(oldData, newData);
+
+                Assert.Equal(KeyValuePair.Create(IdA, 1L), Assert.Single(delta));
+                VerifyDecreaseTelemetry(Times.Once());
+                TelemetryService.Verify(
+                    x => x.TrackDownloadCountDecrease(
+                        IdA,
+                        V1,
+                        true,
+                        true,
+                        7,
+                        true,
+                        false,
+                        0),
+                    Times.Once);
+            }
+
+            [Fact]
+            public void DetectsDecreaseDueToMissingId()
+            {
+                var oldData = new DownloadData();
+                oldData.SetDownloadCount(IdA, V1, 7);
+                oldData.SetDownloadCount(IdA, V2, 1);
+                var newData = new DownloadData();
+
+                var delta = Target.Compare(oldData, newData);
+
+                Assert.Equal(KeyValuePair.Create(IdA, 0L), Assert.Single(delta));
+                VerifyDecreaseTelemetry(Times.Exactly(2));
+                TelemetryService.Verify(
+                    x => x.TrackDownloadCountDecrease(
+                        IdA,
+                        V1,
+                        true,
+                        true,
+                        7,
+                        false,
+                        false,
+                        0),
+                    Times.Once);
+                TelemetryService.Verify(
+                    x => x.TrackDownloadCountDecrease(
+                        IdA,
+                        V2,
+                        true,
+                        true,
+                        1,
+                        false,
+                        false,
+                        0),
+                    Times.Once);
+            }
+        }
+
+        public abstract class Facts
+        {
+            public const string IdA = "NuGet.Frameworks";
+            public const string IdB = "NuGet.Versioning";
+            public const string V1 = "1.0.0";
+            public const string V2 = "2.0.0";
+
+            public Facts(ITestOutputHelper output)
+            {
+                TelemetryService = new Mock<IAzureSearchTelemetryService>();
+                Logger = output.GetLogger<DownloadSetComparer>();
+
+                Target = new DownloadSetComparer(
+                    TelemetryService.Object,
+                    Logger);
+            }
+
+            public Mock<IAzureSearchTelemetryService> TelemetryService { get; }
+            public RecordingLogger<DownloadSetComparer> Logger { get; }
+            public DownloadSetComparer Target { get; }
+
+            public void VerifyDecreaseTelemetry(Times times)
+            {
+                TelemetryService.Verify(
+                    x => x.TrackDownloadCountDecrease(
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<long>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<long>()),
+                    times);
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -37,6 +37,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Auxiliary2AzureSearch\DownloadSetComparerFacts.cs" />
     <Compile Include="AuxiliaryFiles\DownloadByVersionDataFacts.cs" />
     <Compile Include="AuxiliaryFiles\DownloadDataClientFacts.cs" />
     <Compile Include="AuxiliaryFiles\DownloadDataFacts.cs" />


### PR DESCRIPTION
While comparing, fine places where download counts decrease and emit telemetry. This is a strange case currently causing some user pain and this will give us more data.

Progress on https://github.com/NuGet/NuGetGallery/issues/6458
Depends on https://github.com/NuGet/NuGet.Services.Metadata/pull/591
Will help us detect https://github.com/NuGet/NuGetGallery/issues/7258 is one more place