### PR TITLE
[Hotfix] Remove invalid package IDs and versions from old data

### DIFF
--- a/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommand.cs
@@ -90,6 +90,9 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
                 _logger.LogInformation("Fetching new download count data from blob storage.");
                 var newData = await _auxiliaryFileClient.LoadDownloadDataAsync();
 
+                _logger.LogInformation("Removing invalid IDs and versions from the old data.");
+                CleanDownloadData(oldResult.Result);
+
                 _logger.LogInformation("Removing invalid IDs and versions from the new data.");
                 CleanDownloadData(newData);
 
@@ -156,6 +159,9 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
                 // make the batch larger than the maximum batch size, push the index actions we have so far.
                 if (GetBatchSize(indexActionsToPush) + MaxDocumentsPerId > _options.Value.AzureSearchBatchSize)
                 {
+                    _logger.LogInformation(
+                        "Starting to push a batch. There are {IdCount} unprocessed IDs left to index and push.",
+                        idBag.Count);
                     await PushIndexActionsAsync(indexActionsToPush, timeSinceLastPush);
                 }
 

--- a/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommandFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommandFacts.cs
@@ -141,20 +141,23 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
                 Assert.Same(expected, actual);
             }
 
-            [Fact]
-            public async Task RejectsInvalidDataAndNormalizesVersions()
+            [Theory]
+            [InlineData(nameof(NewData))]
+            [InlineData(nameof(OldData))]
+            public async Task RejectsInvalidDataAndNormalizesVersions(string propertyName)
             {
-                NewData.SetDownloadCount("ValidId", "1.0.0-ValidVersion", 3);
-                NewData.SetDownloadCount("ValidId", "1.0.0.a-invalidversion", 5);
-                NewData.SetDownloadCount("ValidId", "1.0.0.0-NonNormalized", 7);
-                NewData.SetDownloadCount("Invalid--Id", "1.0.0-validversion", 11);
-                NewData.SetDownloadCount("Invalid--Id", "1.0.0.a-invalidversion", 13);
+                var downloadData = (DownloadData)GetType().GetProperty(propertyName).GetValue(this);
+                downloadData.SetDownloadCount("ValidId", "1.0.0-ValidVersion", 3);
+                downloadData.SetDownloadCount("ValidId", "1.0.0.a-invalidversion", 5);
+                downloadData.SetDownloadCount("ValidId", "1.0.0.0-NonNormalized", 7);
+                downloadData.SetDownloadCount("Invalid--Id", "1.0.0-validversion", 11);
+                downloadData.SetDownloadCount("Invalid--Id", "1.0.0.a-invalidversion", 13);
 
                 await Target.ExecuteAsync();
 
-                Assert.Equal(new[] { "ValidId" }, NewData.Keys.ToArray());
-                Assert.Equal(new[] { "1.0.0-NonNormalized", "1.0.0-ValidVersion" }, NewData["ValidId"].Keys.ToArray());
-                Assert.Equal(10, NewData.GetDownloadCount("ValidId"));
+                Assert.Equal(new[] { "ValidId" }, downloadData.Keys.ToArray());
+                Assert.Equal(new[] { "1.0.0-NonNormalized", "1.0.0-ValidVersion" }, downloadData["ValidId"].Keys.ToArray());
+                Assert.Equal(10, downloadData.GetDownloadCount("ValidId"));
                 Assert.Contains("There were 1 invalid IDs, 2 invalid versions, and 1 non-normalized IDs.", Logger.Messages);
             }
         }


### PR DESCRIPTION
Db2AzureSearch initializes the downloads.v2.json with all of the data found in the downloads.v1.json.

This means that the first time Auxiliary2AzureSearch runs, it can encounter invalid package IDs in the "old" data set. It already filters out package IDs in the new data set. I made it filter it out in the old data set too.

Another fix would have been cleaning the data in Db2AzureSearch but I chose not to do this since it would require re-running Db2AzureSearch (index rebuild process). This is not worth the effort when I can just fix it here. As an added benefit, it means that in the off change that we change our package ID validation rules, the next Auxiliary2AzureSearch run will apply the rules to both download data sets.

Address https://github.com/NuGet/Engineering/issues/2639