### PR TITLE
Optimize packageid:{ID} case in V3 search since we get a lot of those

### DIFF
--- a/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommand.cs
@@ -271,7 +271,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
 
             foreach (var id in data.Keys.ToList())
             {
-                var isValidId = PackageIdValidator.IsValidPackageId(id);
+                var isValidId = id.Length <= PackageIdValidator.MaxPackageIdLength && PackageIdValidator.IsValidPackageId(id);
                 if (!isValidId)
                 {
                     invalidIdCount++;

--- a/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
@@ -366,5 +366,12 @@ namespace NuGet.Services.AzureSearch
                     { "PackageIdCount", packageIdCount.ToString() },
                 });
         }
+
+        public void TrackV3GetDocument(TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "V3GetDocumentMs",
+                elapsed.TotalMilliseconds);
+        }
     }
 }

--- a/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
@@ -48,5 +48,6 @@ namespace NuGet.Services.AzureSearch
         IDisposable TrackReplaceLatestIndexedDownloads(int packageIdCount);
         void TrackAuxiliary2AzureSearchCompleted(JobOutcome outcome, TimeSpan elapsed);
         IDisposable TrackUploadDownloadsSnapshot(int packageIdCount);
+        void TrackV3GetDocument(TimeSpan elapsed);
     }
 }

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -138,6 +138,7 @@
     <Compile Include="SearchDocumentBuilder.cs" />
     <Compile Include="SearchService\AuxiliaryData.cs" />
     <Compile Include="AuxiliaryFiles\AuxiliaryFileResult.cs" />
+    <Compile Include="SearchService\Models\DebugDocumentResult.cs" />
     <Compile Include="SearchService\IAuxiliaryDataCache.cs" />
     <Compile Include="AuxiliaryFiles\IAuxiliaryFileClient.cs" />
     <Compile Include="SearchService\IAuxiliaryFileReloader.cs" />
@@ -158,6 +159,7 @@
     <Compile Include="SearchService\ISearchService.cs" />
     <Compile Include="SearchService\Models\DebugInformation.cs" />
     <Compile Include="SearchService\Models\IndexStatus.cs" />
+    <Compile Include="SearchService\Models\ApiType.cs" />
     <Compile Include="SearchService\Models\SearchRequest.cs" />
     <Compile Include="SearchService\Models\ServerInformation.cs" />
     <Compile Include="SearchService\Models\SearchStatusResponse.cs" />
@@ -176,6 +178,7 @@
     <Compile Include="SearchService\SearchResponseBuilder.cs" />
     <Compile Include="SearchService\SearchStatusOptions.cs" />
     <Compile Include="SearchService\SearchStatusService.cs" />
+    <Compile Include="SearchService\ParsedQuery.cs" />
     <Compile Include="SearchService\SearchTextBuilder.cs" />
     <Compile Include="AzureSearchTelemetryService.cs" />
     <Compile Include="VersionList\Guard.cs" />

--- a/src/NuGet.Services.AzureSearch/SearchService/ISearchParametersBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/ISearchParametersBuilder.cs
@@ -11,5 +11,6 @@ namespace NuGet.Services.AzureSearch.SearchService
         SearchParameters V2Search(V2SearchRequest request);
         SearchParameters V3Search(V3SearchRequest request);
         SearchParameters Autocomplete(AutocompleteRequest request);
+        SearchFilters GetSearchFilters(SearchRequest request);
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/ISearchResponseBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/ISearchResponseBuilder.cs
@@ -26,6 +26,11 @@ namespace NuGet.Services.AzureSearch.SearchService
             string text,
             DocumentSearchResult<SearchDocument.Full> result,
             TimeSpan duration);
+        V3SearchResponse V3FromSearchDocument(
+            V3SearchRequest request,
+            string documentKey,
+            SearchDocument.Full document,
+            TimeSpan duration);
         AutocompleteResponse AutocompleteFromSearch(
             AutocompleteRequest request,
             SearchParameters parameters,

--- a/src/NuGet.Services.AzureSearch/SearchService/ISearchTextBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/ISearchTextBuilder.cs
@@ -15,7 +15,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         /// <param name="request">The V2 search request.</param>
         /// <returns>The Azure Search query.</returns>
         /// <exception cref="InvalidSearchRequestException">Thrown on invalid search requests.</exception>
-        string V2Search(V2SearchRequest request);
+        ParsedQuery V2Search(V2SearchRequest request);
 
         /// <summary>
         /// Map a V3 search request to Azure Search.
@@ -23,7 +23,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         /// <param name="request">The V3 search request.</param>
         /// <returns>The Azure Search query.</returns>
         /// <exception cref="InvalidSearchRequestException">Thrown on invalid search requests.</exception>
-        string V3Search(V3SearchRequest request);
+        ParsedQuery V3Search(V3SearchRequest request);
 
         /// <summary>
         /// Map an autocomplete request to Azure Search.

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/ApiType.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/ApiType.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public enum ApiType
+    {
+        /// <summary>
+        /// The data for the user was fetched using Azure Search's "get document by key" API. The .NET API is called "Get" and
+        /// "GetAsync" but REST API is called "lookup".
+        /// https://docs.microsoft.com/en-us/rest/api/searchservice/lookup-document
+        /// </summary>
+        Get,
+
+        /// <summary>
+        /// The data for the user was fetched using Azure Search's "search documents" API.
+        /// https://docs.microsoft.com/en-us/rest/api/searchservice/search-documents
+        /// </summary>
+        Search,
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/DebugDocumentResult.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/DebugDocumentResult.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class DebugDocumentResult
+    {
+        public object Document { get; set; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/DebugInformation.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/DebugInformation.cs
@@ -10,13 +10,15 @@ namespace NuGet.Services.AzureSearch.SearchService
     {
         public SearchRequest SearchRequest { get; set; }
         public string IndexName { get; set; }
+        public ApiType ApiType { get; set; }
+        public string DocumentKey { get; set; }
         public SearchParameters SearchParameters { get; set; }
         public string SearchText { get; set; }
         public object DocumentSearchResult { get; set; }
         public TimeSpan QueryDuration { get; set; }
         public AuxiliaryFilesMetadata AuxiliaryFilesMetadata { get; set; }
 
-        public static DebugInformation CreateOrNull<T>(
+        public static DebugInformation CreateFromSearchOrNull<T>(
             SearchRequest request,
             string indexName,
             SearchParameters parameters,
@@ -33,10 +35,34 @@ namespace NuGet.Services.AzureSearch.SearchService
             return new DebugInformation
             {
                 SearchRequest = request,
+                IndexName = indexName,
+                ApiType = ApiType.Search,
                 SearchParameters = parameters,
                 SearchText = text,
-                IndexName = indexName,
                 DocumentSearchResult = result,
+                QueryDuration = duration,
+                AuxiliaryFilesMetadata = auxiliaryFilesMetadata,
+            };
+        }
+
+        public static DebugInformation CreateFromGetOrNull(
+            SearchRequest request,
+            string indexName,
+            string documentKey,
+            TimeSpan duration,
+            AuxiliaryFilesMetadata auxiliaryFilesMetadata)
+        {
+            if (!request.ShowDebug)
+            {
+                return null;
+            }
+
+            return new DebugInformation
+            {
+                SearchRequest = request,
+                IndexName = indexName,
+                ApiType = ApiType.Get,
+                DocumentKey = documentKey,
                 QueryDuration = duration,
                 AuxiliaryFilesMetadata = auxiliaryFilesMetadata,
             };

--- a/src/NuGet.Services.AzureSearch/SearchService/ParsedQuery.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/ParsedQuery.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class ParsedQuery
+    {
+        public ParsedQuery(string text, string packageId)
+        {
+            Text = text ?? throw new ArgumentNullException(nameof(text));
+            PackageId = packageId;
+        }
+
+        /// <summary>
+        /// The text that will be provided to Azure Search. This is a Lucene query, not the query provided by the user.
+        /// </summary>
+        public string Text { get; }
+
+        public string PackageId { get; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchParametersBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchParametersBuilder.cs
@@ -123,7 +123,14 @@ namespace NuGet.Services.AzureSearch.SearchService
             searchParameters.Top = request.Take < 0 || request.Take > MaximumTake ? DefaultTake : request.Take;
         }
 
-        private static void ApplySearchIndexFilter(SearchParameters searchParameters, SearchRequest request)
+        private void ApplySearchIndexFilter(SearchParameters searchParameters, SearchRequest request)
+        {
+            var searchFilters = GetSearchFilters(request);
+
+            searchParameters.Filter = $"{IndexFields.Search.SearchFilters} eq '{DocumentUtilities.GetSearchFilterString(searchFilters)}'";
+        }
+
+        public SearchFilters GetSearchFilters(SearchRequest request)
         {
             var searchFilters = SearchFilters.Default;
 
@@ -137,7 +144,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 searchFilters |= SearchFilters.IncludeSemVer2;
             }
 
-            searchParameters.Filter = $"{IndexFields.Search.SearchFilters} eq '{DocumentUtilities.GetSearchFilterString(searchFilters)}'";
+            return searchFilters;
         }
 
         private static IList<string> GetOrderBy(V2SortBy sortBy)

--- a/src/NuGet.Services.AzureSearch/Wrappers/IDocumentsOperationsWrapper.cs
+++ b/src/NuGet.Services.AzureSearch/Wrappers/IDocumentsOperationsWrapper.cs
@@ -9,6 +9,7 @@ namespace NuGet.Services.AzureSearch.Wrappers
     public interface IDocumentsOperationsWrapper
     {
         Task<DocumentIndexResult> IndexAsync<T>(IndexBatch<T> batch) where T : class;
+        Task<T> GetOrNullAsync<T>(string key) where T : class;
         Task<DocumentSearchResult> SearchAsync(
             string searchText,
             SearchParameters searchParameters);

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryDocumentsOperations.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryDocumentsOperations.cs
@@ -27,6 +27,11 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
             throw new NotImplementedException();
         }
 
+        public Task<T> GetOrNullAsync<T>(string key) where T : class
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<DocumentIndexResult> IndexAsync<T>(IndexBatch<T> batch) where T : class
         {
             if (typeof(T) != typeof(KeyedDocument))

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/AzureSearchServiceFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/AzureSearchServiceFacts.cs
@@ -27,13 +27,16 @@ namespace NuGet.Services.AzureSearch.SearchService
                     x => x.V2Search(_v2Request),
                     Times.Once);
                 _parametersBuilder.Verify(
+                    x => x.GetSearchFilters(It.IsAny<SearchRequest>()),
+                    Times.Never);
+                _parametersBuilder.Verify(
                     x => x.V2Search(_v2Request),
                     Times.Once);
                 _searchOperations.Verify(
-                    x => x.SearchAsync<SearchDocument.Full>(_v2Text, _v2Parameters),
+                    x => x.SearchAsync<SearchDocument.Full>(_v2Parsed.Text, _v2Parameters),
                     Times.Once);
                 _responseBuilder.Verify(
-                    x => x.V2FromSearch(_v2Request, _v2Parameters, _v2Text, _searchResult, It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
+                    x => x.V2FromSearch(_v2Request, _v2Parameters, _v2Parsed.Text, _searchResult, It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
                     Times.Once);
             }
 
@@ -49,13 +52,16 @@ namespace NuGet.Services.AzureSearch.SearchService
                     x => x.V2Search(_v2Request),
                     Times.Once);
                 _parametersBuilder.Verify(
+                    x => x.GetSearchFilters(It.IsAny<SearchRequest>()),
+                    Times.Never);
+                _parametersBuilder.Verify(
                     x => x.V2Search(_v2Request),
                     Times.Once);
                 _hijackOperations.Verify(
-                    x => x.SearchAsync<HijackDocument.Full>(_v2Text, _v2Parameters),
+                    x => x.SearchAsync<HijackDocument.Full>(_v2Parsed.Text, _v2Parameters),
                     Times.Once);
                 _responseBuilder.Verify(
-                    x => x.V2FromHijack(_v2Request, _v2Parameters, _v2Text, _hijackResult, It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
+                    x => x.V2FromHijack(_v2Request, _v2Parameters, _v2Parsed.Text, _hijackResult, It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
                     Times.Once);
             }
         }
@@ -63,22 +69,93 @@ namespace NuGet.Services.AzureSearch.SearchService
         public class V3SearchAsync : BaseFacts
         {
             [Fact]
-            public async Task CallsDependenciesProperly()
+            public async Task SearchesWithNoSpecificPackageId()
             {
+                _v3Request.Skip = 0;
+                _v3Request.Take = 1;
+                _v3Parsed = new ParsedQuery(string.Empty, packageId: null);
+
                 var response = await _target.V3SearchAsync(_v3Request);
 
+                VerifyV3Search(response);
+            }
+
+            [Fact]
+            public async Task SearchesWithSpecificPackageIdAndSkip()
+            {
+                _v3Request.Skip = 1;
+                _v3Request.Take = 1;
+                _v3Parsed = new ParsedQuery(string.Empty, _packageId);
+
+                var response = await _target.V3SearchAsync(_v3Request);
+
+                VerifyV3Search(response);
+            }
+
+            [Fact]
+            public async Task SearchesWithSpecificPackageIdAndNoTake()
+            {
+                _v3Request.Skip = 0;
+                _v3Request.Take = 0;
+                _v3Parsed = new ParsedQuery(string.Empty, _packageId);
+
+                var response = await _target.V3SearchAsync(_v3Request);
+
+                VerifyV3Search(response);
+            }
+
+            [Fact]
+            public async Task GetsDocumentWithSpecificPackageIdNoSkipAndSomeTake()
+            {
+                _v3Request.Skip = 0;
+                _v3Request.Take = 1;
+                _v3Parsed = new ParsedQuery(string.Empty, _packageId);
+
+                var response = await _target.V3SearchAsync(_v3Request);
+
+                VerifyV3SearchDocument(response);
+            }
+
+            private void VerifyV3SearchDocument(V3SearchResponse response)
+            {
                 Assert.Same(_v3Response, response);
                 _textBuilder.Verify(
                     x => x.V3Search(_v3Request),
                     Times.Once);
                 _parametersBuilder.Verify(
+                    x => x.GetSearchFilters(It.IsAny<SearchRequest>()),
+                    Times.Once);
+                _parametersBuilder.Verify(
+                    x => x.V3Search(It.IsAny<V3SearchRequest>()),
+                    Times.Never);
+                _searchOperations.Verify(
+                    x => x.SearchAsync<SearchDocument.Full>(It.IsAny<string>(), It.IsAny<SearchParameters>()),
+                    Times.Never);
+                _searchOperations.Verify(
+                    x => x.GetOrNullAsync<SearchDocument.Full>(_searchDocument.Key),
+                    Times.Once);
+                _responseBuilder.Verify(
+                    x => x.V3FromSearchDocument(_v3Request, _searchDocument.Key, _searchDocument, It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
+                    Times.Once);
+            }
+
+            private void VerifyV3Search(V3SearchResponse response)
+            {
+                Assert.Same(_v3Response, response);
+                _textBuilder.Verify(
+                    x => x.V3Search(_v3Request),
+                    Times.Once);
+                _parametersBuilder.Verify(
+                    x => x.GetSearchFilters(It.IsAny<SearchRequest>()),
+                    Times.Never);
+                _parametersBuilder.Verify(
                     x => x.V3Search(_v3Request),
                     Times.Once);
                 _searchOperations.Verify(
-                    x => x.SearchAsync<SearchDocument.Full>(_v3Text, _v3Parameters),
+                    x => x.SearchAsync<SearchDocument.Full>(_v3Parsed.Text, _v3Parameters),
                     Times.Once);
                 _responseBuilder.Verify(
-                    x => x.V3FromSearch(_v3Request, _v3Parameters, _v3Text, _searchResult, It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
+                    x => x.V3FromSearch(_v3Request, _v3Parameters, _v3Parsed.Text, _searchResult, It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
                     Times.Once);
             }
         }
@@ -93,13 +170,15 @@ namespace NuGet.Services.AzureSearch.SearchService
             protected readonly Mock<IDocumentsOperationsWrapper> _hijackOperations;
             protected readonly Mock<ISearchResponseBuilder> _responseBuilder;
             protected readonly Mock<IAzureSearchTelemetryService> _telemetryService;
+            protected readonly string _packageId;
             protected readonly V2SearchRequest _v2Request;
             protected readonly V3SearchRequest _v3Request;
-            protected readonly string _v2Text;
-            protected readonly string _v3Text;
+            protected readonly ParsedQuery _v2Parsed;
+            protected ParsedQuery _v3Parsed;
             protected readonly SearchParameters _v2Parameters;
             protected readonly SearchParameters _v3Parameters;
             protected readonly DocumentSearchResult<SearchDocument.Full> _searchResult;
+            protected readonly SearchDocument.Full _searchDocument;
             protected readonly DocumentSearchResult<HijackDocument.Full> _hijackResult;
             protected readonly V2SearchResponse _v2Response;
             protected readonly V3SearchResponse _v3Response;
@@ -116,23 +195,28 @@ namespace NuGet.Services.AzureSearch.SearchService
                 _responseBuilder = new Mock<ISearchResponseBuilder>();
                 _telemetryService = new Mock<IAzureSearchTelemetryService>();
 
-                _v2Request = new V2SearchRequest();
-                _v3Request = new V3SearchRequest();
-                _v2Text = "v2";
-                _v3Text = "v3";
+                _packageId = "NuGet.Versioning";
+                _v2Request = new V2SearchRequest { Skip = 0, Take = 20 };
+                _v3Request = new V3SearchRequest { Skip = 0, Take = 20 };
+                _v2Parsed = new ParsedQuery("v2", packageId: null);
+                _v3Parsed = new ParsedQuery("v3", packageId: null);
                 _v2Parameters = new SearchParameters();
                 _v3Parameters = new SearchParameters();
                 _searchResult = new DocumentSearchResult<SearchDocument.Full>();
+                _searchDocument = new SearchDocument.Full
+                {
+                    Key = DocumentUtilities.GetSearchDocumentKey(_packageId, SearchFilters.Default),
+                };
                 _hijackResult = new DocumentSearchResult<HijackDocument.Full>();
                 _v2Response = new V2SearchResponse();
                 _v3Response = new V3SearchResponse();
 
                 _textBuilder
                     .Setup(x => x.V2Search(It.IsAny<V2SearchRequest>()))
-                    .Returns(() => _v2Text);
+                    .Returns(() => _v2Parsed);
                 _textBuilder
                     .Setup(x => x.V3Search(It.IsAny<V3SearchRequest>()))
-                    .Returns(() => _v3Text);
+                    .Returns(() => _v3Parsed);
                 _parametersBuilder
                     .Setup(x => x.V2Search(It.IsAny<V2SearchRequest>()))
                     .Returns(() => _v2Parameters);
@@ -144,6 +228,11 @@ namespace NuGet.Services.AzureSearch.SearchService
                 _searchOperations
                     .Setup(x => x.SearchAsync<SearchDocument.Full>(It.IsAny<string>(), It.IsAny<SearchParameters>()))
                     .ReturnsAsync(() => _searchResult)
+                    .Callback(() => Thread.Sleep(TimeSpan.FromMilliseconds(1)));
+
+                _searchOperations
+                    .Setup(x => x.GetOrNullAsync<SearchDocument.Full>(It.IsAny<string>()))
+                    .ReturnsAsync(() => _searchDocument)
                     .Callback(() => Thread.Sleep(TimeSpan.FromMilliseconds(1)));
 
                 _hijackOperations
@@ -173,6 +262,13 @@ namespace NuGet.Services.AzureSearch.SearchService
                         It.IsAny<SearchParameters>(),
                         It.IsAny<string>(),
                         It.IsAny<DocumentSearchResult<SearchDocument.Full>>(),
+                        It.IsAny<TimeSpan>()))
+                    .Returns(() => _v3Response);
+                _responseBuilder
+                    .Setup(x => x.V3FromSearchDocument(
+                        It.IsAny<V3SearchRequest>(),
+                        It.IsAny<string>(),
+                        It.IsAny<SearchDocument.Full>(),
                         It.IsAny<TimeSpan>()))
                     .Returns(() => _v3Response);
 

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchParametersBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchParametersBuilderFacts.cs
@@ -11,6 +11,24 @@ namespace NuGet.Services.AzureSearch.SearchService
 {
     public class SearchParametersBuilderFacts
     {
+        public class GetSearchFilters : BaseFacts
+        {
+            [Theory]
+            [MemberData(nameof(AllSearchFilters))]
+            public void SearchFilters(bool includePrerelease, bool includeSemVer2, SearchFilters filter)
+            {
+                var request = new SearchRequest
+                {
+                    IncludePrerelease = includePrerelease,
+                    IncludeSemVer2 = includeSemVer2,
+                };
+
+                var actual = _target.GetSearchFilters(request);
+
+                Assert.Equal(filter, actual);
+            }
+        }
+
         public class LastCommitTimestamp : BaseFacts
         {
             [Fact]
@@ -160,7 +178,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             [Theory]
-            [MemberData(nameof(AllSearchFilters))]
+            [MemberData(nameof(AllSearchFiltersExpressions))]
             public void SearchFilters(bool includePrerelease, bool includeSemVer2, string filter)
             {
                 var request = new V2SearchRequest
@@ -247,7 +265,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             [Theory]
-            [MemberData(nameof(AllSearchFilters))]
+            [MemberData(nameof(AllSearchFiltersExpressions))]
             public void SearchFilters(bool includePrerelease, bool includeSemVer2, string filter)
             {
                 var request = new V3SearchRequest
@@ -375,7 +393,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             [Theory]
-            [MemberData(nameof(AllSearchFilters))]
+            [MemberData(nameof(AllSearchFiltersExpressions))]
             public void SearchFilters(bool includePrerelease, bool includeSemVer2, string filter)
             {
                 var request = new AutocompleteRequest
@@ -405,11 +423,14 @@ namespace NuGet.Services.AzureSearch.SearchService
 
             public static IEnumerable<object[]> AllSearchFilters => new[]
             {
-                new object[] { false, false, "searchFilters eq 'Default'" },
-                new object[] { true, false, "searchFilters eq 'IncludePrerelease'" },
-                new object[] { false, true, "searchFilters eq 'IncludeSemVer2'" },
-                new object[] { true, true, "searchFilters eq 'IncludePrereleaseAndSemVer2'" },
+                new object[] { false, false, SearchFilters.Default },
+                new object[] { true, false, SearchFilters.IncludePrerelease },
+                new object[] { false, true, SearchFilters.IncludeSemVer2 },
+                new object[] { true, true, SearchFilters.IncludePrereleaseAndSemVer2 },
             };
+
+            public static IEnumerable<object[]> AllSearchFiltersExpressions => AllSearchFilters
+                .Select(x => new[] { x[0], x[1], $"searchFilters eq '{x[2]}'" });
 
             public static IEnumerable<object[]> AllV2SortBy => Enum
                 .GetValues(typeof(V2SortBy))

--- a/tests/NuGet.Services.AzureSearch.Tests/Wrappers/DocumentOperationsWrapperFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Wrappers/DocumentOperationsWrapperFacts.cs
@@ -4,11 +4,16 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Search;
 using Microsoft.Azure.Search.Models;
+using Microsoft.Rest;
+using Microsoft.Rest.Azure;
 using Moq;
+using Moq.Language;
 using NuGet.Services.AzureSearch.Support;
 using Xunit;
 using Xunit.Abstractions;
@@ -17,55 +22,129 @@ namespace NuGet.Services.AzureSearch.Wrappers
 {
     public class DocumentOperationsWrapperFacts
     {
-        public class IndexAsync : Facts
+        public class IndexAsync : Facts<DocumentIndexResult>
         {
             public IndexAsync(ITestOutputHelper output) : base(output)
             {
             }
 
-            public override async Task ExecuteAsync()
+            public override bool TreatsNotFoundAsDefault => false;
+
+            public override async Task<DocumentIndexResult> ExecuteAsync()
             {
-                await Target.IndexAsync(new IndexBatch<object>(Enumerable.Empty<IndexAction<object>>()));
+                return await Target.IndexAsync(new IndexBatch<object>(Enumerable.Empty<IndexAction<object>>()));
+            }
+
+            public override IReturns<IDocumentsOperations, Task<AzureOperationResponse<DocumentIndexResult>>> Setup()
+            {
+                return DocumentOperations
+                    .Setup(x => x.IndexWithHttpMessagesAsync(
+                        It.IsAny<IndexBatch<object>>(),
+                        It.IsAny<SearchRequestOptions>(),
+                        It.IsAny<Dictionary<string, List<string>>>(),
+                        It.IsAny<CancellationToken>()));
             }
         }
 
-        public class SearchAsync : Facts
+        public class GetOrNullAsyncOfT : Facts<object>
+        {
+            public GetOrNullAsyncOfT(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            public override bool TreatsNotFoundAsDefault => true;
+
+            public override async Task<object> ExecuteAsync()
+            {
+                return await Target.GetOrNullAsync<object>(string.Empty);
+            }
+
+            public override IReturns<IDocumentsOperations, Task<AzureOperationResponse<object>>> Setup()
+            {
+                return DocumentOperations
+                    .Setup(x => x.GetWithHttpMessagesAsync<object>(
+                        It.IsAny<string>(),
+                        It.IsAny<IEnumerable<string>>(),
+                        It.IsAny<SearchRequestOptions>(),
+                        It.IsAny<Dictionary<string, List<string>>>(),
+                        It.IsAny<CancellationToken>()));
+            }
+        }
+
+        public class SearchAsync : Facts<DocumentSearchResult>
         {
             public SearchAsync(ITestOutputHelper output) : base(output)
             {
             }
 
-            public override async Task ExecuteAsync()
+            public override bool TreatsNotFoundAsDefault => false;
+
+            public override async Task<DocumentSearchResult> ExecuteAsync()
             {
-                await Target.SearchAsync(string.Empty, new SearchParameters());
+                return await Target.SearchAsync(string.Empty, new SearchParameters());
+            }
+
+            public override IReturns<IDocumentsOperations, Task<AzureOperationResponse<DocumentSearchResult>>> Setup()
+            {
+                return DocumentOperations
+                    .Setup(x => x.SearchWithHttpMessagesAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<SearchParameters>(),
+                        It.IsAny<SearchRequestOptions>(),
+                        It.IsAny<Dictionary<string, List<string>>>(),
+                        It.IsAny<CancellationToken>()));
             }
         }
 
-        public class SearchAsyncOfT : Facts
+        public class SearchAsyncOfT : Facts<DocumentSearchResult<object>>
         {
             public SearchAsyncOfT(ITestOutputHelper output) : base(output)
             {
             }
 
-            public override async Task ExecuteAsync()
+            public override bool TreatsNotFoundAsDefault => false;
+
+            public override async Task<DocumentSearchResult<object>> ExecuteAsync()
             {
-                await Target.SearchAsync<object>(string.Empty, new SearchParameters());
+                return await Target.SearchAsync<object>(string.Empty, new SearchParameters());
+            }
+
+            public override IReturns<IDocumentsOperations, Task<AzureOperationResponse<DocumentSearchResult<object>>>> Setup()
+            {
+                return DocumentOperations
+                    .Setup(x => x.SearchWithHttpMessagesAsync<object>(
+                        It.IsAny<string>(),
+                        It.IsAny<SearchParameters>(),
+                        It.IsAny<SearchRequestOptions>(),
+                        It.IsAny<Dictionary<string, List<string>>>(),
+                        It.IsAny<CancellationToken>()));
             }
         }
 
-        public class CountAsync : Facts
+        public class CountAsync : Facts<long>
         {
             public CountAsync(ITestOutputHelper output) : base(output)
             {
             }
 
-            public override async Task ExecuteAsync()
+            public override bool TreatsNotFoundAsDefault => false;
+
+            public override async Task<long> ExecuteAsync()
             {
-                await Target.CountAsync();
+                return await Target.CountAsync();
+            }
+
+            public override IReturns<IDocumentsOperations, Task<AzureOperationResponse<long>>> Setup()
+            {
+                return DocumentOperations
+                    .Setup(x => x.CountWithHttpMessagesAsync(
+                        It.IsAny<SearchRequestOptions>(),
+                        It.IsAny<Dictionary<string, List<string>>>(),
+                        It.IsAny<CancellationToken>()));
             }
         }
 
-        public abstract class Facts
+        public abstract class Facts<T>
         {
             public Facts(ITestOutputHelper output)
             {
@@ -82,36 +161,29 @@ namespace NuGet.Services.AzureSearch.Wrappers
             public DocumentsOperationsWrapper Target { get; }
 
             [Fact]
+            public async Task HandlesNotFoundException()
+            {
+                Setup()
+                    .ThrowsAsync(new CloudException
+                    {
+                        Response = new HttpResponseMessageWrapper(new HttpResponseMessage(HttpStatusCode.NotFound), string.Empty),
+                    });
+
+                if (TreatsNotFoundAsDefault)
+                {
+                    var result = await ExecuteAsync();
+                    Assert.Equal(default(T), result);
+                }
+                else
+                {
+                    await Assert.ThrowsAsync<AzureSearchException>(() => ExecuteAsync());
+                }
+            }
+
+            [Fact]
             public async Task RetriesOnNullReferenceException()
             {
-                DocumentOperations
-                    .Setup(x => x.IndexWithHttpMessagesAsync<object>(
-                        It.IsAny<IndexBatch<object>>(),
-                        It.IsAny<SearchRequestOptions>(),
-                        It.IsAny<Dictionary<string, List<string>>>(),
-                        It.IsAny<CancellationToken>()))
-                    .ThrowsAsync(new NullReferenceException());
-                DocumentOperations
-                    .Setup(x => x.SearchWithHttpMessagesAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<SearchParameters>(),
-                        It.IsAny<SearchRequestOptions>(),
-                        It.IsAny<Dictionary<string, List<string>>>(),
-                        It.IsAny<CancellationToken>()))
-                    .ThrowsAsync(new NullReferenceException());
-                DocumentOperations
-                    .Setup(x => x.SearchWithHttpMessagesAsync<object>(
-                        It.IsAny<string>(),
-                        It.IsAny<SearchParameters>(),
-                        It.IsAny<SearchRequestOptions>(),
-                        It.IsAny<Dictionary<string, List<string>>>(),
-                        It.IsAny<CancellationToken>()))
-                    .ThrowsAsync(new NullReferenceException());
-                DocumentOperations
-                    .Setup(x => x.CountWithHttpMessagesAsync(
-                        It.IsAny<SearchRequestOptions>(),
-                        It.IsAny<Dictionary<string, List<string>>>(),
-                        It.IsAny<CancellationToken>()))
+                Setup()
                     .ThrowsAsync(new NullReferenceException());
 
                 var ex = await Assert.ThrowsAsync<AzureSearchException>(() => ExecuteAsync());
@@ -121,7 +193,9 @@ namespace NuGet.Services.AzureSearch.Wrappers
                 Assert.Equal("The search query failed due to Azure/azure-sdk-for-net#3224.", ex.Message);
             }
 
-            public abstract Task ExecuteAsync();
+            public abstract bool TreatsNotFoundAsDefault { get; }
+            public abstract IReturns<IDocumentsOperations, Task<AzureOperationResponse<T>>> Setup();
+            public abstract Task<T> ExecuteAsync();
         }
     }
 }


### PR DESCRIPTION
This cuts the average query time in nearly a half.
Progress on https://github.com/NuGet/NuGetGallery/issues/6466

Basically we use a document lookup API instead of a full blown search. This is much faster.

## Before

Samples | Average | Min | Max | Std. Dev. | Error % | Throughput | Received KB/sec | Sent KB/sec | Avg. Bytes
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
10000 | 152 | 141 | 363 | 13.23 | 0.00% | 64.61701 | 318.63 | 12.2 | 5049.4

## After

Samples | Average | Min | Max | Std. Dev. | Error % | Throughput | Received KB/sec | Sent KB/sec | Avg. Bytes
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
10000 | 79 | 73 | 280 | 9.75 | 0.00% | 123.8405 | 610.66 | 23.38 | 5049.4

