### PR TITLE
Refresh secrets in a background thread in Azure Search Service

### DIFF
--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -89,6 +89,7 @@ namespace NuGet.Services.AzureSearch
                     c.ResolveKeyed<ISearchIndexClientWrapper>(hijackIndexKey),
                     c.Resolve<ISearchParametersBuilder>(),
                     c.Resolve<IAuxiliaryDataCache>(),
+                    c.Resolve<ISecretRefresher>(),
                     c.Resolve<IOptionsSnapshot<SearchServiceConfiguration>>(),
                     c.Resolve<IAzureSearchTelemetryService>(),
                     c.Resolve<ILogger<SearchStatusService>>()));
@@ -236,6 +237,8 @@ namespace NuGet.Services.AzureSearch
             services.AddSingleton<IAuxiliaryDataCache, AuxiliaryDataCache>();
             services.AddScoped(p => p.GetRequiredService<IAuxiliaryDataCache>().Get());
             services.AddSingleton<IAuxiliaryFileReloader, AuxiliaryFileReloader>();
+
+            services.AddSingleton<ISecretRefresher, SecretRefresher>();
 
             services.AddTransient<Auxiliary2AzureSearchCommand>();
             services.AddTransient<Owners2AzureSearchCommand>();

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -144,6 +144,7 @@
     <Compile Include="SearchService\IndexOperation.cs" />
     <Compile Include="SearchService\IndexOperationBuilder.cs" />
     <Compile Include="SearchService\IndexOperationType.cs" />
+    <Compile Include="SearchService\ISecretRefresher.cs" />
     <Compile Include="SearchService\Models\DebugDocumentResult.cs" />
     <Compile Include="SearchService\IAuxiliaryDataCache.cs" />
     <Compile Include="AuxiliaryFiles\IAuxiliaryFileClient.cs" />
@@ -186,6 +187,7 @@
     <Compile Include="SearchService\ParsedQuery.cs" />
     <Compile Include="SearchService\SearchTextBuilder.cs" />
     <Compile Include="AzureSearchTelemetryService.cs" />
+    <Compile Include="SearchService\SecretRefresher.cs" />
     <Compile Include="VersionList\Guard.cs" />
     <Compile Include="VersionList\HijackIndexChange.cs" />
     <Compile Include="VersionList\HijackIndexChangeType.cs" />
@@ -234,15 +236,12 @@
       <Version>5.0.3</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Common.Job">
-      <Version>4.1.0-dev-2701693</Version>
+      <Version>4.1.0-dev-2884457</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Build.Tasks.Pack">
       <Version>4.8.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-master-2699519</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.AzureSearch/SearchService/ISecretRefresher.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/ISecretRefresher.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    /// <summary>
+    /// Used to update the secrets in the background periodically.
+    /// </summary>
+    public interface ISecretRefresher
+    {
+        DateTimeOffset LastRefresh { get; }
+        Task RefreshContinuouslyAsync(CancellationToken token);
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/ServerInformation.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/ServerInformation.cs
@@ -16,5 +16,6 @@ namespace NuGet.Services.AzureSearch.SearchService
         public string AssemblyInformationalVersion { get; set; }
         public string AssemblyBuildDateUtc { get; set; }
         public string InstanceId { get; set; }
+        public DateTimeOffset? LastServiceRefreshTime { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
@@ -18,6 +18,8 @@ namespace NuGet.Services.AzureSearch.SearchService
         public string AuxiliaryDataStorageExcludedPackagesPath { get; set; }
         public TimeSpan AuxiliaryDataReloadFrequency { get; set; } = TimeSpan.FromHours(1);
         public TimeSpan AuxiliaryDataReloadFailureRetryFrequency { get; set; } = TimeSpan.FromSeconds(30);
+        public TimeSpan SecretRefreshFrequency { get; set; } = TimeSpan.FromHours(12);
+        public TimeSpan SecretRefreshFailureRetryFrequency { get; set; } = TimeSpan.FromMinutes(5);
         public string DeploymentLabel { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchStatusService.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchStatusService.cs
@@ -19,6 +19,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         private readonly ISearchIndexClientWrapper _hijackIndex;
         private readonly ISearchParametersBuilder _parametersBuilder;
         private readonly IAuxiliaryDataCache _auxiliaryDataCache;
+        private readonly ISecretRefresher _secretRefresher;
         private readonly IOptionsSnapshot<SearchServiceConfiguration> _options;
         private readonly IAzureSearchTelemetryService _telemetryService;
         private readonly ILogger<SearchStatusService> _logger;
@@ -28,6 +29,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             ISearchIndexClientWrapper hijackIndex,
             ISearchParametersBuilder parametersBuilder,
             IAuxiliaryDataCache auxiliaryDataCache,
+            ISecretRefresher secretRefresher,
             IOptionsSnapshot<SearchServiceConfiguration> options,
             IAzureSearchTelemetryService telemetryService,
             ILogger<SearchStatusService> logger)
@@ -36,6 +38,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             _hijackIndex = hijackIndex ?? throw new ArgumentNullException(nameof(hijackIndex));
             _parametersBuilder = parametersBuilder ?? throw new ArgumentNullException(nameof(parametersBuilder));
             _auxiliaryDataCache = auxiliaryDataCache ?? throw new ArgumentNullException(nameof(auxiliaryDataCache));
+            _secretRefresher = secretRefresher ?? throw new ArgumentNullException(nameof(secretRefresher));
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -127,6 +130,8 @@ namespace NuGet.Services.AzureSearch.SearchService
                 processId = process.Id;
             }
 
+            var lastSecretRefresh = _secretRefresher.LastRefresh;
+
             var serverStatus = new ServerStatus
             {
                 AssemblyBuildDateUtc = GetAssemblyMetadataOrNull(assembly, "BuildDateUtc"),
@@ -138,6 +143,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 ProcessDuration = DateTimeOffset.UtcNow - processStartTime,
                 ProcessId = processId,
                 ProcessStartTime = processStartTime,
+                LastServiceRefreshTime = lastSecretRefresh,
             };
 
             return Task.FromResult(serverStatus);

--- a/src/NuGet.Services.AzureSearch/SearchService/SecretRefresher.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SecretRefresher.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NuGet.Services.AzureSearch.Wrappers;
+using NuGet.Services.KeyVault;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class SecretRefresher : ISecretRefresher
+    {
+        private readonly IRefreshableSecretReaderFactory _factory;
+        private readonly ISystemTime _systemTime;
+        private readonly IOptionsSnapshot<SearchServiceConfiguration> _options;
+        private readonly ILogger<SecretRefresher> _logger;
+
+        public SecretRefresher(
+            IRefreshableSecretReaderFactory factory,
+            ISystemTime systemTime,
+            IOptionsSnapshot<SearchServiceConfiguration> options,
+            ILogger<SecretRefresher> logger)
+        {
+            _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+            _systemTime = systemTime ?? throw new ArgumentNullException(nameof(systemTime));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// We can initialize the "last refresh" time to the current time since secrets are loaded as the app is
+        /// starting.
+        /// </summary>
+        public DateTimeOffset LastRefresh { get; private set; } = DateTimeOffset.UtcNow;
+
+        public async Task RefreshContinuouslyAsync(CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                _logger.LogInformation("Trying to refresh the secrets.");
+
+                TimeSpan delay;
+                try
+                {
+                    await _factory.RefreshAsync(token);
+                    delay = _options.Value.SecretRefreshFrequency;
+                    LastRefresh = DateTimeOffset.UtcNow;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(0, ex, "An exception was thrown while refreshing the secrets.");
+
+                    delay = _options.Value.SecretRefreshFailureRetryFrequency;
+                }
+
+                if (token.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                _logger.LogInformation(
+                    "Waiting {Duration} before attempting to refresh the secrets again.",
+                    delay);
+                await _systemTime.Delay(delay, token);
+            }
+        }
+    }
+}

--- a/src/NuGet.Services.SearchService/Web.config
+++ b/src/NuGet.Services.SearchService/Web.config
@@ -20,156 +20,168 @@
       <add initializationPage="/"/>
     </applicationInitialization>
   </system.webServer>
-	<runtime>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.2.1.0" newVersion="8.2.1.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Xml.ReaderWriter" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Spatial" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Security.Cryptography.X509Certificates" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Runtime" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Reflection" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Net.Http" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.1.2" newVersion="4.1.1.2"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Compression" publicKeyToken="B77A5C561934E089" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.ComponentModel.TypeConverter" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="NuGet.Versioning" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="NuGet.Services.Logging" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-2.46.0.0" newVersion="2.46.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-2.46.0.0" newVersion="2.46.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="NuGet.Services.Contracts" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-2.46.0.0" newVersion="2.46.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="NuGet.Services.Configuration" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-2.46.0.0" newVersion="2.46.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="NuGet.Protocol" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="NuGet.Packaging.Core" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.FileProviders.Physical" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.FileProviders.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Configuration.FileExtensions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Web.Http" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-2.8.1.0" newVersion="2.8.1.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Autofac" publicKeyToken="17863AF14B0044DA" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0"/>
-			</dependentAssembly>
-		</assemblyBinding>
-	</runtime>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-9.3.2.0" newVersion="9.3.2.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Xml.ReaderWriter" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Spatial" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.X509Certificates" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.3" newVersion="4.1.1.3"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="B77A5C561934E089" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ComponentModel.TypeConverter" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.Validation.Issues" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.53.0.0" newVersion="2.53.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.Validation" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.53.0.0" newVersion="2.53.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.Sql" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.53.0.0" newVersion="2.53.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.Logging" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.53.0.0" newVersion="2.53.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.53.0.0" newVersion="2.53.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.Contracts" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.53.0.0" newVersion="2.53.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.Configuration" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.53.0.0" newVersion="2.53.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Protocol" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Packaging.Core" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Physical" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.FileExtensions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.8.1.0" newVersion="2.8.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Autofac" publicKeyToken="17863AF14B0044DA" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/tests/NuGet.Services.AzureSearch.Tests/DatabaseOwnerFetcherFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/DatabaseOwnerFetcherFacts.cs
@@ -127,6 +127,7 @@ namespace NuGet.Services.AzureSearch
             public DbSet<UserCertificate> UserCertificates { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
             public DbSet<SymbolPackage> SymbolPackages { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
             public DbSet<Package> Packages { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public DbSet<PackageDeprecation> Deprecations { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
             public bool Disposed { get; private set; }
 

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="SearchService\AuxiliaryDataFacts.cs" />
     <Compile Include="AuxiliaryFiles\AuxiliaryFileClientFacts.cs" />
     <Compile Include="SearchService\AuxiliaryFileReloaderFacts.cs" />
+    <Compile Include="SearchService\SecretRefresherFacts.cs" />
     <Compile Include="SearchService\AzureSearchServiceFacts.cs" />
     <Compile Include="SearchService\IndexOperationBuilderFacts.cs" />
     <Compile Include="SearchService\SearchParametersBuilderFacts.cs" />

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SecretRefresherFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SecretRefresherFacts.cs
@@ -1,0 +1,158 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Moq;
+using NuGet.Services.AzureSearch.Support;
+using NuGet.Services.AzureSearch.Wrappers;
+using NuGet.Services.KeyVault;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class SecretRefresherFacts
+    {
+        public class RefreshContinuouslyAsync : Facts
+        {
+            public RefreshContinuouslyAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task CanBeCancelledImmediately()
+            {
+                TokenSource.Cancel();
+
+                await Target.RefreshContinuouslyAsync(TokenSource.Token);
+
+                Factory.Verify(x => x.RefreshAsync(It.IsAny<CancellationToken>()), Times.Never);
+            }
+
+            [Fact]
+            public async Task SetsLastRefreshOnSuccess()
+            {
+                CancelAfter(reloads: 1);
+
+                var before = Target.LastRefresh;
+                await Task.Delay(1);
+                await Target.RefreshContinuouslyAsync(TokenSource.Token);
+                var after = DateTimeOffset.UtcNow;
+
+                Assert.NotEqual(before, Target.LastRefresh);
+                Assert.InRange(Target.LastRefresh, before, after);
+            }
+
+            [Fact]
+            public async Task ReloadsUntilCancelled()
+            {
+                CancelAfter(reloads: 5);
+                Config.SecretRefreshFrequency = TimeSpan.Zero;
+
+                await Target.RefreshContinuouslyAsync(TokenSource.Token);
+
+                Factory.Verify(x => x.RefreshAsync(TokenSource.Token), Times.Exactly(5));
+                Factory.Verify(x => x.RefreshAsync(It.IsAny<CancellationToken>()), Times.Exactly(5));
+            }
+
+            [Fact]
+            public async Task UsesReloadFrequencyOnSuccess()
+            {
+                FailAndCancelAfter(2);
+
+                var before = Target.LastRefresh;
+                await Target.RefreshContinuouslyAsync(TokenSource.Token);
+                var after = Target.LastRefresh;
+
+                Assert.Equal(before, Target.LastRefresh);
+                Assert.Equal(after, Target.LastRefresh);
+            }
+
+            [Fact]
+            public async Task UsesReloadFailureRetryFrequencyOnSuccess()
+            {
+                FailAndCancelAfter(2);
+                Config.SecretRefreshFrequency = TimeSpan.Zero;
+                Config.SecretRefreshFailureRetryFrequency = TimeSpan.FromMilliseconds(100);
+
+                await Target.RefreshContinuouslyAsync(TokenSource.Token);
+
+                Factory.Verify(x => x.RefreshAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+                SystemTime.Verify(x => x.Delay(Config.SecretRefreshFailureRetryFrequency, TokenSource.Token), Times.Once);
+                SystemTime.Verify(x => x.Delay(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()), Times.Once);
+            }
+        }
+
+        public abstract class Facts
+        {
+            public Facts(ITestOutputHelper output)
+            {
+                Factory = new Mock<IRefreshableSecretReaderFactory>();
+                SystemTime = new Mock<ISystemTime>();
+                Config = new SearchServiceConfiguration();
+                Options = new Mock<IOptionsSnapshot<SearchServiceConfiguration>>();
+                Logger = output.GetLogger<SecretRefresher>();
+
+                TokenSource = new CancellationTokenSource();
+
+                // Default test behavior is to cancel after the first invocation otherwise it is very easy to loop
+                // forever, which is annoying for the person writing the tests.
+                CancelAfter(reloads: 1);
+
+                Config.SecretRefreshFrequency = TimeSpan.FromMilliseconds(100);
+                Config.SecretRefreshFailureRetryFrequency = TimeSpan.FromMilliseconds(20);
+                Options.Setup(x => x.Value).Returns(() => Config);
+
+                Target = new SecretRefresher(
+                    Factory.Object,
+                    SystemTime.Object,
+                    Options.Object,
+                    Logger);
+            }
+
+            public Mock<IRefreshableSecretReaderFactory> Factory { get; }
+            public Mock<ISystemTime> SystemTime { get; }
+            public SearchServiceConfiguration Config { get; }
+            public Mock<IOptionsSnapshot<SearchServiceConfiguration>> Options { get; }
+            public RecordingLogger<SecretRefresher> Logger { get; }
+            public CancellationTokenSource TokenSource { get; }
+            public SecretRefresher Target { get; }
+
+            protected void FailAndCancelAfter(int reloads)
+            {
+                int count = 0;
+                Factory
+                    .Setup(x => x.RefreshAsync(It.IsAny<CancellationToken>()))
+                    .Returns(() =>
+                    {
+                        count++;
+                        if (count >= reloads)
+                        {
+                            TokenSource.Cancel();
+                        }
+
+                        throw new InvalidOperationException("Please retry later.");
+                    });
+            }
+
+            protected void CancelAfter(int reloads)
+            {
+                int count = 0;
+                Factory
+                    .Setup(x => x.RefreshAsync(It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask)
+                    .Callback(() =>
+                    {
+                        count++;
+                        if (count >= reloads)
+                        {
+                            TokenSource.Cancel();
+                        }
+                    });
+            }
+        }
+    }
+}


### PR DESCRIPTION
Depends on https://github.com/NuGet/ServerCommon/pull/304.
Address https://github.com/NuGet/NuGetGallery/issues/7337.

This makes Azure Search Service refresh the KeyVault secret cache on a background thread instead of caching them forever. I have seen Azure app server processes live for over 19 days we shouldn't just depend on process restart.