### PR TITLE
[Azure Search 5] Implement Auxiliary2AzureSearchCommand

### DIFF
--- a/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommand.cs
@@ -1,17 +1,315 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NuGet.Packaging;
+using NuGet.Services.AzureSearch.AuxiliaryFiles;
+using NuGet.Services.AzureSearch.Wrappers;
+using NuGet.Services.Metadata.Catalog.Helpers;
+using NuGet.Versioning;
 
 namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
 {
     public class Auxiliary2AzureSearchCommand
     {
+        /// <summary>
+        /// A package ID can result in one document per search filter if the there is a version that applies to each
+        /// of the filters. The simplest such case is a prerelease, SemVer 1.0.0 package version like 1.0.0-beta. This
+        /// version applies to all package filters.
+        /// </summary>
+        private static readonly int MaxDocumentsPerId = Enum.GetValues(typeof(SearchFilters)).Length;
+
+        private readonly IAuxiliaryFileClient _auxiliaryFileClient;
+        private readonly IDownloadDataClient _downloadDataClient;
+        private readonly IDownloadSetComparer _downloadSetComparer;
+        private readonly ISearchDocumentBuilder _searchDocumentBuilder;
+        private readonly ISearchIndexActionBuilder _indexActionBuilder;
+        private readonly Func<IBatchPusher> _batchPusherFactory;
+        private readonly ISystemTime _systemTime;
+        private readonly IOptionsSnapshot<Auxiliary2AzureSearchConfiguration> _options;
+        private readonly IAzureSearchTelemetryService _telemetryService;
+        private readonly ILogger<Auxiliary2AzureSearchCommand> _logger;
+
+        public Auxiliary2AzureSearchCommand(
+            IAuxiliaryFileClient auxiliaryFileClient,
+            IDownloadDataClient downloadDataClient,
+            IDownloadSetComparer downloadSetComparer,
+            ISearchDocumentBuilder searchDocumentBuilder,
+            ISearchIndexActionBuilder indexActionBuilder,
+            Func<IBatchPusher> batchPusherFactory,
+            ISystemTime systemTime,
+            IOptionsSnapshot<Auxiliary2AzureSearchConfiguration> options,
+            IAzureSearchTelemetryService telemetryService,
+            ILogger<Auxiliary2AzureSearchCommand> logger)
+        {
+            _auxiliaryFileClient = auxiliaryFileClient ?? throw new ArgumentNullException(nameof(auxiliaryFileClient));
+            _downloadDataClient = downloadDataClient ?? throw new ArgumentNullException(nameof(downloadDataClient));
+            _downloadSetComparer = downloadSetComparer ?? throw new ArgumentNullException(nameof(downloadSetComparer));
+            _searchDocumentBuilder = searchDocumentBuilder ?? throw new ArgumentNullException(nameof(searchDocumentBuilder));
+            _indexActionBuilder = indexActionBuilder ?? throw new ArgumentNullException(nameof(indexActionBuilder));
+            _batchPusherFactory = batchPusherFactory ?? throw new ArgumentNullException(nameof(batchPusherFactory));
+            _systemTime = systemTime ?? throw new ArgumentNullException(nameof(systemTime));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            if (_options.Value.MaxConcurrentBatches <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(options),
+                    $"The {nameof(AzureSearchJobConfiguration.MaxConcurrentBatches)} must be greater than zero.");
+            }
+
+            if (_options.Value.MaxConcurrentVersionListWriters <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(options),
+                    $"The {nameof(AzureSearchJobConfiguration.MaxConcurrentVersionListWriters)} must be greater than zero.");
+            }
+        }
+
         public async Task ExecuteAsync()
         {
-            // TODO: implement the job
-            // https://github.com/NuGet/NuGetGallery/issues/6447
-            await Task.Yield();
+            var stopwatch = Stopwatch.StartNew();
+            var success = false;
+            try
+            {
+                // The "old" data in this case is the download count data that was last indexed by this job (or
+                // initialized by Db2AzureSearch).
+                _logger.LogInformation("Fetching old download count data from blob storage.");
+                var oldResult = await _downloadDataClient.ReadLatestIndexedAsync();
+
+                // The "new" data in this case is from the statistics pipeline.
+                _logger.LogInformation("Fetching new download count data from blob storage.");
+                var newData = await _auxiliaryFileClient.LoadDownloadDataAsync();
+
+                _logger.LogInformation("Removing invalid IDs and versions from the new data.");
+                CleanDownloadData(newData);
+
+                _logger.LogInformation("Detecting download count changes.");
+                var changes = _downloadSetComparer.Compare(oldResult.Result, newData);
+                var idBag = new ConcurrentBag<string>(changes.Keys);
+                _logger.LogInformation("{Count} package IDs have download count changes.", idBag.Count);
+
+                if (!changes.Any())
+                {
+                    success = true;
+                    return;
+                }
+
+                _logger.LogInformation(
+                    "Starting {Count} workers pushing download count changes to Azure Search.",
+                    _options.Value.MaxConcurrentBatches);
+                await ParallelAsync.Repeat(
+                    () => WorkAsync(idBag, changes),
+                    _options.Value.MaxConcurrentBatches);
+                _logger.LogInformation("All of the download count changes have been pushed to Azure Search.");
+
+                _logger.LogInformation("Uploading the new download count data to blob storage.");
+                await _downloadDataClient.ReplaceLatestIndexedAsync(newData, oldResult.AccessCondition);
+                success = true;
+            }
+            finally
+            {
+                stopwatch.Stop();
+                _telemetryService.TrackAuxiliary2AzureSearchCompleted(success, stopwatch.Elapsed);
+            }
+        }
+
+        private async Task WorkAsync(ConcurrentBag<string> idBag, SortedDictionary<string, long> changes)
+        {
+            // Perform two batching mechanisms:
+            //
+            //   1. Group package IDs into batches so version lists can be fetched in parallel.
+            //   2. Group index actions so documents can be pushed to Azure Search in batches.
+            // 
+            // Also, throttle the pushes to Azure Search based on time so that we don't cause too much load.
+            var idsToIndex = new ConcurrentBag<string>();
+            var indexActionsToPush = new ConcurrentBag<IdAndValue<IndexActions>>();
+            var timeSinceLastPush = new Stopwatch();
+
+            while (idBag.TryTake(out var id))
+            {
+                // FIRST, check if we have a full batch of package IDs to produce index actions for.
+                //
+                // If all of the IDs to index and the current ID were to need a document for each search filter and
+                // that number plus the current index actions to push would make the batch larger than the maximum
+                // batch size, produce index actions for the IDs that we have collected so far.
+                if (GetBatchSize(indexActionsToPush) + ((idsToIndex.Count + 1) * MaxDocumentsPerId) > _options.Value.AzureSearchBatchSize)
+                {
+                    await GenerateIndexActionsAsync(idsToIndex, indexActionsToPush, changes);
+                }
+
+                // SECOND, check if we have a full batch of index actions to push to Azure Search.
+                //
+                // If the current ID were to need a document for each search filter and the current batch size would
+                // make the batch larger than the maximum batch size, push the index actions we have so far.
+                if (GetBatchSize(indexActionsToPush) + MaxDocumentsPerId > _options.Value.AzureSearchBatchSize)
+                {
+                    await PushIndexActionsAsync(indexActionsToPush, timeSinceLastPush);
+                }
+
+                // THIRD, now that the two batching "buffers" have been flushed if necessary, add the current ID to the
+                // batch of IDs to produce index actions for.
+                idsToIndex.Add(id);
+            }
+
+            // Process any leftover IDs that didn't make it into a full batch.
+            if (idsToIndex.Any())
+            {
+                await GenerateIndexActionsAsync(idsToIndex, indexActionsToPush, changes);
+            }
+
+            // Push any leftover index actions that didn't make it into a full batch.
+            if (indexActionsToPush.Any())
+            {
+                await PushIndexActionsAsync(indexActionsToPush, timeSinceLastPush);
+            }
+
+            Guard.Assert(idsToIndex.IsEmpty, "There should be no more IDs to process.");
+            Guard.Assert(indexActionsToPush.IsEmpty, "There should be no more index actions to push.");
+        }
+
+        /// <summary>
+        /// Generate index actions for each provided ID. This reads the version list per package ID so we want to
+        /// parallel this work by <see cref="AzureSearchJobConfiguration.MaxConcurrentVersionListWriters"/>.
+        /// </summary>
+        private async Task GenerateIndexActionsAsync(
+            ConcurrentBag<string> idsToIndex,
+            ConcurrentBag<IdAndValue<IndexActions>> indexActionsToPush,
+            SortedDictionary<string, long> changes)
+        {
+            await ParallelAsync.Repeat(
+                async () =>
+                {
+                    while (idsToIndex.TryTake(out var id))
+                    {
+                        var indexActions = await _indexActionBuilder.UpdateAsync(
+                            id,
+                            sf => _searchDocumentBuilder.UpdateDownloadCount(id, sf, changes[id]));
+
+                        if (indexActions.IsEmpty)
+                        {
+                            continue;
+                        }
+
+                        Guard.Assert(indexActions.Hijack.Count == 0, "There should be no hijack index changes.");
+
+                        indexActionsToPush.Add(new IdAndValue<IndexActions>(id, indexActions));
+                    }
+                },
+                _options.Value.MaxConcurrentVersionListWriters);
+        }
+
+        private async Task<int> PushIndexActionsAsync(
+            ConcurrentBag<IdAndValue<IndexActions>> indexActionsToPush,
+            Stopwatch timeSinceLastPush)
+        {
+            var elapsed = timeSinceLastPush.Elapsed;
+            if (timeSinceLastPush.IsRunning && elapsed < _options.Value.MinPushPeriod)
+            {
+                var timeUntilNextPush = _options.Value.MinPushPeriod - elapsed;
+                _logger.LogInformation(
+                    "Waiting for {Duration} before continuing.",
+                    timeUntilNextPush);
+                await _systemTime.Delay(timeUntilNextPush);
+            }
+
+            /// Create a new batch pusher just for this operation. Note that we don't use the internal queue of the
+            /// batch pusher for more than a single batch because we want to control exactly when batches are pushed to
+            /// Azure Search so that we can observe the <see cref="Auxiliary2AzureSearchConfiguration.MinPushPeriod"/>
+            /// configuration property.
+            var batchPusher = _batchPusherFactory();
+
+            _logger.LogInformation(
+                "Pushing a batch of {IdCount} IDs and {DocumentCount} documents.",
+                indexActionsToPush.Count,
+                GetBatchSize(indexActionsToPush));
+
+            while (indexActionsToPush.TryTake(out var indexActions))
+            {
+                batchPusher.EnqueueIndexActions(indexActions.Id, indexActions.Value);
+            }
+
+            // Note that this method can throw a storage exception if one of the version lists has been modified during
+            // the execution of this job loop.
+            await batchPusher.FinishAsync();
+
+            // Restart the timer AFTER the push is completed to err on the side of caution.
+            timeSinceLastPush.Restart();
+
+            return 0;
+        }
+
+        /// <summary>
+        /// This returns the number of documents that will be pushed to an Azure Search index in a
+        /// single batch. The caller is responsible that this number does not exceed
+        /// <see cref="AzureSearchJobConfiguration.AzureSearchBatchSize"/>. If this job were to start pushing changes
+        /// to more than one index (more than the search index), then the number returned here should be the max of
+        /// the document counts per index.
+        /// </summary>
+        private int GetBatchSize(ConcurrentBag<IdAndValue<IndexActions>> indexActionsToPush)
+        {
+            return indexActionsToPush.Sum(x => x.Value.Search.Count);
+        }
+
+        private void CleanDownloadData(DownloadData data)
+        {
+            var invalidIdCount = 0;
+            var invalidVersionCount = 0;
+            var nonNormalizedVersionCount = 0;
+
+            foreach (var id in data.Keys.ToList())
+            {
+                var isValidId = PackageIdValidator.IsValidPackageId(id);
+                if (!isValidId)
+                {
+                    invalidIdCount++;
+                }
+
+                foreach (var version in data[id].Keys.ToList())
+                {
+                    var isValidVersion = NuGetVersion.TryParse(version, out var parsedVersion);
+                    if (!isValidVersion)
+                    {
+                        invalidVersionCount++;
+                    }
+
+                    if (!isValidId || !isValidVersion)
+                    {
+                        // Clear the download count if the ID or version is invalid.
+                        data.SetDownloadCount(id, version, 0);
+                        continue;
+                    }
+
+                    var normalizedVersion = parsedVersion.ToNormalizedString();
+                    var isNormalizedVersion = StringComparer.OrdinalIgnoreCase.Equals(version, normalizedVersion);
+
+                    if (!isNormalizedVersion)
+                    {
+                        nonNormalizedVersionCount++;
+
+                        // Use the normalized version string if the original was not normalized.
+                        var downloads = data.GetDownloadCount(id, version);
+                        data.SetDownloadCount(id, version, 0);
+                        data.SetDownloadCount(id, normalizedVersion, downloads);
+                    }
+                }
+            }
+
+            _logger.LogInformation(
+                "There were {InvalidIdCount} invalid IDs, {InvalidVersionCount} invalid versions, and " +
+                "{NonNormalizedVersionCount} non-normalized IDs.",
+                invalidIdCount,
+                invalidVersionCount,
+                nonNormalizedVersionCount);
         }
     }
 }

--- a/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using NuGet.Services.AzureSearch.AuxiliaryFiles;
 
 namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
@@ -11,5 +12,6 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
         public string AuxiliaryDataStorageContainer { get; set; }
         public string AuxiliaryDataStorageDownloadsPath { get; set; }
         public string AuxiliaryDataStorageVerifiedPackagesPath { get; set; }
+        public TimeSpan MinPushPeriod { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/AzureSearchJobConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/AzureSearchJobConfiguration.cs
@@ -8,8 +8,24 @@ namespace NuGet.Services.AzureSearch
     public class AzureSearchJobConfiguration : AzureSearchConfiguration
     {
         public int AzureSearchBatchSize { get; set; } = 1000;
+
+        /// <summary>
+        /// The definition of batches is defined by the job that uses this configuration value, but in general this
+        /// property is used to control how many "workers" are allowed to work in parallel producing, and perhaps also
+        /// pushing, document changes for Azure Search.
+        /// </summary>
         public int MaxConcurrentBatches { get; set; } = 4;
+
+        /// <summary>
+        /// The maximum number of threads that should write version lists in parallel. This primary use for this
+        /// property is the <see cref="BatchPusher"/> implementation that updates version lists after all documents
+        /// for a specific package ID have been pushed to Azure Search. The specific semantics of this property vary
+        /// on a per-job basis. In some cases this property may be used within a batch
+        /// (i.e. <see cref="MaxConcurrentBatches"/>) so the actual maximum degree of parallelism for a single process
+        /// may be a multiple of this property.
+        /// </summary>
         public int MaxConcurrentVersionListWriters { get; set; } = 8;
+
         public string StorageConnectionString { get; set; }
         public string StorageContainer { get; set; }
         public string StoragePath { get; set; }

--- a/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
@@ -345,5 +345,16 @@ namespace NuGet.Services.AzureSearch
                     { "NewDownloads", newDownloads.ToString() },
                 });
         }
+
+        public void TrackAuxiliary2AzureSearchCompleted(bool success, TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "Auxiliary2AzureSearchCompletedSeconds",
+                elapsed.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { "Success", success.ToString() },
+                });
+        }
     }
 }

--- a/src/NuGet.Services.AzureSearch/BatchPusher.cs
+++ b/src/NuGet.Services.AzureSearch/BatchPusher.cs
@@ -155,6 +155,7 @@ namespace NuGet.Services.AzureSearch
                                 await Task.Yield();
                                 while (work.TryTake(out var finished))
                                 {
+                                    // This method can throw a storage exception if the version list has changed.
                                     await _versionListDataClient.ReplaceAsync(
                                         finished.Id,
                                         finished.Value.Result,

--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -147,6 +147,13 @@ namespace NuGet.Services.AzureSearch
                     c.Resolve<ILogger<BlobContainerBuilder>>()));
 
             containerBuilder
+                .Register<IDownloadDataClient>(c => new DownloadDataClient(
+                    c.ResolveKeyed<ICloudBlobClient>(key),
+                    c.Resolve<IOptionsSnapshot<AzureSearchJobConfiguration>>(),
+                    c.Resolve<IAzureSearchTelemetryService>(),
+                    c.Resolve<ILogger<DownloadDataClient>>()));
+
+            containerBuilder
                 .Register<IOwnerDataClient>(c => new OwnerDataClient(
                     c.ResolveKeyed<ICloudBlobClient>(key),
                     c.Resolve<IOptionsSnapshot<AzureSearchJobConfiguration>>(),
@@ -242,6 +249,7 @@ namespace NuGet.Services.AzureSearch
             services.AddTransient<ICommitCollectorLogic, AzureSearchCollectorLogic>();
             services.AddTransient<IDatabaseOwnerFetcher, DatabaseOwnerFetcher>();
             services.AddTransient<IDiagnosticsService, LoggerDiagnosticsService>();
+            services.AddTransient<IDownloadSetComparer, DownloadSetComparer>();
             services.AddTransient<IEntitiesContextFactory, EntitiesContextFactory>();
             services.AddTransient<IHijackDocumentBuilder, HijackDocumentBuilder>();
             services.AddTransient<IIndexBuilder, IndexBuilder>();

--- a/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
@@ -46,5 +46,6 @@ namespace NuGet.Services.AzureSearch
         IDisposable TrackCatalogLeafDownloadBatch(int count);
         void TrackReadLatestIndexedDownloads(int packageIdCount, TimeSpan elapsed);
         IDisposable TrackReplaceLatestIndexedDownloads(int packageIdCount);
+        void TrackAuxiliary2AzureSearchCompleted(bool success, TimeSpan elapsed);
     }
 }

--- a/src/NuGet.Services.AzureSearch/IBatchPusher.cs
+++ b/src/NuGet.Services.AzureSearch/IBatchPusher.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage;
 
 namespace NuGet.Services.AzureSearch
 {
@@ -27,11 +28,13 @@ namespace NuGet.Services.AzureSearch
         /// the index actions for a specific package ID completed (pushed to Azure Search), the corresponding version
         /// list is also updated. Hijack index changes are applied before search index changes.
         /// </summary>
+        /// <exception cref="StorageException">Thrown if the one of the version lists has changed.</exception>
         Task PushFullBatchesAsync();
 
         /// <summary>
         /// Same as <see cref="PushFullBatchesAsync"/> but if there is a partial batch remaining, it is also pushed.
         /// </summary>
+        /// <exception cref="StorageException">Thrown if the one of the version lists has changed.</exception>
         Task FinishAsync();
     }
 }

--- a/src/NuGet.Services.AzureSearch/Owners2AzureSearch/Owners2AzureSearchCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Owners2AzureSearch/Owners2AzureSearchCommand.cs
@@ -120,6 +120,9 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
                 }
 
                 batchPusher.EnqueueIndexActions(changes.Id, indexActions);
+
+                // Note that this method can throw a storage exception if one of the version lists has been modified
+                // during the execution of this job loop.
                 await batchPusher.PushFullBatchesAsync();
             }
 

--- a/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommandFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommandFacts.cs
@@ -1,0 +1,292 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.Search.Models;
+using Microsoft.Extensions.Options;
+using Moq;
+using NuGet.Services.AzureSearch.AuxiliaryFiles;
+using NuGet.Services.AzureSearch.Support;
+using NuGet.Services.AzureSearch.Wrappers;
+using NuGetGallery;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
+{
+    public class Auxiliary2AzureSearchCommandFacts
+    {
+        public class ExecuteAsync : Facts
+        {
+            public ExecuteAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task PushesNothingWhenThereAreNoChanges()
+            {
+                await Target.ExecuteAsync();
+
+                VerifyCompletedTelemetry(success: true);
+                VerifyAllIdsAreProcessed(changeCount: 0);
+                IndexActionBuilder.Verify(
+                    x => x.UpdateAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<Func<SearchFilters, KeyedDocument>>()),
+                    Times.Never);
+                BatchPusher.Verify(x => x.FinishAsync(), Times.Never);
+                BatchPusher.Verify(x => x.PushFullBatchesAsync(), Times.Never);
+                DownloadDataClient.Verify(
+                    x => x.ReplaceLatestIndexedAsync(It.IsAny<DownloadData>(), It.IsAny<IAccessCondition>()),
+                    Times.Never);
+            }
+
+            [Theory]
+            [InlineData(1, 7, 4,  1)] // 1, 2, ... 7 + 4 = 11 is greater than 10 so 7 is the batch size.
+            [InlineData(2, 8, 7,  1)] // 2, 4, ... 8 + 4 = 12 is greater than 10 so 8 is the batch size.
+            [InlineData(3, 9, 10, 0)] // 3, 6,     9 + 4 = 13 is greater than 10 so 9 is the batch size.
+            [InlineData(4, 8, 15, 0)] // 4,        8 + 4 = 12 is greater than 10 so 8 is the batch size.
+            public async Task RespectsAzureSearchBatchSize(int documentsPerId, int batchSize, int fullPushes, int partialPushes)
+            {
+                var changeCount = 30;
+                var expectedPushes = fullPushes + partialPushes;
+                Config.AzureSearchBatchSize = 10;
+
+                IndexActions = new IndexActions(
+                    new List<IndexAction<KeyedDocument>>(
+                        Enumerable
+                            .Range(0, documentsPerId)
+                            .Select(x => IndexAction.Merge(new KeyedDocument()))),
+                    new List<IndexAction<KeyedDocument>>(),
+                    new ResultAndAccessCondition<VersionListData>(
+                        new VersionListData(new Dictionary<string, VersionPropertiesData>()),
+                        new Mock<IAccessCondition>().Object));      
+
+                AddChanges(changeCount);
+
+                await Target.ExecuteAsync();
+
+                VerifyCompletedTelemetry(success: true);
+                VerifyAllIdsAreProcessed(changeCount);
+                IndexActionBuilder.Verify(
+                    x => x.UpdateAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<Func<SearchFilters, KeyedDocument>>()),
+                    Times.Exactly(changeCount));
+                BatchPusher.Verify(
+                    x => x.EnqueueIndexActions(It.IsAny<string>(), It.IsAny<IndexActions>()),
+                    Times.Exactly(changeCount));
+                BatchPusher.Verify(x => x.FinishAsync(), Times.Exactly(expectedPushes));
+                BatchPusher.Verify(x => x.PushFullBatchesAsync(), Times.Never);
+                SystemTime.Verify(x => x.Delay(It.IsAny<TimeSpan>()), Times.Exactly(expectedPushes - 1));
+                DownloadDataClient.Verify(
+                    x => x.ReplaceLatestIndexedAsync(NewData, OldResult.AccessCondition),
+                    Times.Once);
+
+                Assert.Equal(
+                    fullPushes,
+                    FinishedBatches.Count(b => b.Sum(ia => ia.Search.Count) == batchSize));
+                Assert.Equal(
+                    partialPushes,
+                    FinishedBatches.Count(b => b.Sum(ia => ia.Search.Count) != batchSize));
+                Assert.Empty(CurrentBatch);
+            }
+
+            [Fact]
+            public async Task CanProcessInParallel()
+            {
+                var changeCount = 1000;
+                Config.AzureSearchBatchSize = 5;
+                Config.MaxConcurrentBatches = 4;
+                Config.MaxConcurrentVersionListWriters = 8;
+                AddChanges(changeCount);
+
+                await Target.ExecuteAsync();
+
+                VerifyCompletedTelemetry(success: true);
+                VerifyAllIdsAreProcessed(changeCount);
+                IndexActionBuilder.Verify(
+                    x => x.UpdateAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<Func<SearchFilters, KeyedDocument>>()),
+                    Times.Exactly(changeCount));
+                BatchPusher.Verify(
+                    x => x.EnqueueIndexActions(It.IsAny<string>(), It.IsAny<IndexActions>()),
+                    Times.Exactly(changeCount));
+                BatchPusher.Verify(x => x.FinishAsync(), Times.AtLeastOnce);
+                BatchPusher.Verify(x => x.PushFullBatchesAsync(), Times.Never);
+            }
+
+            [Fact]
+            public async Task FailureIsRecordedInTelemetry()
+            {
+                var expected = new InvalidOperationException("Something bad!");
+                DownloadDataClient
+                    .Setup(x => x.ReadLatestIndexedAsync())
+                    .ThrowsAsync(expected);
+
+                var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => Target.ExecuteAsync());
+
+                VerifyCompletedTelemetry(success: false);
+                Assert.Same(expected, actual);
+            }
+
+            [Fact]
+            public async Task RejectsInvalidDataAndNormalizesVersions()
+            {
+                NewData.SetDownloadCount("ValidId", "1.0.0-ValidVersion", 3);
+                NewData.SetDownloadCount("ValidId", "1.0.0.a-invalidversion", 5);
+                NewData.SetDownloadCount("ValidId", "1.0.0.0-NonNormalized", 7);
+                NewData.SetDownloadCount("Invalid--Id", "1.0.0-validversion", 11);
+                NewData.SetDownloadCount("Invalid--Id", "1.0.0.a-invalidversion", 13);
+
+                await Target.ExecuteAsync();
+
+                Assert.Equal(new[] { "ValidId" }, NewData.Keys.ToArray());
+                Assert.Equal(new[] { "1.0.0-NonNormalized", "1.0.0-ValidVersion" }, NewData["ValidId"].Keys.ToArray());
+                Assert.Equal(10, NewData.GetDownloadCount("ValidId"));
+                Assert.Contains("There were 1 invalid IDs, 2 invalid versions, and 1 non-normalized IDs.", Logger.Messages);
+            }
+        }
+
+        public abstract class Facts
+        {
+            public Facts(ITestOutputHelper output)
+            {
+                AuxiliaryFileClient = new Mock<IAuxiliaryFileClient>();
+                DownloadDataClient = new Mock<IDownloadDataClient>();
+                DownloadSetComparer = new Mock<IDownloadSetComparer>();
+                SearchDocumentBuilder = new Mock<ISearchDocumentBuilder>();
+                IndexActionBuilder = new Mock<ISearchIndexActionBuilder>();
+                BatchPusher = new Mock<IBatchPusher>();
+                SystemTime = new Mock<ISystemTime>();
+                Options = new Mock<IOptionsSnapshot<Auxiliary2AzureSearchConfiguration>>();
+                TelemetryService = new Mock<IAzureSearchTelemetryService>();
+                Logger = output.GetLogger<Auxiliary2AzureSearchCommand>();
+
+                Config = new Auxiliary2AzureSearchConfiguration
+                {
+                    AzureSearchBatchSize = 10,
+                    MaxConcurrentBatches = 1,
+                    MaxConcurrentVersionListWriters = 1,
+                    MinPushPeriod = TimeSpan.FromSeconds(5),
+                };
+                Options.Setup(x => x.Value).Returns(() => Config);
+
+                OldData = new DownloadData();
+                OldResult = new ResultAndAccessCondition<DownloadData>(OldData, Mock.Of<IAccessCondition>());
+                DownloadDataClient.Setup(x => x.ReadLatestIndexedAsync()).ReturnsAsync(() => OldResult);
+                NewData = new DownloadData();
+                AuxiliaryFileClient.Setup(x => x.LoadDownloadDataAsync()).ReturnsAsync(() => NewData);
+
+                Changes = new SortedDictionary<string, long>();
+                DownloadSetComparer
+                    .Setup(x => x.Compare(It.IsAny<DownloadData>(), It.IsAny<DownloadData>()))
+                    .Returns(() => Changes);
+
+                IndexActions = new IndexActions(
+                    new List<IndexAction<KeyedDocument>> { IndexAction.Merge(new KeyedDocument()) },
+                    new List<IndexAction<KeyedDocument>>(),
+                    new ResultAndAccessCondition<VersionListData>(
+                        new VersionListData(new Dictionary<string, VersionPropertiesData>()),
+                        new Mock<IAccessCondition>().Object));
+                ProcessedIds = new ConcurrentBag<string>();
+                IndexActionBuilder
+                    .Setup(x => x.UpdateAsync(It.IsAny<string>(), It.IsAny<Func<SearchFilters, KeyedDocument>>()))
+                    .ReturnsAsync(() => IndexActions)
+                    .Callback<string, Func<SearchFilters, KeyedDocument>>((id, b) =>
+                    {
+                        ProcessedIds.Add(id);
+                        b(SearchFilters.IncludePrereleaseAndSemVer2);
+                    });
+
+                // When pushing, delay for a little bit of time so the stopwatch has some measurable duration.
+                PushedIds = new ConcurrentBag<string>();
+                CurrentBatch = new ConcurrentBag<IndexActions>();
+                FinishedBatches = new ConcurrentBag<List<IndexActions>>();
+                BatchPusher
+                    .Setup(x => x.EnqueueIndexActions(It.IsAny<string>(), It.IsAny<IndexActions>()))
+                    .Callback<string, IndexActions>((id, indexActions) =>
+                    {
+                        CurrentBatch.Add(indexActions);
+                        PushedIds.Add(id);
+                    });
+                BatchPusher
+                    .Setup(x => x.FinishAsync())
+                    .Returns(Task.Delay(TimeSpan.FromMilliseconds(1)))
+                    .Callback(() =>
+                    {
+                        FinishedBatches.Add(CurrentBatch.ToList());
+                        CurrentBatch = new ConcurrentBag<IndexActions>();
+                    });
+
+                Target = new Auxiliary2AzureSearchCommand(
+                    AuxiliaryFileClient.Object,
+                    DownloadDataClient.Object,
+                    DownloadSetComparer.Object,
+                    SearchDocumentBuilder.Object,
+                    IndexActionBuilder.Object,
+                    () => BatchPusher.Object,
+                    SystemTime.Object,
+                    Options.Object,
+                    TelemetryService.Object,
+                    Logger);
+            }
+
+            public Mock<IAuxiliaryFileClient> AuxiliaryFileClient { get; }
+            public Mock<IDownloadDataClient> DownloadDataClient { get; }
+            public Mock<IDownloadSetComparer> DownloadSetComparer { get; }
+            public Mock<ISearchDocumentBuilder> SearchDocumentBuilder { get; }
+            public Mock<ISearchIndexActionBuilder> IndexActionBuilder { get; }
+            public Mock<IBatchPusher> BatchPusher { get; }
+            public Mock<ISystemTime> SystemTime { get; }
+            public Mock<IOptionsSnapshot<Auxiliary2AzureSearchConfiguration>> Options { get; }
+            public Mock<IAzureSearchTelemetryService> TelemetryService { get; }
+            public RecordingLogger<Auxiliary2AzureSearchCommand> Logger { get; }
+            public Auxiliary2AzureSearchConfiguration Config { get; }
+            public DownloadData OldData { get; }
+            public ResultAndAccessCondition<DownloadData> OldResult { get; }
+            public DownloadData NewData { get; }
+            public SortedDictionary<string, long> Changes { get; }
+            public Auxiliary2AzureSearchCommand Target { get; }
+            public IndexActions IndexActions { get; set; }
+            public ConcurrentBag<string> ProcessedIds { get; }
+            public ConcurrentBag<string> PushedIds { get; }
+            public ConcurrentBag<IndexActions> CurrentBatch { get; set; }
+            public ConcurrentBag<List<IndexActions>> FinishedBatches { get; }
+
+            public void VerifyCompletedTelemetry(bool success)
+            {
+                TelemetryService.Verify(
+                    x => x.TrackAuxiliary2AzureSearchCompleted(It.IsAny<bool>(), It.IsAny<TimeSpan>()),
+                    Times.Once);
+                TelemetryService.Verify(
+                    x => x.TrackAuxiliary2AzureSearchCompleted(success, It.IsAny<TimeSpan>()),
+                    Times.Once);
+            }
+
+            public void AddChanges(int changeCount)
+            {
+                for (var i = 1; i <= changeCount; i++)
+                {
+                    Changes[$"Package{i}"] = i;
+                }
+            }
+
+            public void VerifyAllIdsAreProcessed(int changeCount)
+            {
+                var changedIds = Changes.Keys.OrderBy(x => x).ToArray();
+                var processedIds = ProcessedIds.OrderBy(x => x).ToArray();
+                var pushedIds = PushedIds.OrderBy(x => x).ToArray();
+
+                Assert.Equal(changeCount, changedIds.Length);
+                Assert.Equal(changedIds, processedIds);
+                Assert.Equal(changedIds, pushedIds);
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -37,6 +37,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Auxiliary2AzureSearch\Auxiliary2AzureSearchCommandFacts.cs" />
     <Compile Include="Auxiliary2AzureSearch\DownloadSetComparerFacts.cs" />
     <Compile Include="AuxiliaryFiles\DownloadByVersionDataFacts.cs" />
     <Compile Include="AuxiliaryFiles\DownloadDataClientFacts.cs" />


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/6458
Depends on https://github.com/NuGet/NuGet.Services.Metadata/pull/594

This is the main command logic. Note that I clean out invalid package IDs (138 exist in PROD), versions (0 exist in PROD), and non-normalized versions (0 exist in PROD).