### PR TITLE
Introduce IndexOperationBuilder to encapsulate query optimizations

### DIFF
--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -77,8 +77,7 @@ namespace NuGet.Services.AzureSearch
 
             containerBuilder
                 .Register<ISearchService>(c => new AzureSearchService(
-                    c.Resolve<ISearchTextBuilder>(),
-                    c.Resolve<ISearchParametersBuilder>(),
+                    c.Resolve<IIndexOperationBuilder>(),
                     c.ResolveKeyed<ISearchIndexClientWrapper>(searchIndexKey),
                     c.ResolveKeyed<ISearchIndexClientWrapper>(hijackIndexKey),
                     c.Resolve<ISearchResponseBuilder>(),
@@ -253,6 +252,7 @@ namespace NuGet.Services.AzureSearch
             services.AddTransient<IEntitiesContextFactory, EntitiesContextFactory>();
             services.AddTransient<IHijackDocumentBuilder, HijackDocumentBuilder>();
             services.AddTransient<IIndexBuilder, IndexBuilder>();
+            services.AddTransient<IIndexOperationBuilder, IndexOperationBuilder>();
             services.AddTransient<INewPackageRegistrationProducer, NewPackageRegistrationProducer>();
             services.AddTransient<IOwnerSetComparer, OwnerSetComparer>();
             services.AddTransient<IPackageEntityIndexActionBuilder, PackageEntityIndexActionBuilder>();

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -138,6 +138,10 @@
     <Compile Include="SearchDocumentBuilder.cs" />
     <Compile Include="SearchService\AuxiliaryData.cs" />
     <Compile Include="AuxiliaryFiles\AuxiliaryFileResult.cs" />
+    <Compile Include="SearchService\IIndexOperationBuilder.cs" />
+    <Compile Include="SearchService\IndexOperation.cs" />
+    <Compile Include="SearchService\IndexOperationBuilder.cs" />
+    <Compile Include="SearchService\IndexOperationType.cs" />
     <Compile Include="SearchService\Models\DebugDocumentResult.cs" />
     <Compile Include="SearchService\IAuxiliaryDataCache.cs" />
     <Compile Include="AuxiliaryFiles\IAuxiliaryFileClient.cs" />
@@ -159,7 +163,6 @@
     <Compile Include="SearchService\ISearchService.cs" />
     <Compile Include="SearchService\Models\DebugInformation.cs" />
     <Compile Include="SearchService\Models\IndexStatus.cs" />
-    <Compile Include="SearchService\Models\ApiType.cs" />
     <Compile Include="SearchService\Models\SearchRequest.cs" />
     <Compile Include="SearchService\Models\ServerInformation.cs" />
     <Compile Include="SearchService\Models\SearchStatusResponse.cs" />

--- a/src/NuGet.Services.AzureSearch/SearchService/IIndexOperationBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IIndexOperationBuilder.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    /// <summary>
+    /// This interface encapsulates the selection of Azure Search operation as well as the generation of parameters for
+    /// the selected operation. Query optimizations such as looking up a document by key instead of doing a full Lucene
+    /// query are decided here.
+    /// </summary>
+    public interface IIndexOperationBuilder
+    {
+        IndexOperation Autocomplete(AutocompleteRequest request);
+        IndexOperation V2SearchWithHijackIndex(V2SearchRequest request);
+        IndexOperation V2SearchWithSearchIndex(V2SearchRequest request);
+        IndexOperation V3Search(V3SearchRequest request);
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/ISearchResponseBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/ISearchResponseBuilder.cs
@@ -10,20 +10,20 @@ namespace NuGet.Services.AzureSearch.SearchService
     {
         V2SearchResponse V2FromHijack(
             V2SearchRequest request,
-            SearchParameters parameters,
             string text,
+            SearchParameters parameters,
             DocumentSearchResult<HijackDocument.Full> result,
             TimeSpan duration);
         V2SearchResponse V2FromSearch(
             V2SearchRequest request,
-            SearchParameters parameters,
             string text,
+            SearchParameters parameters,
             DocumentSearchResult<SearchDocument.Full> result,
             TimeSpan duration);
         V3SearchResponse V3FromSearch(
             V3SearchRequest request,
-            SearchParameters parameters,
             string text,
+            SearchParameters parameters,
             DocumentSearchResult<SearchDocument.Full> result,
             TimeSpan duration);
         V3SearchResponse V3FromSearchDocument(
@@ -33,8 +33,8 @@ namespace NuGet.Services.AzureSearch.SearchService
             TimeSpan duration);
         AutocompleteResponse AutocompleteFromSearch(
             AutocompleteRequest request,
-            SearchParameters parameters,
             string text,
+            SearchParameters parameters,
             DocumentSearchResult<SearchDocument.Full> result,
             TimeSpan duration);
     }

--- a/src/NuGet.Services.AzureSearch/SearchService/ISearchTextBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/ISearchTextBuilder.cs
@@ -15,7 +15,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         /// <param name="request">The V2 search request.</param>
         /// <returns>The Azure Search query.</returns>
         /// <exception cref="InvalidSearchRequestException">Thrown on invalid search requests.</exception>
-        ParsedQuery V2Search(V2SearchRequest request);
+        ParsedQuery ParseV2Search(V2SearchRequest request);
 
         /// <summary>
         /// Map a V3 search request to Azure Search.
@@ -23,7 +23,14 @@ namespace NuGet.Services.AzureSearch.SearchService
         /// <param name="request">The V3 search request.</param>
         /// <returns>The Azure Search query.</returns>
         /// <exception cref="InvalidSearchRequestException">Thrown on invalid search requests.</exception>
-        ParsedQuery V3Search(V3SearchRequest request);
+        ParsedQuery ParseV3Search(V3SearchRequest request);
+
+        /// <summary>
+        /// Build a parsed query into search text.
+        /// </summary>
+        /// <param name="parsed">The parsed query.</param>
+        /// <returns>The Lucene search text to pass to Azure Search.</returns>
+        string Build(ParsedQuery parsed);
 
         /// <summary>
         /// Map an autocomplete request to Azure Search.

--- a/src/NuGet.Services.AzureSearch/SearchService/IndexOperation.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IndexOperation.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Search.Models;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class IndexOperation
+    {
+        private IndexOperation(
+            IndexOperationType type,
+            string documentKey,
+            string searchText,
+            SearchParameters searchParameters)
+        {
+            Type = type;
+            DocumentKey = documentKey;
+            SearchText = searchText;
+            SearchParameters = searchParameters;
+        }
+
+        /// <summary>
+        /// The type of index operation. This is used to determine which other properties are applicable.
+        /// </summary>
+        public IndexOperationType Type { get; }
+
+        /// <summary>
+        /// The key to look up an Azure Search document with.
+        /// Used when <see cref="Type"/> is <see cref="IndexOperationType.Get"/>.
+        /// </summary>
+        public string DocumentKey { get; }
+
+        /// <summary>
+        /// The text to use for a search query.
+        /// Used when <see cref="Type"/> is <see cref="IndexOperationType.Search"/>.
+        /// </summary>
+        public string SearchText { get; }
+
+        /// <summary>
+        /// The parameters to use for an Azure Search query.
+        /// Used when <see cref="Type"/> is <see cref="IndexOperationType.Search"/>.
+        /// </summary>
+        public SearchParameters SearchParameters { get; }
+
+        public static IndexOperation Get(string documentKey)
+        {
+            return new IndexOperation(
+                IndexOperationType.Get,
+                documentKey,
+                searchText: null,
+                searchParameters: null);
+        }
+
+        public static IndexOperation Search(string text, SearchParameters parameters)
+        {
+            return new IndexOperation(
+                IndexOperationType.Search,
+                documentKey: null,
+                searchText: text,
+                searchParameters: parameters);
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/IndexOperationBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IndexOperationBuilder.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using NuGet.Indexing;
+using NuGet.Packaging;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class IndexOperationBuilder : IIndexOperationBuilder
+    {
+        private readonly ISearchTextBuilder _textBuilder;
+        private readonly ISearchParametersBuilder _parametersBuilder;
+
+        public IndexOperationBuilder(
+            ISearchTextBuilder textBuilder,
+            ISearchParametersBuilder parametersBuilder)
+        {
+            _textBuilder = textBuilder ?? throw new ArgumentNullException(nameof(textBuilder));
+            _parametersBuilder = parametersBuilder ?? throw new ArgumentNullException(nameof(parametersBuilder));
+        }
+
+        public IndexOperation V3Search(V3SearchRequest request)
+        {
+            var parsed = _textBuilder.ParseV3Search(request);
+
+            IndexOperation indexOperation;
+            if (TryGetSearchDocumentByKey(request, parsed, out indexOperation))
+            {
+                return indexOperation;
+            }
+
+            var text = _textBuilder.Build(parsed);
+            var parameters = _parametersBuilder.V3Search(request);
+            return IndexOperation.Search(text, parameters);
+        }
+
+        public IndexOperation V2SearchWithSearchIndex(V2SearchRequest request)
+        {
+            var parsed = _textBuilder.ParseV2Search(request);
+            var text = _textBuilder.Build(parsed);
+            var parameters = _parametersBuilder.V2Search(request);
+            return IndexOperation.Search(text, parameters);
+        }
+
+        public IndexOperation V2SearchWithHijackIndex(V2SearchRequest request)
+        {
+            var parsed = _textBuilder.ParseV2Search(request);
+            var text = _textBuilder.Build(parsed);
+            var parameters = _parametersBuilder.V2Search(request);
+            return IndexOperation.Search(text, parameters);
+        }
+
+        public IndexOperation Autocomplete(AutocompleteRequest request)
+        {
+            var text = _textBuilder.Autocomplete(request);
+            var parameters = _parametersBuilder.Autocomplete(request);
+            return IndexOperation.Search(text, parameters);
+        }
+
+        private bool TryGetSearchDocumentByKey(
+            SearchRequest request,
+            ParsedQuery parsed,
+            out IndexOperation indexOperation)
+        {
+            if (PagedToFirstItem(request)
+                && parsed.Grouping.Count == 1
+                && TryGetSinglePackageId(parsed, out var packageId))
+            {
+                var searchFilters = _parametersBuilder.GetSearchFilters(request);
+                var documentKey = DocumentUtilities.GetSearchDocumentKey(packageId, searchFilters);
+
+                indexOperation = IndexOperation.Get(documentKey);
+                return true;
+            }
+
+            indexOperation = null;
+            return false;
+        }
+
+        private bool TryGetSinglePackageId(
+            ParsedQuery parsed,
+            out string packageId)
+        {
+            if (parsed.Grouping.TryGetValue(QueryField.PackageId, out var terms)
+                && terms.Count == 1)
+            {
+                packageId = terms.First();
+                if (packageId.Length <= PackageIdValidator.MaxPackageIdLength
+                    && PackageIdValidator.IsValidPackageId(packageId))
+                {
+                    return true;
+                }
+            }
+
+            packageId = null;
+            return false;
+        }
+
+        private static bool PagedToFirstItem(SearchRequest request)
+        {
+            return request.Skip <= 0 && request.Take >= 1;
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/IndexOperationType.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IndexOperationType.cs
@@ -3,7 +3,7 @@
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
-    public enum ApiType
+    public enum IndexOperationType
     {
         /// <summary>
         /// The data for the user was fetched using Azure Search's "get document by key" API. The .NET API is called "Get" and

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/DebugInformation.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/DebugInformation.cs
@@ -10,7 +10,7 @@ namespace NuGet.Services.AzureSearch.SearchService
     {
         public SearchRequest SearchRequest { get; set; }
         public string IndexName { get; set; }
-        public ApiType ApiType { get; set; }
+        public IndexOperationType IndexOperationType { get; set; }
         public string DocumentKey { get; set; }
         public SearchParameters SearchParameters { get; set; }
         public string SearchText { get; set; }
@@ -36,7 +36,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             {
                 SearchRequest = request,
                 IndexName = indexName,
-                ApiType = ApiType.Search,
+                IndexOperationType = IndexOperationType.Search,
                 SearchParameters = parameters,
                 SearchText = text,
                 DocumentSearchResult = result,
@@ -61,7 +61,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             {
                 SearchRequest = request,
                 IndexName = indexName,
-                ApiType = ApiType.Get,
+                IndexOperationType = IndexOperationType.Get,
                 DocumentKey = documentKey,
                 QueryDuration = duration,
                 AuxiliaryFilesMetadata = auxiliaryFilesMetadata,

--- a/src/NuGet.Services.AzureSearch/SearchService/ParsedQuery.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/ParsedQuery.cs
@@ -2,22 +2,21 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using NuGet.Indexing;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
+    /// <summary>
+    /// Contains the parsed in-memory model of the user's query.
+    /// </summary>
     public class ParsedQuery
     {
-        public ParsedQuery(string text, string packageId)
+        public ParsedQuery(Dictionary<QueryField, HashSet<string>> grouping)
         {
-            Text = text ?? throw new ArgumentNullException(nameof(text));
-            PackageId = packageId;
+            Grouping = grouping ?? throw new ArgumentNullException(nameof(grouping));
         }
 
-        /// <summary>
-        /// The text that will be provided to Azure Search. This is a Lucene query, not the query provided by the user.
-        /// </summary>
-        public string Text { get; }
-
-        public string PackageId { get; }
+        public Dictionary<QueryField, HashSet<string>> Grouping { get; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
@@ -40,8 +40,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         public V2SearchResponse V2FromHijack(
             V2SearchRequest request,
-            SearchParameters searchParameters,
             string text,
+            SearchParameters searchParameters,
             DocumentSearchResult<HijackDocument.Full> result,
             TimeSpan duration)
         {
@@ -57,8 +57,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         public V2SearchResponse V2FromSearch(
             V2SearchRequest request,
-            SearchParameters parameters,
             string text,
+            SearchParameters parameters,
             DocumentSearchResult<SearchDocument.Full> result,
             TimeSpan duration)
         {
@@ -71,7 +71,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 duration,
                 p => ToV2SearchPackage(p));
         }
-        
+
         public V3SearchResponse V3FromSearchDocument(
             V3SearchRequest request,
             string documentKey,
@@ -108,8 +108,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         public V3SearchResponse V3FromSearch(
             V3SearchRequest request,
-            SearchParameters parameters,
             string text,
+            SearchParameters parameters,
             DocumentSearchResult<SearchDocument.Full> result,
             TimeSpan duration)
         {
@@ -147,8 +147,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         public AutocompleteResponse AutocompleteFromSearch(
             AutocompleteRequest request,
-            SearchParameters parameters,
             string text,
+            SearchParameters parameters,
             DocumentSearchResult<SearchDocument.Full> result,
             TimeSpan duration)
         {

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="AuxiliaryFiles\AuxiliaryFileClientFacts.cs" />
     <Compile Include="SearchService\AuxiliaryFileReloaderFacts.cs" />
     <Compile Include="SearchService\AzureSearchServiceFacts.cs" />
+    <Compile Include="SearchService\IndexOperationBuilderFacts.cs" />
     <Compile Include="SearchService\SearchParametersBuilderFacts.cs" />
     <Compile Include="SearchService\SearchResponseBuilderFacts.cs" />
     <Compile Include="SearchService\SearchStatusServiceFacts.cs" />

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/AzureSearchServiceFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/AzureSearchServiceFacts.cs
@@ -16,52 +16,46 @@ namespace NuGet.Services.AzureSearch.SearchService
         public class V2SearchAsync : BaseFacts
         {
             [Fact]
-            public async Task CallsDependenciesProperlyWithoutHijack()
+            public async Task SearchIndexAndSearchOperation()
             {
                 _v2Request.IgnoreFilter = false;
 
                 var response = await _target.V2SearchAsync(_v2Request);
 
                 Assert.Same(_v2Response, response);
-                _textBuilder.Verify(
-                    x => x.V2Search(_v2Request),
-                    Times.Once);
-                _parametersBuilder.Verify(
-                    x => x.GetSearchFilters(It.IsAny<SearchRequest>()),
-                    Times.Never);
-                _parametersBuilder.Verify(
-                    x => x.V2Search(_v2Request),
+                _operationBuilder.Verify(
+                    x => x.V2SearchWithSearchIndex(_v2Request),
                     Times.Once);
                 _searchOperations.Verify(
-                    x => x.SearchAsync<SearchDocument.Full>(_v2Parsed.Text, _v2Parameters),
+                    x => x.SearchAsync<SearchDocument.Full>(_text, _parameters),
                     Times.Once);
                 _responseBuilder.Verify(
-                    x => x.V2FromSearch(_v2Request, _v2Parameters, _v2Parsed.Text, _searchResult, It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
+                    x => x.V2FromSearch(_v2Request, _text, _parameters, _searchResult, It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
+                    Times.Once);
+                _telemetryService.Verify(
+                    x => x.TrackV2SearchQueryWithSearchIndex(It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
                     Times.Once);
             }
 
             [Fact]
-            public async Task CallsDependenciesProperlyWithHijack()
+            public async Task HijackIndexAndSearchOperation()
             {
                 _v2Request.IgnoreFilter = true;
 
                 var response = await _target.V2SearchAsync(_v2Request);
 
                 Assert.Same(_v2Response, response);
-                _textBuilder.Verify(
-                    x => x.V2Search(_v2Request),
-                    Times.Once);
-                _parametersBuilder.Verify(
-                    x => x.GetSearchFilters(It.IsAny<SearchRequest>()),
-                    Times.Never);
-                _parametersBuilder.Verify(
-                    x => x.V2Search(_v2Request),
+                _operationBuilder.Verify(
+                    x => x.V2SearchWithHijackIndex(_v2Request),
                     Times.Once);
                 _hijackOperations.Verify(
-                    x => x.SearchAsync<HijackDocument.Full>(_v2Parsed.Text, _v2Parameters),
+                    x => x.SearchAsync<HijackDocument.Full>(_text, _parameters),
                     Times.Once);
                 _responseBuilder.Verify(
-                    x => x.V2FromHijack(_v2Request, _v2Parameters, _v2Parsed.Text, _hijackResult, It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
+                    x => x.V2FromHijack(_v2Request, _text, _parameters, _hijackResult, It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
+                    Times.Once);
+                _telemetryService.Verify(
+                    x => x.TrackV2SearchQueryWithHijackIndex(It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
                     Times.Once);
             }
         }
@@ -69,125 +63,117 @@ namespace NuGet.Services.AzureSearch.SearchService
         public class V3SearchAsync : BaseFacts
         {
             [Fact]
-            public async Task SearchesWithNoSpecificPackageId()
+            public async Task SearchIndexAndSearchOperation()
             {
-                _v3Request.Skip = 0;
-                _v3Request.Take = 1;
-                _v3Parsed = new ParsedQuery(string.Empty, packageId: null);
-
                 var response = await _target.V3SearchAsync(_v3Request);
 
-                VerifyV3Search(response);
-            }
-
-            [Fact]
-            public async Task SearchesWithSpecificPackageIdAndSkip()
-            {
-                _v3Request.Skip = 1;
-                _v3Request.Take = 1;
-                _v3Parsed = new ParsedQuery(string.Empty, _packageId);
-
-                var response = await _target.V3SearchAsync(_v3Request);
-
-                VerifyV3Search(response);
-            }
-
-            [Fact]
-            public async Task SearchesWithSpecificPackageIdAndNoTake()
-            {
-                _v3Request.Skip = 0;
-                _v3Request.Take = 0;
-                _v3Parsed = new ParsedQuery(string.Empty, _packageId);
-
-                var response = await _target.V3SearchAsync(_v3Request);
-
-                VerifyV3Search(response);
-            }
-
-            [Fact]
-            public async Task GetsDocumentWithSpecificPackageIdNoSkipAndSomeTake()
-            {
-                _v3Request.Skip = 0;
-                _v3Request.Take = 1;
-                _v3Parsed = new ParsedQuery(string.Empty, _packageId);
-
-                var response = await _target.V3SearchAsync(_v3Request);
-
-                VerifyV3SearchDocument(response);
-            }
-
-            private void VerifyV3SearchDocument(V3SearchResponse response)
-            {
                 Assert.Same(_v3Response, response);
-                _textBuilder.Verify(
+                _operationBuilder.Verify(
                     x => x.V3Search(_v3Request),
                     Times.Once);
-                _parametersBuilder.Verify(
-                    x => x.GetSearchFilters(It.IsAny<SearchRequest>()),
-                    Times.Once);
-                _parametersBuilder.Verify(
-                    x => x.V3Search(It.IsAny<V3SearchRequest>()),
-                    Times.Never);
                 _searchOperations.Verify(
-                    x => x.SearchAsync<SearchDocument.Full>(It.IsAny<string>(), It.IsAny<SearchParameters>()),
-                    Times.Never);
-                _searchOperations.Verify(
-                    x => x.GetOrNullAsync<SearchDocument.Full>(_searchDocument.Key),
+                    x => x.SearchAsync<SearchDocument.Full>(_text, _parameters),
                     Times.Once);
                 _responseBuilder.Verify(
-                    x => x.V3FromSearchDocument(_v3Request, _searchDocument.Key, _searchDocument, It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
+                    x => x.V3FromSearch(_v3Request, _text, _parameters, _searchResult, It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
+                    Times.Once);
+                _telemetryService.Verify(
+                    x => x.TrackV3SearchQuery(It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
                     Times.Once);
             }
 
-            private void VerifyV3Search(V3SearchResponse response)
+            [Fact]
+            public async Task SearchIndexAndGetOperation()
             {
+                _operation = IndexOperation.Get(_key);
+
+                var response = await _target.V3SearchAsync(_v3Request);
+
                 Assert.Same(_v3Response, response);
-                _textBuilder.Verify(
-                    x => x.V3Search(_v3Request),
-                    Times.Once);
-                _parametersBuilder.Verify(
-                    x => x.GetSearchFilters(It.IsAny<SearchRequest>()),
-                    Times.Never);
-                _parametersBuilder.Verify(
+                _operationBuilder.Verify(
                     x => x.V3Search(_v3Request),
                     Times.Once);
                 _searchOperations.Verify(
-                    x => x.SearchAsync<SearchDocument.Full>(_v3Parsed.Text, _v3Parameters),
+                    x => x.GetOrNullAsync<SearchDocument.Full>(_key),
                     Times.Once);
                 _responseBuilder.Verify(
-                    x => x.V3FromSearch(_v3Request, _v3Parameters, _v3Parsed.Text, _searchResult, It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
+                    x => x.V3FromSearchDocument(_v3Request, _key, _searchDocument, It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
                     Times.Once);
+                _telemetryService.Verify(
+                    x => x.TrackV3GetDocument(It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
+                    Times.Once);
+            }
+        }
+
+        public class AutocompleteAsync : BaseFacts
+        {
+            [Fact]
+            public async Task SearchIndexAndSearchOperation()
+            {
+                var response = await _target.AutocompleteAsync(_autocompleteRequest);
+
+                Assert.Same(_autocompleteResponse, response);
+                _operationBuilder.Verify(
+                    x => x.Autocomplete(_autocompleteRequest),
+                    Times.Once);
+                _searchOperations.Verify(
+                    x => x.SearchAsync<SearchDocument.Full>(_text, _parameters),
+                    Times.Once);
+                _responseBuilder.Verify(
+                    x => x.AutocompleteFromSearch(_autocompleteRequest, _text, _parameters, _searchResult, It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
+                    Times.Once);
+                _telemetryService.Verify(
+                    x => x.TrackAutocompleteQuery(It.Is<TimeSpan>(t => t > TimeSpan.Zero)),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task SearchIndexAndGetOperation()
+            {
+                _operation = IndexOperation.Get(_key);
+
+                var ex = await Assert.ThrowsAsync<NotImplementedException>(() => _target.AutocompleteAsync(_autocompleteRequest));
+                Assert.Equal("The operation type Get is not supported.", ex.Message);
+                _operationBuilder.Verify(
+                    x => x.Autocomplete(_autocompleteRequest),
+                    Times.Once);
+                _searchOperations.Verify(
+                    x => x.GetOrNullAsync<SearchDocument.Full>(It.IsAny<string>()),
+                    Times.Never);
+                _telemetryService.Verify(
+                    x => x.TrackV3GetDocument(It.IsAny<TimeSpan>()),
+                    Times.Never);
             }
         }
 
         public abstract class BaseFacts
         {
-            protected readonly Mock<ISearchTextBuilder> _textBuilder;
-            protected readonly Mock<ISearchParametersBuilder> _parametersBuilder;
+            protected readonly Mock<IIndexOperationBuilder> _operationBuilder;
             protected readonly Mock<ISearchIndexClientWrapper> _searchIndex;
             protected readonly Mock<IDocumentsOperationsWrapper> _searchOperations;
             protected readonly Mock<ISearchIndexClientWrapper> _hijackIndex;
             protected readonly Mock<IDocumentsOperationsWrapper> _hijackOperations;
             protected readonly Mock<ISearchResponseBuilder> _responseBuilder;
             protected readonly Mock<IAzureSearchTelemetryService> _telemetryService;
-            protected readonly string _packageId;
             protected readonly V2SearchRequest _v2Request;
             protected readonly V3SearchRequest _v3Request;
-            protected readonly ParsedQuery _v2Parsed;
-            protected ParsedQuery _v3Parsed;
-            protected readonly SearchParameters _v2Parameters;
-            protected readonly SearchParameters _v3Parameters;
+            protected readonly AutocompleteRequest _autocompleteRequest;
+            protected readonly string _key;
+            protected readonly string _text;
+            protected readonly SearchParameters _parameters;
+            protected IndexOperation _operation;
             protected readonly DocumentSearchResult<SearchDocument.Full> _searchResult;
             protected readonly SearchDocument.Full _searchDocument;
             protected readonly DocumentSearchResult<HijackDocument.Full> _hijackResult;
+            protected readonly HijackDocument.Full _hijackDocument;
             protected readonly V2SearchResponse _v2Response;
             protected readonly V3SearchResponse _v3Response;
+            protected readonly AutocompleteResponse _autocompleteResponse;
             protected readonly AzureSearchService _target;
 
             public BaseFacts()
             {
-                _textBuilder = new Mock<ISearchTextBuilder>();
-                _parametersBuilder = new Mock<ISearchParametersBuilder>();
+                _operationBuilder = new Mock<IIndexOperationBuilder>();
                 _searchIndex = new Mock<ISearchIndexClientWrapper>();
                 _searchOperations = new Mock<IDocumentsOperationsWrapper>();
                 _hijackIndex = new Mock<ISearchIndexClientWrapper>();
@@ -195,72 +181,73 @@ namespace NuGet.Services.AzureSearch.SearchService
                 _responseBuilder = new Mock<ISearchResponseBuilder>();
                 _telemetryService = new Mock<IAzureSearchTelemetryService>();
 
-                _packageId = "NuGet.Versioning";
-                _v2Request = new V2SearchRequest { Skip = 0, Take = 20 };
-                _v3Request = new V3SearchRequest { Skip = 0, Take = 20 };
-                _v2Parsed = new ParsedQuery("v2", packageId: null);
-                _v3Parsed = new ParsedQuery("v3", packageId: null);
-                _v2Parameters = new SearchParameters();
-                _v3Parameters = new SearchParameters();
+                _v2Request = new V2SearchRequest();
+                _v3Request = new V3SearchRequest();
+                _autocompleteRequest = new AutocompleteRequest();
+                _key = "key";
+                _text = "search";
+                _parameters = new SearchParameters();
+                _operation = IndexOperation.Search(_text, _parameters);
                 _searchResult = new DocumentSearchResult<SearchDocument.Full>();
-                _searchDocument = new SearchDocument.Full
-                {
-                    Key = DocumentUtilities.GetSearchDocumentKey(_packageId, SearchFilters.Default),
-                };
+                _searchDocument = new SearchDocument.Full();
                 _hijackResult = new DocumentSearchResult<HijackDocument.Full>();
+                _hijackDocument = new HijackDocument.Full();
                 _v2Response = new V2SearchResponse();
                 _v3Response = new V3SearchResponse();
+                _autocompleteResponse = new AutocompleteResponse();
 
-                _textBuilder
-                    .Setup(x => x.V2Search(It.IsAny<V2SearchRequest>()))
-                    .Returns(() => _v2Parsed);
-                _textBuilder
+                _operationBuilder
+                    .Setup(x => x.V2SearchWithHijackIndex(It.IsAny<V2SearchRequest>()))
+                    .Returns(() => _operation);
+                _operationBuilder
+                    .Setup(x => x.V2SearchWithSearchIndex(It.IsAny<V2SearchRequest>()))
+                    .Returns(() => _operation);
+                _operationBuilder
                     .Setup(x => x.V3Search(It.IsAny<V3SearchRequest>()))
-                    .Returns(() => _v3Parsed);
-                _parametersBuilder
-                    .Setup(x => x.V2Search(It.IsAny<V2SearchRequest>()))
-                    .Returns(() => _v2Parameters);
-                _parametersBuilder
-                    .Setup(x => x.V3Search(It.IsAny<V3SearchRequest>()))
-                    .Returns(() => _v3Parameters);
+                    .Returns(() => _operation);
+                _operationBuilder
+                    .Setup(x => x.Autocomplete(It.IsAny<AutocompleteRequest>()))
+                    .Returns(() => _operation);
 
                 // Set up the search to take at least one millisecond. This allows us to test the measured duration.
                 _searchOperations
                     .Setup(x => x.SearchAsync<SearchDocument.Full>(It.IsAny<string>(), It.IsAny<SearchParameters>()))
                     .ReturnsAsync(() => _searchResult)
                     .Callback(() => Thread.Sleep(TimeSpan.FromMilliseconds(1)));
-
                 _searchOperations
                     .Setup(x => x.GetOrNullAsync<SearchDocument.Full>(It.IsAny<string>()))
                     .ReturnsAsync(() => _searchDocument)
                     .Callback(() => Thread.Sleep(TimeSpan.FromMilliseconds(1)));
-
                 _hijackOperations
                     .Setup(x => x.SearchAsync<HijackDocument.Full>(It.IsAny<string>(), It.IsAny<SearchParameters>()))
                     .ReturnsAsync(() => _hijackResult)
+                    .Callback(() => Thread.Sleep(TimeSpan.FromMilliseconds(1)));
+                _hijackOperations
+                    .Setup(x => x.GetOrNullAsync<HijackDocument.Full>(It.IsAny<string>()))
+                    .ReturnsAsync(() => _hijackDocument)
                     .Callback(() => Thread.Sleep(TimeSpan.FromMilliseconds(1)));
 
                 _responseBuilder
                     .Setup(x => x.V2FromHijack(
                         It.IsAny<V2SearchRequest>(),
-                        It.IsAny<SearchParameters>(),
                         It.IsAny<string>(),
+                        It.IsAny<SearchParameters>(),
                         It.IsAny<DocumentSearchResult<HijackDocument.Full>>(),
                         It.IsAny<TimeSpan>()))
                     .Returns(() => _v2Response);
                 _responseBuilder
                     .Setup(x => x.V2FromSearch(
                         It.IsAny<V2SearchRequest>(),
-                        It.IsAny<SearchParameters>(),
                         It.IsAny<string>(),
+                        It.IsAny<SearchParameters>(),
                         It.IsAny<DocumentSearchResult<SearchDocument.Full>>(),
                         It.IsAny<TimeSpan>()))
                     .Returns(() => _v2Response);
                 _responseBuilder
                     .Setup(x => x.V3FromSearch(
                         It.IsAny<V3SearchRequest>(),
-                        It.IsAny<SearchParameters>(),
                         It.IsAny<string>(),
+                        It.IsAny<SearchParameters>(),
                         It.IsAny<DocumentSearchResult<SearchDocument.Full>>(),
                         It.IsAny<TimeSpan>()))
                     .Returns(() => _v3Response);
@@ -271,13 +258,20 @@ namespace NuGet.Services.AzureSearch.SearchService
                         It.IsAny<SearchDocument.Full>(),
                         It.IsAny<TimeSpan>()))
                     .Returns(() => _v3Response);
+                _responseBuilder
+                    .Setup(x => x.AutocompleteFromSearch(
+                        It.IsAny<AutocompleteRequest>(),
+                        It.IsAny<string>(),
+                        It.IsAny<SearchParameters>(),
+                        It.IsAny<DocumentSearchResult<SearchDocument.Full>>(),
+                        It.IsAny<TimeSpan>()))
+                    .Returns(() => _autocompleteResponse);
 
                 _searchIndex.Setup(x => x.Documents).Returns(() => _searchOperations.Object);
                 _hijackIndex.Setup(x => x.Documents).Returns(() => _hijackOperations.Object);
 
                 _target = new AzureSearchService(
-                    _textBuilder.Object,
-                    _parametersBuilder.Object,
+                    _operationBuilder.Object,
                     _searchIndex.Object,
                     _hijackIndex.Object,
                     _responseBuilder.Object,

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/IndexOperationBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/IndexOperationBuilderFacts.cs
@@ -1,0 +1,289 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Data.Entity.Core.Metadata.Edm;
+using System.Linq;
+using Microsoft.Azure.Search.Models;
+using Moq;
+using NuGet.Indexing;
+using Xunit;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class IndexOperationBuilderFacts
+    {
+        public class Autocomplete : Facts
+        {
+            [Fact]
+            public void BuildsSearchOperation()
+            {
+                var actual = Target.Autocomplete(AutocompleteRequest);
+
+                Assert.Equal(IndexOperationType.Search, actual.Type);
+                Assert.Same(Text, actual.SearchText);
+                Assert.Same(Parameters, actual.SearchParameters);
+                TextBuilder.Verify(x => x.Autocomplete(AutocompleteRequest), Times.Once);
+                ParametersBuilder.Verify(x => x.Autocomplete(AutocompleteRequest), Times.Once);
+            }
+        }
+
+        public class V3Search : SearchIndexFacts
+        {
+            public override IndexOperation Build()
+            {
+                return Target.V3Search(V3SearchRequest);
+            }
+
+            [Fact]
+            public void CallsDependenciesForGetOperation()
+            {
+                ParsedQuery.Grouping[QueryField.PackageId] = new HashSet<string>(new[] { Id });
+
+                Build();
+
+                TextBuilder.Verify(x => x.ParseV3Search(V3SearchRequest), Times.Once);
+                TextBuilder.Verify(x => x.Build(It.IsAny<ParsedQuery>()), Times.Never);
+                ParametersBuilder.Verify(x => x.V3Search(It.IsAny<V3SearchRequest>()), Times.Never);
+            }
+
+            [Fact]
+            public void CallsDependenciesForSearchOperation()
+            {
+                Build();
+
+                TextBuilder.Verify(x => x.ParseV3Search(V3SearchRequest), Times.Once);
+                ParametersBuilder.Verify(x => x.V3Search(V3SearchRequest), Times.Once);
+            }
+        }
+
+        public class V2SearchWithSearchIndex : Facts
+        {
+            public IndexOperation Build()
+            {
+                return Target.V2SearchWithSearchIndex(V2SearchRequest);
+            }
+
+            [Fact]
+            public void CallsDependenciesForSearchOperation()
+            {
+                Build();
+
+                TextBuilder.Verify(x => x.ParseV2Search(V2SearchRequest), Times.Once);
+                ParametersBuilder.Verify(x => x.V2Search(V2SearchRequest), Times.Once);
+            }
+        }
+
+        public class V2SearchWithHijackIndex : Facts
+        {
+            public IndexOperation Build()
+            {
+                return Target.V2SearchWithHijackIndex(V2SearchRequest);
+            }
+
+            [Fact]
+            public void CallsDependenciesForSearchOperation()
+            {
+                Build();
+
+                TextBuilder.Verify(x => x.ParseV2Search(V2SearchRequest), Times.Once);
+                ParametersBuilder.Verify(x => x.V2Search(V2SearchRequest), Times.Once);
+            }
+        }
+
+        public abstract class SearchIndexFacts : Facts
+        {
+            public abstract IndexOperation Build();
+
+            [Theory]
+            [MemberData(nameof(ValidIdData))]
+            public void BuildsGetOperationForSingleValidPackageId(string id)
+            {
+                ParsedQuery.Grouping[QueryField.PackageId] = new HashSet<string>(new[] { id });
+
+                var actual = Build();
+
+                Assert.Equal(IndexOperationType.Get, actual.Type);
+                Assert.Equal(
+                    DocumentUtilities.GetSearchDocumentKey(id, SearchFilters.Default),
+                    actual.DocumentKey);
+            }
+
+            [Theory]
+            [MemberData(nameof(InvalidIdData))]
+            public void DoesNotBuildGetOperationForInvalidPackageId(string id)
+            {
+                ParsedQuery.Grouping[QueryField.PackageId] = new HashSet<string>(new[] { id });
+
+                var actual = Build();
+
+                Assert.Equal(IndexOperationType.Search, actual.Type);
+            }
+
+            [Fact]
+            public void DoesNotBuildGetOperationForEmptyPackageIdQuery()
+            {
+                ParsedQuery.Grouping[QueryField.PackageId] = new HashSet<string>();
+
+                var actual = Build();
+
+                Assert.Equal(IndexOperationType.Search, actual.Type);
+            }
+
+            [Fact]
+            public void DoesNotBuildGetOperationForIdQuery()
+            {
+                ParsedQuery.Grouping[QueryField.Id] = new HashSet<string>(new[] { Id });
+
+                var actual = Build();
+
+                Assert.Equal(IndexOperationType.Search, actual.Type);
+            }
+
+            [Fact]
+            public void DoesNotBuildGetOperationForSkippingFirstItem()
+            {
+                V2SearchRequest.Skip = 1;
+                V3SearchRequest.Skip = 1;
+                ParsedQuery.Grouping[QueryField.PackageId] = new HashSet<string>(new[] { Id });
+
+                var actual = Build();
+
+                Assert.Equal(IndexOperationType.Search, actual.Type);
+            }
+
+            [Fact]
+            public void DoesNotBuildGetOperationForNoTake()
+            {
+                V2SearchRequest.Take = 0;
+                V3SearchRequest.Take = 0;
+                ParsedQuery.Grouping[QueryField.PackageId] = new HashSet<string>(new[] { Id });
+
+                var actual = Build();
+
+                Assert.Equal(IndexOperationType.Search, actual.Type);
+            }
+
+            [Fact]
+            public void DoesNotBuildGetOperationForPackageIdVersion()
+            {
+                ParsedQuery.Grouping[QueryField.PackageId] = new HashSet<string>(new[] { Id });
+                ParsedQuery.Grouping[QueryField.Version] = new HashSet<string>(new[] { Version });
+
+                var actual = Build();
+
+                Assert.Equal(IndexOperationType.Search, actual.Type);
+            }
+
+            [Fact]
+            public void DoesNotBuildGetOperationForMultipleFields()
+            {
+                ParsedQuery.Grouping[QueryField.PackageId] = new HashSet<string>(new[] { Id });
+                ParsedQuery.Grouping[QueryField.Description] = new HashSet<string>(new[] { "hi" });
+
+                var actual = Build();
+
+                Assert.Equal(IndexOperationType.Search, actual.Type);
+            }
+
+            [Fact]
+            public void DoesNotBuildGetOperationForMultiplePackageIds()
+            {
+                ParsedQuery.Grouping[QueryField.PackageId] = new HashSet<string>(new[] { Id, "A" });
+
+                var actual = Build();
+
+                Assert.Equal(IndexOperationType.Search, actual.Type);
+            }
+
+            [Fact]
+            public void BuildsSearchOperationForNonPackageIdQueries()
+            {
+                var actual = Build();
+
+                Assert.Equal(IndexOperationType.Search, actual.Type);
+            }
+        }
+
+        public abstract class Facts
+        {
+            public const string Id = "NuGet.Versioning";
+            public const string Version = "5.1.0";
+
+            public const int MaxIdLength = 100;
+
+            public static IReadOnlyList<string> ValidIds => new[]
+            {
+                Id,
+                new string('a', MaxIdLength),
+                "A",
+                "Foo__Bar",
+            };
+
+            public static IReadOnlyList<string> InvalidIds => new[]
+            {
+                string.Empty,
+                "   ",
+                "\nNuGet.Versioning",
+                "A,B",
+                "foo--bar",
+                "foo..bar",
+                "   NuGet.Versioning   ",
+                "   NuGet.Versioning",
+                "NuGet.Versioning   ",
+                "\"NuGet.Versioning\"",
+                new string('a', MaxIdLength + 1),
+            };
+
+            public static IEnumerable<object[]> ValidIdData => ValidIds.Select(x => new object[] { x });
+            public static IEnumerable<object[]> InvalidIdData => InvalidIds.Select(x => new object[] { x });
+
+            public Facts()
+            {
+                TextBuilder = new Mock<ISearchTextBuilder>();
+                ParametersBuilder = new Mock<ISearchParametersBuilder>();
+
+                AutocompleteRequest = new AutocompleteRequest { Skip = 0, Take = 20 };
+                V2SearchRequest = new V2SearchRequest { Skip = 0, Take = 20 };
+                V3SearchRequest = new V3SearchRequest { Skip = 0, Take = 20 };
+                Text = "";
+                Parameters = new SearchParameters();
+                ParsedQuery = new ParsedQuery(new Dictionary<QueryField, HashSet<string>>());
+
+                TextBuilder
+                    .Setup(x => x.Autocomplete(It.IsAny<AutocompleteRequest>()))
+                    .Returns(() => Text);
+                TextBuilder
+                    .Setup(x => x.ParseV2Search(It.IsAny<V2SearchRequest>()))
+                    .Returns(() => ParsedQuery);
+                TextBuilder
+                    .Setup(x => x.ParseV3Search(It.IsAny<V3SearchRequest>()))
+                    .Returns(() => ParsedQuery);
+                TextBuilder
+                    .Setup(x => x.Build(It.IsAny<ParsedQuery>()))
+                    .Returns(() => Text);
+                ParametersBuilder
+                    .Setup(x => x.Autocomplete(It.IsAny<AutocompleteRequest>()))
+                    .Returns(() => Parameters);
+                ParametersBuilder
+                    .Setup(x => x.V2Search(It.IsAny<V2SearchRequest>()))
+                    .Returns(() => Parameters);
+                ParametersBuilder
+                    .Setup(x => x.V3Search(It.IsAny<V3SearchRequest>()))
+                    .Returns(() => Parameters);
+
+                Target = new IndexOperationBuilder(
+                    TextBuilder.Object,
+                    ParametersBuilder.Object);
+            }
+
+            public Mock<ISearchTextBuilder> TextBuilder { get; }
+            public Mock<ISearchParametersBuilder> ParametersBuilder { get; }
+            public AutocompleteRequest AutocompleteRequest { get; }
+            public V2SearchRequest V2SearchRequest { get; }
+            public V3SearchRequest V3SearchRequest { get; }
+            public string Text { get; }
+            public SearchParameters Parameters { get; }
+            public ParsedQuery ParsedQuery { get; }
+            public IndexOperationBuilder Target { get; }
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -26,8 +26,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var response = _target.V2FromHijack(
                     _v2Request,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _hijackResult,
                     _duration);
 
@@ -53,8 +53,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var response = _target.V2FromHijack(
                     _v2Request,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _hijackResult,
                     _duration);
 
@@ -70,8 +70,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var response = _target.V2FromHijack(
                     _v2Request,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _hijackResult,
                     _duration);
 
@@ -91,8 +91,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var response = _target.V2FromHijack(
                     _v2Request,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _hijackResult,
                     _duration);
 
@@ -113,8 +113,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var response = _target.V2FromHijack(
                     _v2Request,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _hijackResult,
                     _duration);
 
@@ -129,8 +129,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var response = _target.V2FromHijack(
                     _v2Request,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _hijackResult,
                     _duration);
 
@@ -149,7 +149,7 @@ namespace NuGet.Services.AzureSearch.SearchService
     ""ShowDebug"": true
   },
   ""IndexName"": ""hijack-index"",
-  ""ApiType"": ""Search"",
+  ""IndexOperationType"": ""Search"",
   ""SearchParameters"": {
     ""IncludeTotalResultCount"": false,
     ""QueryType"": ""simple"",
@@ -185,8 +185,8 @@ namespace NuGet.Services.AzureSearch.SearchService
             {
                 var response = _target.V2FromHijack(
                     _v2Request,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _hijackResult,
                     _duration);
 
@@ -246,8 +246,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var response = _target.V2FromSearch(
                     _v2Request,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _searchResult,
                     _duration);
 
@@ -267,8 +267,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var response = _target.V2FromSearch(
                     _v2Request,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _searchResult,
                     _duration);
 
@@ -289,8 +289,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var response = _target.V2FromSearch(
                     _v2Request,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _searchResult,
                     _duration);
 
@@ -305,8 +305,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var response = _target.V2FromSearch(
                     _v2Request,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _searchResult,
                     _duration);
 
@@ -325,7 +325,7 @@ namespace NuGet.Services.AzureSearch.SearchService
     ""ShowDebug"": true
   },
   ""IndexName"": ""search-index"",
-  ""ApiType"": ""Search"",
+  ""IndexOperationType"": ""Search"",
   ""SearchParameters"": {
     ""IncludeTotalResultCount"": false,
     ""QueryType"": ""simple"",
@@ -361,8 +361,8 @@ namespace NuGet.Services.AzureSearch.SearchService
             {
                 var response = _target.V2FromSearch(
                     _v2Request,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _searchResult,
                     _duration);
 
@@ -426,8 +426,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var response = _target.V3FromSearch(
                     _v3Request,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _searchResult,
                     _duration);
 
@@ -451,8 +451,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var response = _target.V3FromSearch(
                     _v3Request,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _searchResult,
                     _duration);
 
@@ -470,8 +470,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var response = _target.V3FromSearch(
                     _v3Request,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _searchResult,
                     _duration);
 
@@ -492,8 +492,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var response = _target.V3FromSearch(
                     _v3Request,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _searchResult,
                     _duration);
 
@@ -512,8 +512,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var response = _target.V3FromSearch(
                     _v3Request,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _searchResult,
                     _duration);
 
@@ -530,7 +530,7 @@ namespace NuGet.Services.AzureSearch.SearchService
     ""ShowDebug"": true
   },
   ""IndexName"": ""search-index"",
-  ""ApiType"": ""Search"",
+  ""IndexOperationType"": ""Search"",
   ""SearchParameters"": {
     ""IncludeTotalResultCount"": false,
     ""QueryType"": ""simple"",
@@ -565,8 +565,8 @@ namespace NuGet.Services.AzureSearch.SearchService
             {
                 var response = _target.V3FromSearch(
                     _v3Request,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _searchResult,
                     _duration);
 
@@ -662,7 +662,7 @@ namespace NuGet.Services.AzureSearch.SearchService
     ""ShowDebug"": true
   },
   ""IndexName"": ""search-index"",
-  ""ApiType"": ""Get"",
+  ""IndexOperationType"": ""Get"",
   ""DocumentKey"": ""windowsazure_storage-d2luZG93c2F6dXJlLnN0b3JhZ2U1-IncludePrereleaseAndSemVer2"",
   ""QueryDuration"": ""00:00:00.2500000"",
   ""AuxiliaryFilesMetadata"": {
@@ -768,8 +768,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var response = _target.AutocompleteFromSearch(
                     _autocompleteRequest,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _searchResult,
                     _duration);
 
@@ -785,7 +785,7 @@ namespace NuGet.Services.AzureSearch.SearchService
     ""ShowDebug"": true
   },
   ""IndexName"": ""search-index"",
-  ""ApiType"": ""Search"",
+  ""IndexOperationType"": ""Search"",
   ""SearchParameters"": {
     ""IncludeTotalResultCount"": false,
     ""QueryType"": ""simple"",
@@ -806,8 +806,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var response = _target.AutocompleteFromSearch(
                     _autocompleteRequest,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _searchResult,
                     _duration);
 
@@ -823,8 +823,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var response = _target.AutocompleteFromSearch(
                     _autocompleteRequest,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _emptySearchResult,
                     _duration);
 
@@ -839,8 +839,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var response = _target.AutocompleteFromSearch(
                     _autocompleteRequest,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _searchResult,
                     _duration);
 
@@ -859,8 +859,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var exception = Assert.Throws<ArgumentException>(() => _target.AutocompleteFromSearch(
                     _autocompleteRequest,
-                    _searchParameters,
                     _text,
+                    _searchParameters,
                     _manySearchResults,
                     _duration));
 


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/6466.

There is some low hanging fruit for optimizing the most common Azure Search queries:

1. `packageid:` + `ignoreFilter=false` should use document lookup against search index (https://github.com/NuGet/NuGet.Services.Metadata/pull/602)
   - Many non-hijack requests use this pattern, presumably to get download count or latest stable version.
1. `packageid:` + `version:` + `ignoreFilter=true` should use document lookup against hijack index
   - This is the `Packages(Id=,Version=)` hijack case.
1. (maybe) `packageid:` + `ignoreFilter=true`
   - This is the `FindPackagesById()` hijack case.

This PR introduces a new class which will encapsulate this sort of logic. It will parse the query, inspect the groupings, and generate the parameters for the appropriate operation. For "lookup document" it will generate the document key and for "search" it will generate the search text and search parameters.

The performance has not regressed from the previous implementation.

Samples | Average | Min | Max | Std. Dev. | Error % | Throughput | Received KB/sec | Sent KB/sec | Avg. Bytes
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
10000 | 62 | 57 | 402 | 10.44 | 0.00% | 158.6345 | 783.91 | 29.95 | 5060.2

