### PR TITLE
[Azure Search 3] Read DowloadData from downloads.v1.json

### DIFF
--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryFileClient.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryFileClient.cs
@@ -9,6 +9,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 {
     public interface IAuxiliaryFileClient
     {
+        Task<DownloadData> LoadDownloadDataAsync();
         Task<AuxiliaryFileResult<Downloads>> LoadDownloadsAsync(string etag);
         Task<AuxiliaryFileResult<HashSet<string>>> LoadVerifiedPackagesAsync(string etag);
     }


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/6458
Depends on https://github.com/NuGet/NuGet.Services.Metadata/pull/592

I wanted to leave the existing `download.v1.json` data structure `Downloads` as-is to ensure existing search is unaffected. Instead I added an API to read this file into the more convenient `DownloadData` class I added which is flexible enough for comparison and maintaining original case of IDs.