### PR TITLE
Optimize packageid:{id} version:{version} ignoreFilter=true case

### DIFF
--- a/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
@@ -373,5 +373,19 @@ namespace NuGet.Services.AzureSearch
                 Prefix + "V3GetDocumentMs",
                 elapsed.TotalMilliseconds);
         }
+
+        public void TrackV2GetDocumentWithSearchIndex(TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "V2GetDocumentWithSearchIndexMs",
+                elapsed.TotalMilliseconds);
+        }
+
+        public void TrackV2GetDocumentWithHijackIndex(TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "V2GetDocumentWithHijackIndexMs",
+                elapsed.TotalMilliseconds);
+        }
     }
 }

--- a/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
@@ -49,5 +49,7 @@ namespace NuGet.Services.AzureSearch
         void TrackAuxiliary2AzureSearchCompleted(JobOutcome outcome, TimeSpan elapsed);
         IDisposable TrackUploadDownloadsSnapshot(int packageIdCount);
         void TrackV3GetDocument(TimeSpan elapsed);
+        void TrackV2GetDocumentWithSearchIndex(TimeSpan elapsed);
+        void TrackV2GetDocumentWithHijackIndex(TimeSpan elapsed);
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/ISearchResponseBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/ISearchResponseBuilder.cs
@@ -20,11 +20,21 @@ namespace NuGet.Services.AzureSearch.SearchService
             SearchParameters parameters,
             DocumentSearchResult<SearchDocument.Full> result,
             TimeSpan duration);
+        V2SearchResponse V2FromHijackDocument(
+            V2SearchRequest request,
+            string documentKey,
+            HijackDocument.Full document,
+            TimeSpan duration);
         V3SearchResponse V3FromSearch(
             V3SearchRequest request,
             string text,
             SearchParameters parameters,
             DocumentSearchResult<SearchDocument.Full> result,
+            TimeSpan duration);
+        V2SearchResponse V2FromSearchDocument(
+            V2SearchRequest request,
+            string documentKey,
+            SearchDocument.Full document,
             TimeSpan duration);
         V3SearchResponse V3FromSearchDocument(
             V3SearchRequest request,

--- a/tests/BasicSearchTests.FunctionalTests.Core/Constants.cs
+++ b/tests/BasicSearchTests.FunctionalTests.Core/Constants.cs
@@ -7,8 +7,13 @@ namespace BasicSearchTests.FunctionalTests.Core
     {
         // Predefined Texts
         public const string TestPackageId = "BaseTestPackage";
-        public const string TestPackageIdSemVer2 = "BaseTestPackage.SemVer2";
+        public const string TestPackageId_SearchFilters = "BaseTestPackage.SearchFilters";
+        public const string TestPackageId_SemVer2 = "BaseTestPackage.SemVer2";
         public const string TestPackageVersion = "1.0.0";
+        public const string TestPackageVersion_SearchFilters_Default = "1.1.0";
+        public const string TestPackageVersion_SearchFilters_Prerel = "1.2.0-beta";
+        public const string TestPackageVersion_SearchFilters_SemVer2 = "1.3.0+metadata";
+        public const string TestPackageVersion_SearchFilters_PrerelSemVer2 = "1.4.0-delta.4";
         public const string TestPackageTitle = "BaseTestPackage";
         public const string TestPackageDescription = "Package description";
         public const string TestPackageSummary = "";

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
@@ -11,11 +11,6 @@ namespace NuGet.Services.AzureSearch.SearchService
     {
         public class V2Search : FactsBase
         {
-            /// <summary>
-            /// 100 characters is the maximum length for package IDs.
-            /// </summary>
-            private const string MaxId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-
             [Theory]
             [MemberData(nameof(CommonAzureSearchQueryData))]
             public void GeneratesAzureSearchQuery(string input, string expected)


### PR DESCRIPTION
This is the gallery hijack for OData `Packages(Id=,Version=)`. This accounts for 22.47% of all requests in the past 90 days. As with the previous optimization PR (https://github.com/NuGet/NuGet.Services.Metadata/pull/602) switching from a search to a document lookup cut the query time in roughly a half.

A hijack URL looks something like this:
```
/search/query?q=id:"Colorspace" AND version:"1.0.2"&skip=0&take=20&sortBy=relevance&semVerLevel=2.0.0&prerelease=true&ignoreFilter=true
```

(note that V2 queries have a leading `id:` turned to `packageid:` so this case gets the optimization)

https://github.com/NuGet/NuGet.Services.Metadata/blob/1820cabb8ac3ee948b58c952875559aae231e492/src/NuGet.Services.AzureSearch/SearchService/SearchTextBuilder.cs#L41-L46

## Baseline

Samples | Average | Min | Max | Std. Dev. | Error % | Throughput | Received KB/sec | Sent KB/sec | Avg. Bytes
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
10000 | 133 | 109 | 564 | 21.81 | 0.00% | 67.1204 | 863.26 | 18.15 | 13170

## With optimization

Samples | Average | Min | Max | Std. Dev. | Error % | Throughput | Received KB/sec | Sent KB/sec | Avg. Bytes
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
10000 | 61 | 55 | 252 | 8.36 | 0.00% | 156.4627 | 327 | 42.31 | 2140.1


