### PR TITLE
Default luceneQuery to true in Azure Search Service

### DIFF
--- a/src/NuGet.Services.SearchService/Controllers/SearchController.cs
+++ b/src/NuGet.Services.SearchService/Controllers/SearchController.cs
@@ -77,7 +77,7 @@ namespace NuGet.Services.SearchService.Controllers
             string semVerLevel = null,
             string q = null,
             string sortBy = null,
-            bool luceneQuery = false,
+            bool luceneQuery = true,
             bool debug = false)
         {
             await EnsureInitializedAsync();

--- a/tests/BasicSearchTests.FunctionalTests.Core/TestSupport/V2SearchBuilder.cs
+++ b/tests/BasicSearchTests.FunctionalTests.Core/TestSupport/V2SearchBuilder.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Specialized;
 
 namespace BasicSearchTests.FunctionalTests.Core.TestSupport
@@ -19,6 +18,8 @@ namespace BasicSearchTests.FunctionalTests.Core.TestSupport
         public bool IncludeSemVer2 { get; set; }
 
         public string SortBy { get; set; }
+
+        public bool? LuceneQuery { get; set; }
 
         public V2SearchBuilder() : base("/search/query?") { }
 
@@ -48,6 +49,11 @@ namespace BasicSearchTests.FunctionalTests.Core.TestSupport
             if (!string.IsNullOrWhiteSpace(SortBy))
             {
                 queryString["sortBy"] = SortBy;
+            }
+
+            if (LuceneQuery.HasValue)
+            {
+                queryString["luceneQuery"] = LuceneQuery.ToString();
             }
 
             return queryString;

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/V2SearchProtocolTests.cs
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/V2SearchProtocolTests.cs
@@ -86,6 +86,58 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
             Assert.Null(results.Data);
         }
 
+        /// <summary>
+        /// This is the query pattern used by gallery to handle "FindPackagesById()?id={id}" OData queries.
+        /// </summary>
+        [Fact]
+        public async Task ODataFindPackagesById()
+        {
+            var results = await V2SearchAsync(new V2SearchBuilder
+            {
+                Query = $"Id:\"{Constants.TestPackageId}\"",
+                Skip = 0,
+                Take = 100,
+                SortBy = "relevance",
+                IncludeSemVer2 = true,
+                Prerelease = true,
+                IgnoreFilter = true,
+                LuceneQuery = null,
+            });
+
+            Assert.NotNull(results);
+            Assert.True(results.TotalHits >= 1);
+            Assert.NotEmpty(results.Data);
+            foreach (var result in results.Data)
+            {
+                Assert.Equal(Constants.TestPackageId, result.PackageRegistration.Id);
+            }
+        }
+
+        /// <summary>
+        /// This is the query pattern used by gallery to handle "Packages(Id='{id}',Version='{version}')" OData queries.
+        /// </summary>
+        [Fact]
+        public async Task ODataSpecificPackage()
+        {
+            var results = await V2SearchAsync(new V2SearchBuilder
+            {
+                Query = $"Id:\"{Constants.TestPackageId}\" AND Version:\"{Constants.TestPackageVersion}\"",
+                Skip = 0,
+                Take = 1,
+                SortBy = "relevance",
+                IncludeSemVer2 = true,
+                Prerelease = true,
+                IgnoreFilter = true,
+                LuceneQuery = null,
+            });
+
+            Assert.NotNull(results);
+            Assert.Equal(1, results.TotalHits);
+            var package = Assert.Single(results.Data);
+            Assert.Equal(Constants.TestPackageId, package.PackageRegistration.Id);
+            Assert.Equal(Constants.TestPackageVersion, package.NormalizedVersion);
+        }
+
         [Fact]
         public async Task ResultsHonorPreReleaseField()
         {

--- a/tests/NuGet.Services.SearchService.Tests/Controllers/SearchControllerFacts.cs
+++ b/tests/NuGet.Services.SearchService.Tests/Controllers/SearchControllerFacts.cs
@@ -150,7 +150,7 @@ namespace NuGet.Services.SearchService.Controllers
                 Assert.False(lastRequest.IncludePrerelease);
                 Assert.False(lastRequest.IncludeSemVer2);
                 Assert.Null(lastRequest.Query);
-                Assert.False(lastRequest.LuceneQuery);
+                Assert.True(lastRequest.LuceneQuery);
                 Assert.False(lastRequest.ShowDebug);
             }
 


### PR DESCRIPTION
This is necessary for hijack to work properly. Old search defaulted it to true.
Address https://github.com/NuGet/NuGetGallery/issues/7360