### PR TITLE
[Azure Search] Boost results that match all queried terms

### DIFF
--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -74,7 +74,7 @@
     <Compile Include="AuxiliaryFiles\OwnerDataClient.cs" />
     <Compile Include="ScoringProfiles\DefaultScoringProfile.cs" />
     <Compile Include="Owners2AzureSearch\Owners2AzureSearchCommand.cs" />
-    <Compile Include="SearchService\AzureSearchQueryBuilder.cs" />
+    <Compile Include="SearchService\AzureSearchTextBuilder.cs" />
     <Compile Include="BlobContainerBuilder.cs" />
     <Compile Include="IBlobContainerBuilder.cs" />
     <Compile Include="Measure.cs" />

--- a/src/NuGet.Services.AzureSearch/SearchService/AzureSearchTextBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AzureSearchTextBuilder.cs
@@ -55,7 +55,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             /// <summary>
-            /// Append search terms to the query that may match any field.
+            /// Append search terms to the query. These terms may match any field.
             /// </summary>
             /// <param name="terms">The terms to append to the search query.</param>
             public void AppendTerms(IReadOnlyList<string> terms)

--- a/src/NuGet.Services.AzureSearch/SearchService/AzureSearchTextBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AzureSearchTextBuilder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -21,7 +22,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         ///   * "value1" is a field-scoped term
         ///   * "value2" is an unscoped term
         /// </remarks>
-        private class AzureSearchQueryBuilder
+        private class AzureSearchTextBuilder
         {
             /// <summary>
             /// Azure Search Queries must have less than 1024 clauses.
@@ -47,26 +48,26 @@ namespace NuGet.Services.AzureSearch.SearchService
             private readonly StringBuilder _result;
             private int _clauses;
 
-            public AzureSearchQueryBuilder()
+            public AzureSearchTextBuilder()
             {
                 _result = new StringBuilder();
                 _clauses = 0;
             }
 
             /// <summary>
-            /// Append unscoped search terms to the query. This can be called many times.
+            /// Append search terms to the query that may match any field.
             /// </summary>
-            /// <param name="terms">
-            /// The terms to append to the search query. Each term will be escaped and will be wrapped
-            /// with quotes if it contains whitespaces.
-            /// </param>
+            /// <param name="terms">The terms to append to the search query.</param>
             public void AppendTerms(IReadOnlyList<string> terms)
             {
-                ValidateOrThrow(terms, additionalClauses: terms.Count);
+                ValidateAdditionalClausesOrThrow(terms.Count);
+                ValidateTermsOrThrow(terms);
+
+                AppendSpaceIfNotEmpty();
 
                 for (var i = 0; i < terms.Count; i++)
                 {
-                    if (_result.Length > 0)
+                    if (i > 0)
                     {
                         _result.Append(' ');
                     }
@@ -76,32 +77,53 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             /// <summary>
-            /// Append search terms to the query. These terms will be scoped to the specified field. This can be called many times.
+            /// Append a clause to boost results that match all terms.
+            /// </summary>
+            /// <param name="terms">All terms that must be matched.</param>
+            /// <param name="boost">The boost for results that match all terms.</param>
+            public void AppendBoostIfMatchAllTerms(IReadOnlyList<string> terms, float boost)
+            {
+                // We will generate a clause for each term and a clause to OR terms together.
+                ValidateAdditionalClausesOrThrow(terms.Count + 1);
+                ValidateTermsOrThrow(terms);
+
+                AppendSpaceIfNotEmpty();
+
+                _result.Append('(');
+
+                for (var i = 0; i < terms.Count; i++)
+                {
+                    if (i > 0)
+                    {
+                        _result.Append(' ');
+                    }
+
+                    _result.Append('+');
+                    AppendEscapedString(terms[i], quoteWhiteSpace: true);
+                }
+
+                _result.Append(")^");
+                _result.Append(boost);
+            }
+
+            /// <summary>
+            /// Append a term to the query that is scoped to a specified field.
             /// </summary>
             /// <param name="fieldName">The field that these terms should be scoped to.</param>
             /// <param name="terms">The terms to search for.</param>
             /// <param name="required">Whether search results MUST match these terms.</param>
             /// <param name="prefixSearch">If true, prefix matches are allowed for the terms.</param>
-            public void AppendScopedTerms(
+            public void AppendScopedTerm(
                 string fieldName,
-                IReadOnlyList<string> terms,
+                string term,
                 bool required = false,
                 bool prefixSearch = false)
             {
-                // We will only generate a single clause if this field-scope has a single term.
-                // Otherwise, we will generate a clause for each term and a clause to OR terms together.
-                var additionalClauses = 1;
-                if (terms.Count > 1)
-                {
-                    additionalClauses += terms.Count;
-                }
+                // We will generate a single clause.
+                ValidateAdditionalClausesOrThrow(1);
+                ValidateTermOrThrow(term);
 
-                ValidateOrThrow(terms, additionalClauses);
-
-                if (_result.Length > 0)
-                {
-                    _result.Append(' ');
-                }
+                AppendSpaceIfNotEmpty();
 
                 if (required)
                 {
@@ -111,26 +133,51 @@ namespace NuGet.Services.AzureSearch.SearchService
                 _result.Append(fieldName);
                 _result.Append(':');
 
-                if (terms.Count == 1)
+                // Don't escape whitespace with quotes if this is prefix matching.
+                AppendEscapedString(term.Trim(), quoteWhiteSpace: !prefixSearch);
+
+                if (prefixSearch)
                 {
-                    AppendScopedTerm(terms[0], prefixSearch);
+                    _result.Append('*');
                 }
-                else
+            }
+
+            /// <summary>
+            /// Append search terms to the query that are scoped to a specified field.
+            /// </summary>
+            /// <param name="fieldName">The field that these terms should be scoped to.</param>
+            /// <param name="terms">The terms to search</param>
+            /// <param name="required">Whether search results MUST match these terms.</param>
+            public void AppendScopedTerms(
+                string fieldName,
+                IReadOnlyList<string> terms,
+                bool required = false)
+            {
+                // We will generate a clause for each term and a clause to OR terms together.
+                ValidateAdditionalClausesOrThrow(terms.Count + 1);
+                ValidateTermsOrThrow(terms);
+
+                AppendSpaceIfNotEmpty();
+
+                if (required)
                 {
-                    _result.Append('(');
+                    _result.Append('+');
+                }
 
-                    for (var i = 0; i < terms.Count; i++)
+                _result.Append(fieldName);
+                _result.Append(":(");
+
+                for (var i = 0; i < terms.Count; i++)
+                {
+                    if (i > 0)
                     {
-                        if (i > 0)
-                        {
-                            _result.Append(' ');
-                        }
-
-                        AppendScopedTerm(terms[i], prefixSearch);
+                        _result.Append(' ');
                     }
 
-                    _result.Append(')');
+                    AppendEscapedString(terms[i].Trim(), quoteWhiteSpace: true);
                 }
+
+                _result.Append(')');
             }
 
             /// <summary>
@@ -142,13 +189,11 @@ namespace NuGet.Services.AzureSearch.SearchService
                 return _result.ToString();
             }
 
-            private void AppendScopedTerm(string term, bool prefixSearch)
+            private void AppendSpaceIfNotEmpty()
             {
-                AppendEscapedString(term.Trim(), quoteWhiteSpace: !prefixSearch);
-
-                if (prefixSearch)
+                if (_result.Length > 0)
                 {
-                    _result.Append('*');
+                    _result.Append(' ');
                 }
             }
 
@@ -204,24 +249,30 @@ namespace NuGet.Services.AzureSearch.SearchService
                 }
             }
 
-            private void ValidateOrThrow(IReadOnlyList<string> terms, int additionalClauses)
+            private void ValidateAdditionalClausesOrThrow(int additionalClauses)
             {
                 if ((_clauses + additionalClauses) > MaxClauses)
                 {
                     throw new InvalidSearchRequestException($"A query can only have up to {MaxClauses} clauses.");
                 }
 
-                if (terms.Any(TermExceedsMaxSize))
-                {
-                    throw new InvalidSearchRequestException($"Query terms cannot exceed {MaxTermSizeBytes} bytes.");
-                }
-
                 _clauses += additionalClauses;
             }
 
-            private static bool TermExceedsMaxSize(string term)
+            private void ValidateTermsOrThrow(IReadOnlyList<string> terms)
             {
-                return Encoding.Unicode.GetByteCount(term) > MaxTermSizeBytes;
+                foreach (var term in terms)
+                {
+                    ValidateTermOrThrow(term);
+                }
+            }
+
+            private void ValidateTermOrThrow(string term)
+            {
+                if (Encoding.Unicode.GetByteCount(term) > MaxTermSizeBytes)
+                {
+                    throw new InvalidSearchRequestException($"Query terms cannot exceed {MaxTermSizeBytes} bytes.");
+                }
             }
         }
     }

--- a/src/NuGet.Services.AzureSearch/SearchService/AzureSearchTextBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AzureSearchTextBuilder.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -107,10 +106,12 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             /// <summary>
-            /// Append a term to the query that is scoped to a specified field.
+            /// Append a term to the query that is scoped to a specified field. This generates
+            /// queries like "field:value". Unlike <see cref="AppendScopedTerms"/>, this supports
+            /// prefix matching.
             /// </summary>
             /// <param name="fieldName">The field that these terms should be scoped to.</param>
-            /// <param name="terms">The terms to search for.</param>
+            /// <param name="term">The term to search.</param>
             /// <param name="required">Whether search results MUST match these terms.</param>
             /// <param name="prefixSearch">If true, prefix matches are allowed for the terms.</param>
             public void AppendScopedTerm(
@@ -144,8 +145,10 @@ namespace NuGet.Services.AzureSearch.SearchService
 
             /// <summary>
             /// Append search terms to the query that are scoped to a specified field.
+            /// This generates queries like "field:(value1 value2)". Unlike
+            /// <see cref="AppendScopedTerm"/>, this doesn't support prefix matches.
             /// </summary>
-            /// <param name="fieldName">The field that these terms should be scoped to.</param>
+            /// <param name="fieldName">The field that should match the terms.</param>
             /// <param name="terms">The terms to search</param>
             /// <param name="required">Whether search results MUST match these terms.</param>
             public void AppendScopedTerms(

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
@@ -8,6 +8,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 {
     public class SearchServiceConfiguration : AzureSearchConfiguration, IAuxiliaryDataStorageConfiguration
     {
+        public float MatchAllTermsBoost { get; set; } = 2;
         public string SemVer1RegistrationsBaseUrl { get; set; }
         public string SemVer2RegistrationsBaseUrl { get; set; }
         public string AuxiliaryDataStorageConnectionString { get; set; }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
@@ -8,7 +8,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 {
     public class SearchServiceConfiguration : AzureSearchConfiguration, IAuxiliaryDataStorageConfiguration
     {
-        public float MatchAllTermsBoost { get; set; } = 2;
+        public float MatchAllTermsBoost { get; set; } = 3;
         public string SemVer1RegistrationsBaseUrl { get; set; }
         public string SemVer2RegistrationsBaseUrl { get; set; }
         public string AuxiliaryDataStorageConnectionString { get; set; }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchTextBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchTextBuilder.cs
@@ -121,7 +121,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                     // This happens if tags have only delimiters.
                     continue;
                 }
-                if (values.Count > 1)
+                else if (values.Count > 1)
                 {
                     builder.AppendScopedTerms(fieldName, values, required: requireScopedTerms);
                 }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchTextBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchTextBuilder.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Lucene.Net.Search;
+using Microsoft.Extensions.Options;
 using NuGet.Indexing;
 using NuGet.Services.Metadata.Catalog;
 using NuGet.Versioning;
@@ -28,10 +29,12 @@ namespace NuGet.Services.AzureSearch.SearchService
             { QueryField.Version, IndexFields.NormalizedVersion },
         };
 
+        private readonly IOptionsSnapshot<SearchServiceConfiguration> _options;
         private readonly NuGetQueryParser _parser;
 
-        public SearchTextBuilder()
+        public SearchTextBuilder(IOptionsSnapshot<SearchServiceConfiguration> options)
         {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
             _parser = new NuGetQueryParser();
         }
 
@@ -129,7 +132,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 if (unscopedTerms.Count > 1)
                 {
-                    builder.AppendBoostIfMatchAllTerms(unscopedTerms, boost: 2.0f);
+                    builder.AppendBoostIfMatchAllTerms(unscopedTerms, _options.Value.MatchAllTermsBoost);
                 }
             }
 

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchTextBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchTextBuilder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Lucene.Net.Search;
 using NuGet.Indexing;
 using NuGet.Services.Metadata.Catalog;
 using NuGet.Versioning;
@@ -60,22 +61,15 @@ namespace NuGet.Services.AzureSearch.SearchService
                 return MatchAllDocumentsQuery;
             }
 
-            // Generate a query on package ids. This will be a prefix search
-            // if we are autocompleting package ids.
-            var builder = new AzureSearchQueryBuilder();
+            // Query package ids. If autocompleting package ids, allow prefix matches.
+            var builder = new AzureSearchTextBuilder();
 
-            builder.AppendScopedTerms(
-                IndexFields.PackageId,
-                new[] { request.Query },
+            builder.AppendScopedTerm(
+                fieldName: IndexFields.PackageId,
+                term: request.Query,
                 prefixSearch: request.Type == AutocompleteRequestType.PackageIds);
 
-            var result = builder.ToString();
-            if (string.IsNullOrWhiteSpace(result))
-            {
-                return MatchAllDocumentsQuery;
-            }
-
-            return result;
+            return builder.ToString();
         }
 
         private ParsedQuery GetParsedQuery(string query)
@@ -97,36 +91,49 @@ namespace NuGet.Services.AzureSearch.SearchService
                 return MatchAllDocumentsQuery;
             }
 
-            // Generate a Lucene query for Azure Search.
-            var builder = new AzureSearchQueryBuilder();
             var scopedTerms = parsed.Grouping.Where(g => g.Key != QueryField.Any && g.Key != QueryField.Invalid).ToList();
             var unscopedTerms = parsed.Grouping.Where(g => g.Key == QueryField.Any)
                 .Select(g => g.Value)
-                .SingleOrDefault();
+                .SingleOrDefault()?
+                .ToList();
 
-            var requireScopedTerms = unscopedTerms != null
-                || scopedTerms.Select(t => t.Key).Distinct().Count() > 1;
+            // Don't bother generating Azure Search text if all terms are scoped to invalid fields.
+            if (scopedTerms.Count == 0 && (unscopedTerms == null || unscopedTerms.Count == 0))
+            {
+                return MatchAllDocumentsQuery;
+            }
+
+            // Add the terms that are scoped to specific fields.
+            var builder = new AzureSearchTextBuilder();
+            var requireScopedTerms = unscopedTerms != null || scopedTerms.Count > 1;
 
             foreach (var scopedTerm in scopedTerms)
             {
                 var fieldName = FieldNames[scopedTerm.Key];
                 var values = ProcessFieldValues(scopedTerm.Key, scopedTerm.Value).ToList();
 
-                builder.AppendScopedTerms(fieldName, values, required: requireScopedTerms);
+                if (values.Count > 1)
+                {
+                    builder.AppendScopedTerms(fieldName, values, required: requireScopedTerms);
+                }
+                else
+                {
+                    builder.AppendScopedTerm(fieldName, values.First(), required: requireScopedTerms);
+                }
             }
 
+            // Add the terms that can match any fields.
             if (unscopedTerms != null)
             {
-                builder.AppendTerms(unscopedTerms.ToList());
+                builder.AppendTerms(unscopedTerms);
+
+                if (unscopedTerms.Count > 1)
+                {
+                    builder.AppendBoostIfMatchAllTerms(unscopedTerms, boost: 2.0f);
+                }
             }
 
-            var result = builder.ToString();
-            if (string.IsNullOrWhiteSpace(result))
-            {
-                return MatchAllDocumentsQuery;
-            }
-
-            return result;
+            return builder.ToString();
         }
 
         private static IEnumerable<string> ProcessFieldValues(QueryField field, IEnumerable<string> values)

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchTextBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchTextBuilder.cs
@@ -109,7 +109,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 
             // Add the terms that are scoped to specific fields.
             var builder = new AzureSearchTextBuilder();
-            var requireScopedTerms = hasUnscopedTerms|| scopedTerms.Count > 1;
+            var requireScopedTerms = hasUnscopedTerms || scopedTerms.Count > 1;
 
             foreach (var scopedTerm in scopedTerms)
             {

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchTextBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchTextBuilder.cs
@@ -101,14 +101,15 @@ namespace NuGet.Services.AzureSearch.SearchService
                 .ToList();
 
             // Don't bother generating Azure Search text if all terms are scoped to invalid fields.
-            if (scopedTerms.Count == 0 && (unscopedTerms == null || unscopedTerms.Count == 0))
+            var hasUnscopedTerms = unscopedTerms != null && unscopedTerms.Count > 0;
+            if (scopedTerms.Count == 0 && !hasUnscopedTerms)
             {
                 return MatchAllDocumentsQuery;
             }
 
             // Add the terms that are scoped to specific fields.
             var builder = new AzureSearchTextBuilder();
-            var requireScopedTerms = unscopedTerms != null || scopedTerms.Count > 1;
+            var requireScopedTerms = hasUnscopedTerms|| scopedTerms.Count > 1;
 
             foreach (var scopedTerm in scopedTerms)
             {
@@ -126,7 +127,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             // Add the terms that can match any fields.
-            if (unscopedTerms != null)
+            if (hasUnscopedTerms)
             {
                 builder.AppendTerms(unscopedTerms);
 

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/Relevancy/V3RelevancyFunctionalTests.cs
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/Relevancy/V3RelevancyFunctionalTests.cs
@@ -35,7 +35,7 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
             // Test that common queries have the most frequently selected results at the top.
             // These results were determined using the "BrowserSearchPage" and "BrowserSearchSelection" metrics
             // on the Gallery's Application Insights telemetry.
-            // TODO: Reduce exact match boost and update "json.net", "entity framework", "redis", and "csv" tests.
+            // TODO: Reduce exact match boost and update "json.net", "redis", and "csv" tests.
             // See: https://github.com/NuGet/NuGetGallery/issues/7330
             yield return new object[] { "newtonsoft.json", new[] { "newtonsoft.json" } };
             yield return new object[] { "newtonsoft", new[] { "newtonsoft.json" } };

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/Relevancy/V3RelevancyFunctionalTests.cs
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/Relevancy/V3RelevancyFunctionalTests.cs
@@ -45,7 +45,7 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
             yield return new object[] { "tags:\"aws-sdk-v3\"", new[] { "awssdk.core", "awssdk.s3" } };
 
             yield return new object[] { "entityframework", new[] { "entityframework" } };
-            yield return new object[] { "entity framework", new[] { "entity", "entityframework" } };
+            yield return new object[] { "entity framework", new[] { "entityframework" } };
             yield return new object[] { "EntityFrameworkCore", new[] { "microsoft.entityframeworkcore" } };
             yield return new object[] { "microsoft.entityframeworkcore", new[] { "microsoft.entityframeworkcore" } };
             yield return new object[] { "mysql", new[] { "mysql.data" } };

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
@@ -204,6 +204,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                     
                     // Unknown fields are ignored
                     { "fake:test", "*" },
+                    { "foo:a bar:b", "*" },
 
                     // The version field is normalized, if possible
                     { "version:1.0.0.0", "normalizedVersion:1.0.0" },
@@ -230,21 +231,24 @@ namespace NuGet.Services.AzureSearch.SearchService
                     { "title:foo unknown:bar", "title:foo" },
 
                     // If there are non-field-scoped terms and no field-scoped terms, at least of one the non-field-scoped terms is required.
-                    { "foo bar", "foo bar" },
-                    { "id packageId version title description tag author summary owner owners", "id packageId version title description tag author summary owner owners" },
-                    { "ID PACKAGEID VERSION TITLE DESCRIPTION TAG AUTHOR SUMMARY OWNER OWNERS", "ID PACKAGEID VERSION TITLE DESCRIPTION TAG AUTHOR SUMMARY OWNER OWNERS" },
+                    // Results that match all terms are boosted.
+                    { "foo", "foo" },
+                    { "foo bar", "foo bar (+foo +bar)^2" },
+                    { "id packageId VERSION Title description tag author summary owner owners",
+                        "id packageId VERSION Title description tag author summary owner owners " +
+                        "(+id +packageId +VERSION +Title +description +tag +author +summary +owner +owners)^2" },
                     
-                    // Quotes allow adjacent terms to be searched
+                    // Phrases are supported in queries
                     { @"""foo bar""", @"""foo bar""" },
-                    { @"""foo bar"" baz", @"""foo bar"" baz" },
+                    { @"""foo bar"" baz", @"""foo bar"" baz (+""foo bar"" +baz)^2" },
                     { @"title:""foo bar""", @"title:""foo bar""" },
-                    { @"title:""a b"" c title:d f", @"+title:(""a b"" d) c f" },
+                    { @"title:""a b"" c title:d f", @"+title:(""a b"" d) c f (+c +f)^2" },
                     { @"title:"" a b    c   """, @"title:""a b    c""" },
 
                     // Dangling quotes are handled with best effort
                     { @"Tags:""windows", "tags:windows" },
                     { @"json Tags:""net"" Tags:""windows sdk", @"+tags:(net windows sdk) json" },
-                    { @"json Tags:""net Tags:""windows sdk""", @"+tags:(net Tags\:) json windows sdk" },
+                    { @"json Tags:""net Tags:""windows sdk""", @"+tags:(net Tags\:) json windows sdk (+json +windows +sdk)^2" },
                     { @"sdk Tags:""windows", "+tags:windows sdk" },
                     { @"Tags:""windows sdk", "tags:(windows sdk)" },
                     { @"Tags:""""windows""", "windows" },
@@ -270,8 +274,8 @@ namespace NuGet.Services.AzureSearch.SearchService
                     { @"AND OR", @"*" },
                     { @"""AND"" ""OR""", @"*" },
                     { @"""AND OR""", @"""AND OR""" },
-                    { @"hello AND world", @"hello world" },
-                    { @"hello OR world", @"hello world" },
+                    { @"hello AND world", @"hello world (+hello +world)^2" },
+                    { @"hello OR world", @"hello world (+hello +world)^2" },
                     { @"title:""hello AND world""", @"title:""hello AND world""" },
                     { @"title:""hello OR world""", @"title:""hello OR world""" },
 
@@ -294,14 +298,17 @@ namespace NuGet.Services.AzureSearch.SearchService
                     { @"title:/ description:""/""", @"+title:\/ +description:\/" },
                     { @"title:"":""", @"title:\:" },
 
-                    { @"+ - & | ! ( ) { } [ ] ~ * ? \ / "":""", @"\+ \- \& \| \! \( \) \{ \} \[ \] \~ \* \? \\ \/ \:" },
+                    { @"+ - & | ! ( ) { } [ ] ~ * ? \ / "":""",
+                        @"\+ \- \& \| \! \( \) \{ \} \[ \] \~ \* \? \\ \/ \: " +
+                        @"(+\+ +\- +\& +\| +\! +\( +\) +\{ +\} +\[ +\] +\~ +\* +\? +\\ +\/ +\:)^2"},
 
                     // Unicode surrogate pairs
                     { "A𠈓C", "A𠈓C" },
                     { "packageId:A𠈓C", "packageId:A𠈓C" },
-                    { "A𠈓C packageId:A𠈓C A𠈓C packageId:A𠈓C hello packageId:hello", "+packageId:(A𠈓C hello) A𠈓C hello" },
                     { @"""A𠈓C"" packageId:""A𠈓C""", "+packageId:A𠈓C A𠈓C" },
                     { @"(𠈓) packageId:(𠈓)", @"+packageId:\(𠈓\) \(𠈓\)" },
+                    { "A𠈓C packageId:A𠈓C A𠈓C packageId:A𠈓C hello packageId:hello",
+                        "+packageId:(A𠈓C hello) A𠈓C hello (+A𠈓C +hello)^2" },
                 };
 
                 foreach (var datum in data)

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
@@ -220,6 +220,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                     // The tags field is split by delimiters
                     { "tag:a,b;c|d", "tags:(a b c d)" },
                     { "tags:a,b;c|d", "tags:(a b c d)" },
+                    { "tags:,;|", "*" },
 
                     { "id:foo id:bar", "tokenizedPackageId:(foo bar)" },
                     { "packageId:foo packageId:bar", "packageId:(foo bar)" },

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Options;
+using Moq;
 using Xunit;
 
 namespace NuGet.Services.AzureSearch.SearchService
@@ -164,7 +166,11 @@ namespace NuGet.Services.AzureSearch.SearchService
 
             public FactsBase()
             {
-                _target = new SearchTextBuilder();
+                var config = new SearchServiceConfiguration { MatchAllTermsBoost = 2.0f };
+                var options = new Mock<IOptionsSnapshot<SearchServiceConfiguration>>();
+                options.Setup(o => o.Value).Returns(config);
+
+                _target = new SearchTextBuilder(options.Object);
             }
 
             public static IEnumerable<object[]> CommonAzureSearchQueryData()


### PR DESCRIPTION
From my manual testing, queries with multiple terms have significantly better results.

Queries that improved:
* "entity framework" ("EntityFramework", "Microsoft.EntityFrameworkCore" are the first results, "entity" is now the 18th result)
* "asp.net core initialization" ("AspNetCore.AsyncInitialization" is now the first result)
* "azure typeprovider" ("FSharp.Azure.DocumentDbTypeProvider" is now the first result)
* "fxcop analyzers" ("Microsoft.CodeAnalysis.FxCopAnalyzers" is now the first result)
* "wilderness labs" ("Netduino.Foundation" is now the first result)
* "mysql data entity" ("Mysql.Data.Entity" is now 1st, up from 10th)
* "aspnetcore app" ("Microsoft.AspNetCore.App" is now 1st, up from 2nd. Other results seem more relevant)
* "micro orm" ("Dapper" is now 1st, up from 2nd)
* "sqlserver types" ("Microsoft.SqlServer.Types" is now 1st, up from 2nd)
* "toast notifications" ("ToastNotifications" is now 1st, up from 2nd)
* "oragon spring" ("Oragon.Spring.*" results are now 1st, 2nd, and 3rd)
* "newtonsoft wamp" ("WampSharp.NewtonsoftMsgpack" is now 1st, up from 2nd)
* "multi line" ("MultiLineStringAnalyzer" is now 3rd, up from 7th. Other results seem more relevant)
* "microsoft advertising" (1st result unchanged, other results seem more relevant)
* "microsoft graph" (1st result unchanged, 3rd and 4th result are more relevant now "Microsoft.IdentityModel.Clients.ActiveDirectory", "Microsoft.Azure.ActiveDirectory.GraphClient")

Queries that are better but still need work:
* "unit test" ("xunit" is now 1st, up from 3rd. "nunit" is now 6th, up from 15th)
* "azure f#" ("FSharp.Azure.*" packages are 4th and 5th now)

Queries that regressed:
* "common helpers" ("CommonHelpers" is now 8th, down from 7th. This package has low download count though)

Addresses https://github.com/nuget/nugetgallery/issues/7333