### PR TITLE
Add a server and maximum execution timeout for blob storage calls

### DIFF
--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -236,7 +236,7 @@
       <Version>5.0.3</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Common.Job">
-      <Version>4.1.0-dev-2884457</Version>
+      <Version>4.1.0-dev-2925650</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Build.Tasks.Pack">
       <Version>4.8.0</Version>


### PR DESCRIPTION
Address https://github.com/NuGet/Engineering/issues/2633

The hang on PROD SEA auxiliary file reload is consistent with the hangs seen in V3 pipeline a while back that necessitated a similar change. The symptom was an indefinite hang with no log after it.