### PR TITLE
Do not depend on AzureStorage for timeouts

### DIFF
--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -211,8 +211,8 @@ namespace NuGet.Services.AzureSearch
         {
             return new BlobRequestOptions
             {
-                ServerTimeout = AzureStorage.DefaultServerTimeout,
-                MaximumExecutionTime = AzureStorage.DefaultMaxExecutionTime,
+                ServerTimeout = TimeSpan.FromMinutes(2),
+                MaximumExecutionTime = TimeSpan.FromMinutes(10),
                 LocationMode = LocationMode.PrimaryThenSecondary,
                 RetryPolicy = new ExponentialRetry(),
             };


### PR DESCRIPTION
Use 2 minutes instead of 30 seconds for ServerTimeout.

These timeouts should not be coupled to `AzureStorage` defaults since this code path since the performance concerns are different. In particular, `AzureStorage` is used by... less reliable V3 jobs who may need different timeouts.