### PR TITLE
[Azure Search 2] Copy verified package data file to Azure Search storage account

### DIFF
--- a/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommand.cs
@@ -28,6 +28,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
 
         private readonly IAuxiliaryFileClient _auxiliaryFileClient;
         private readonly IDownloadDataClient _downloadDataClient;
+        private readonly IVerifiedPackagesDataClient _verifiedPackagesDataClient;
         private readonly IDownloadSetComparer _downloadSetComparer;
         private readonly ISearchDocumentBuilder _searchDocumentBuilder;
         private readonly ISearchIndexActionBuilder _indexActionBuilder;
@@ -40,6 +41,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
         public Auxiliary2AzureSearchCommand(
             IAuxiliaryFileClient auxiliaryFileClient,
             IDownloadDataClient downloadDataClient,
+            IVerifiedPackagesDataClient verifiedPackagesDataClient,
             IDownloadSetComparer downloadSetComparer,
             ISearchDocumentBuilder searchDocumentBuilder,
             ISearchIndexActionBuilder indexActionBuilder,
@@ -51,6 +53,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
         {
             _auxiliaryFileClient = auxiliaryFileClient ?? throw new ArgumentNullException(nameof(auxiliaryFileClient));
             _downloadDataClient = downloadDataClient ?? throw new ArgumentNullException(nameof(downloadDataClient));
+            _verifiedPackagesDataClient = verifiedPackagesDataClient ?? throw new ArgumentNullException(nameof(verifiedPackagesDataClient));
             _downloadSetComparer = downloadSetComparer ?? throw new ArgumentNullException(nameof(downloadSetComparer));
             _searchDocumentBuilder = searchDocumentBuilder ?? throw new ArgumentNullException(nameof(searchDocumentBuilder));
             _indexActionBuilder = indexActionBuilder ?? throw new ArgumentNullException(nameof(indexActionBuilder));
@@ -81,46 +84,77 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
             var outcome = JobOutcome.Failure;
             try
             {
-                // The "old" data in this case is the download count data that was last indexed by this job (or
-                // initialized by Db2AzureSearch).
-                _logger.LogInformation("Fetching old download count data from blob storage.");
-                var oldResult = await _downloadDataClient.ReadLatestIndexedAsync();
-
-                // The "new" data in this case is from the statistics pipeline.
-                _logger.LogInformation("Fetching new download count data from blob storage.");
-                var newData = await _auxiliaryFileClient.LoadDownloadDataAsync();
-
-                _logger.LogInformation("Removing invalid IDs and versions from the new data.");
-                CleanDownloadData(newData);
-
-                _logger.LogInformation("Detecting download count changes.");
-                var changes = _downloadSetComparer.Compare(oldResult.Result, newData);
-                var idBag = new ConcurrentBag<string>(changes.Keys);
-                _logger.LogInformation("{Count} package IDs have download count changes.", idBag.Count);
-
-                if (!changes.Any())
-                {
-                    outcome = JobOutcome.NoOp;
-                    return;
-                }
-
-                _logger.LogInformation(
-                    "Starting {Count} workers pushing download count changes to Azure Search.",
-                    _options.Value.MaxConcurrentBatches);
-                await ParallelAsync.Repeat(
-                    () => WorkAsync(idBag, changes),
-                    _options.Value.MaxConcurrentBatches);
-                _logger.LogInformation("All of the download count changes have been pushed to Azure Search.");
-
-                _logger.LogInformation("Uploading the new download count data to blob storage.");
-                await _downloadDataClient.ReplaceLatestIndexedAsync(newData, oldResult.AccessCondition);
-                outcome = JobOutcome.Success;
+                var hasVerifiedPackagesChanged = await CopyVerifiedPackagesAsync();
+                var hasIndexChanged = await PushIndexChangesAsync();
+                outcome = hasVerifiedPackagesChanged || hasIndexChanged ? JobOutcome.Success : JobOutcome.NoOp;
             }
             finally
             {
                 stopwatch.Stop();
                 _telemetryService.TrackAuxiliary2AzureSearchCompleted(outcome, stopwatch.Elapsed);
             }
+        }
+
+        private async Task<bool> CopyVerifiedPackagesAsync()
+        {
+            // The "old" data in this case is the latest file that was copied to the region's storage container by this
+            // job (or initialized by Db2AzureSearch).
+            var oldResult = await _verifiedPackagesDataClient.ReadLatestAsync();
+
+            // The "new" data in this case is from the auxiliary data container that is updated by the
+            // Search.GenerateAuxiliaryData job.
+            var newResult = await _auxiliaryFileClient.LoadVerifiedPackagesAsync(etag: null);
+
+            var changes = new HashSet<string>(oldResult.Result, oldResult.Result.Comparer);
+            changes.SymmetricExceptWith(newResult.Data);
+            _logger.LogInformation("{Count} package IDs have verified status changes.", changes.Count);
+
+            if (changes.Count == 0)
+            {
+                return false;
+            }
+            else
+            {
+                await _verifiedPackagesDataClient.ReplaceLatestAsync(newResult.Data, oldResult.AccessCondition);
+                return true;
+            }
+        }
+
+        private async Task<bool> PushIndexChangesAsync()
+        {
+            // The "old" data in this case is the download count data that was last indexed by this job (or
+            // initialized by Db2AzureSearch).
+            _logger.LogInformation("Fetching old download count data from blob storage.");
+            var oldResult = await _downloadDataClient.ReadLatestIndexedAsync();
+
+            // The "new" data in this case is from the statistics pipeline.
+            _logger.LogInformation("Fetching new download count data from blob storage.");
+            var newData = await _auxiliaryFileClient.LoadDownloadDataAsync();
+
+            _logger.LogInformation("Removing invalid IDs and versions from the new data.");
+            CleanDownloadData(newData);
+
+            _logger.LogInformation("Detecting download count changes.");
+            var changes = _downloadSetComparer.Compare(oldResult.Result, newData);
+            var idBag = new ConcurrentBag<string>(changes.Keys);
+            _logger.LogInformation("{Count} package IDs have download count changes.", idBag.Count);
+
+            if (!changes.Any())
+            {
+                return false;
+            }
+
+            _logger.LogInformation(
+                "Starting {Count} workers pushing download count changes to Azure Search.",
+                _options.Value.MaxConcurrentBatches);
+            await ParallelAsync.Repeat(
+                () => WorkAsync(idBag, changes),
+                _options.Value.MaxConcurrentBatches);
+            _logger.LogInformation("All of the download count changes have been pushed to Azure Search.");
+
+            _logger.LogInformation("Uploading the new download count data to blob storage.");
+            await _downloadDataClient.ReplaceLatestIndexedAsync(newData, oldResult.AccessCondition);
+            return true;
         }
 
         private async Task WorkAsync(ConcurrentBag<string> idBag, SortedDictionary<string, long> changes)

--- a/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchConfiguration.cs
@@ -11,8 +11,8 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
         public string AuxiliaryDataStorageConnectionString { get; set; }
         public string AuxiliaryDataStorageContainer { get; set; }
         public string AuxiliaryDataStorageDownloadsPath { get; set; }
-        public string AuxiliaryDataStorageVerifiedPackagesPath { get; set; }
         public string AuxiliaryDataStorageExcludedPackagesPath { get; }
+        public string AuxiliaryDataStorageVerifiedPackagesPath { get; set; }
         public TimeSpan MinPushPeriod { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryDataStorageConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryDataStorageConfiguration.cs
@@ -8,7 +8,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
         string AuxiliaryDataStorageConnectionString { get; }
         string AuxiliaryDataStorageContainer { get; }
         string AuxiliaryDataStorageDownloadsPath { get; }
-        string AuxiliaryDataStorageVerifiedPackagesPath { get; }
         string AuxiliaryDataStorageExcludedPackagesPath { get; }
+        string AuxiliaryDataStorageVerifiedPackagesPath { get; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchConfiguration.cs
@@ -12,8 +12,8 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
         public string CatalogIndexUrl { get; set; }
         public string AuxiliaryDataStorageConnectionString { get; set; }
         public string AuxiliaryDataStorageContainer { get; set; }
-        public string AuxiliaryDataStorageExcludedPackagesPath { get; set; }
         public string AuxiliaryDataStorageDownloadsPath { get; set; }
+        public string AuxiliaryDataStorageExcludedPackagesPath { get; set; }
         public string AuxiliaryDataStorageVerifiedPackagesPath { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/InitialAuxiliaryData.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/InitialAuxiliaryData.cs
@@ -12,15 +12,18 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
         public InitialAuxiliaryData(
             SortedDictionary<string, SortedSet<string>> owners,
             DownloadData downloads,
-            HashSet<string> excludedPackages)
+            HashSet<string> excludedPackages,
+            HashSet<string> verifiedPackages)
         {
             Owners = owners ?? throw new ArgumentNullException(nameof(owners));
             Downloads = downloads ?? throw new ArgumentNullException(nameof(downloads));
             ExcludedPackages = excludedPackages ?? throw new ArgumentNullException(nameof(excludedPackages));
+            VerifiedPackages = verifiedPackages ?? throw new ArgumentNullException(nameof(verifiedPackages));
         }
 
         public SortedDictionary<string, SortedSet<string>> Owners { get; }
         public DownloadData Downloads { get; }
         public HashSet<string> ExcludedPackages { get; }
+        public HashSet<string> VerifiedPackages { get; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationProducer.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationProducer.cs
@@ -55,6 +55,12 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
             // numbers we don't use the gallery DB values.
             var downloads = await _auxiliaryFileClient.LoadDownloadDataAsync();
 
+            // Fetch the verified packages file. This is not used inside the index but is used at query-time in the
+            // Azure Search service. We want to copy this file to the local region's storage container to improve
+            // availability and start-up of the service.
+            var verifiedPackagesResult = await _auxiliaryFileClient.LoadVerifiedPackagesAsync(etag: null);
+            var verifiedPackages = verifiedPackagesResult.Data;
+
             // Build a list of the owners data as we collect package registrations from the database.
             var ownersBuilder = new PackageIdToOwnersBuilder(_logger);
 
@@ -104,7 +110,8 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
             return new InitialAuxiliaryData(
                 ownersBuilder.GetResult(),
                 downloads,
-                excludedPackages);
+                excludedPackages,
+                verifiedPackages);
         }
 
         private bool ShouldWait(ConcurrentBag<NewPackageRegistration> allWork, bool log)

--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -190,6 +190,7 @@ namespace NuGet.Services.AzureSearch
                     c.ResolveKeyed<IStorageFactory>(key),
                     c.Resolve<IOwnerDataClient>(),
                     c.Resolve<IDownloadDataClient>(),
+                    c.Resolve<IVerifiedPackagesDataClient>(),
                     c.Resolve<IOptionsSnapshot<Db2AzureSearchConfiguration>>(),
                     c.Resolve<ILogger<Db2AzureSearchCommand>>()));
         }

--- a/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommandFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommandFacts.cs
@@ -27,6 +27,43 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
             }
 
             [Fact]
+            public async Task PushesAddedVerifiedPackage()
+            {
+                NewVerifiedPackagesData.Add("NuGet.Versioning");
+
+                await Target.ExecuteAsync();
+
+                VerifyCompletedTelemetry(JobOutcome.Success);
+                VerifiedPackagesDataClient.Verify(
+                    x => x.ReplaceLatestAsync(NewVerifiedPackagesData, OldVerifiedPackagesResult.AccessCondition),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task PushesRemovedVerifiedPackage()
+            {
+                OldVerifiedPackagesData.Add("NuGet.Versioning");
+
+                await Target.ExecuteAsync();
+
+                VerifyCompletedTelemetry(JobOutcome.Success);
+                VerifiedPackagesDataClient.Verify(
+                    x => x.ReplaceLatestAsync(NewVerifiedPackagesData, OldVerifiedPackagesResult.AccessCondition),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task DoesNotPushUnchangedVerifiedPackages()
+            {
+                await Target.ExecuteAsync();
+
+                VerifyCompletedTelemetry(JobOutcome.NoOp);
+                VerifiedPackagesDataClient.Verify(
+                    x => x.ReplaceLatestAsync(It.IsAny<HashSet<string>>(), It.IsAny<IAccessCondition>()),
+                    Times.Never);
+            }
+
+            [Fact]
             public async Task PushesNothingWhenThereAreNoChanges()
             {
                 await Target.ExecuteAsync();
@@ -84,7 +121,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
                 BatchPusher.Verify(x => x.PushFullBatchesAsync(), Times.Never);
                 SystemTime.Verify(x => x.Delay(It.IsAny<TimeSpan>()), Times.Exactly(expectedPushes - 1));
                 DownloadDataClient.Verify(
-                    x => x.ReplaceLatestIndexedAsync(NewData, OldResult.AccessCondition),
+                    x => x.ReplaceLatestIndexedAsync(NewDownloadData, OldDownloadResult.AccessCondition),
                     Times.Once);
 
                 Assert.Equal(
@@ -138,17 +175,17 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
             [Fact]
             public async Task RejectsInvalidDataAndNormalizesVersions()
             {
-                NewData.SetDownloadCount("ValidId", "1.0.0-ValidVersion", 3);
-                NewData.SetDownloadCount("ValidId", "1.0.0.a-invalidversion", 5);
-                NewData.SetDownloadCount("ValidId", "1.0.0.0-NonNormalized", 7);
-                NewData.SetDownloadCount("Invalid--Id", "1.0.0-validversion", 11);
-                NewData.SetDownloadCount("Invalid--Id", "1.0.0.a-invalidversion", 13);
+                NewDownloadData.SetDownloadCount("ValidId", "1.0.0-ValidVersion", 3);
+                NewDownloadData.SetDownloadCount("ValidId", "1.0.0.a-invalidversion", 5);
+                NewDownloadData.SetDownloadCount("ValidId", "1.0.0.0-NonNormalized", 7);
+                NewDownloadData.SetDownloadCount("Invalid--Id", "1.0.0-validversion", 11);
+                NewDownloadData.SetDownloadCount("Invalid--Id", "1.0.0.a-invalidversion", 13);
 
                 await Target.ExecuteAsync();
 
-                Assert.Equal(new[] { "ValidId" }, NewData.Keys.ToArray());
-                Assert.Equal(new[] { "1.0.0-NonNormalized", "1.0.0-ValidVersion" }, NewData["ValidId"].Keys.ToArray());
-                Assert.Equal(10, NewData.GetDownloadCount("ValidId"));
+                Assert.Equal(new[] { "ValidId" }, NewDownloadData.Keys.ToArray());
+                Assert.Equal(new[] { "1.0.0-NonNormalized", "1.0.0-ValidVersion" }, NewDownloadData["ValidId"].Keys.ToArray());
+                Assert.Equal(10, NewDownloadData.GetDownloadCount("ValidId"));
                 Assert.Contains("There were 1 invalid IDs, 2 invalid versions, and 1 non-normalized IDs.", Logger.Messages);
             }
         }
@@ -159,6 +196,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
             {
                 AuxiliaryFileClient = new Mock<IAuxiliaryFileClient>();
                 DownloadDataClient = new Mock<IDownloadDataClient>();
+                VerifiedPackagesDataClient = new Mock<IVerifiedPackagesDataClient>();
                 DownloadSetComparer = new Mock<IDownloadSetComparer>();
                 SearchDocumentBuilder = new Mock<ISearchDocumentBuilder>();
                 IndexActionBuilder = new Mock<ISearchIndexActionBuilder>();
@@ -177,11 +215,26 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
                 };
                 Options.Setup(x => x.Value).Returns(() => Config);
 
-                OldData = new DownloadData();
-                OldResult = new ResultAndAccessCondition<DownloadData>(OldData, Mock.Of<IAccessCondition>());
-                DownloadDataClient.Setup(x => x.ReadLatestIndexedAsync()).ReturnsAsync(() => OldResult);
-                NewData = new DownloadData();
-                AuxiliaryFileClient.Setup(x => x.LoadDownloadDataAsync()).ReturnsAsync(() => NewData);
+                OldDownloadData = new DownloadData();
+                OldDownloadResult = new ResultAndAccessCondition<DownloadData>(OldDownloadData, Mock.Of<IAccessCondition>());
+                DownloadDataClient.Setup(x => x.ReadLatestIndexedAsync()).ReturnsAsync(() => OldDownloadResult);
+                NewDownloadData = new DownloadData();
+                AuxiliaryFileClient.Setup(x => x.LoadDownloadDataAsync()).ReturnsAsync(() => NewDownloadData);
+
+                OldVerifiedPackagesData = new HashSet<string>();
+                OldVerifiedPackagesResult = new ResultAndAccessCondition<HashSet<string>>(OldVerifiedPackagesData, Mock.Of<IAccessCondition>());
+                VerifiedPackagesDataClient.Setup(x => x.ReadLatestAsync()).ReturnsAsync(() => OldVerifiedPackagesResult);
+                NewVerifiedPackagesData = new HashSet<string>();
+                NewVerifiedPackagesResult = new AuxiliaryFileResult<HashSet<string>>(
+                    notModified: false,
+                    data: NewVerifiedPackagesData,
+                    metadata: new AuxiliaryFileMetadata(
+                        DateTimeOffset.MinValue,
+                        DateTimeOffset.MinValue,
+                        TimeSpan.Zero,
+                        fileSize: 0,
+                        etag: "etag"));
+                AuxiliaryFileClient.Setup(x => x.LoadVerifiedPackagesAsync(It.IsAny<string>())).ReturnsAsync(() => NewVerifiedPackagesResult);
 
                 Changes = new SortedDictionary<string, long>();
                 DownloadSetComparer
@@ -227,6 +280,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
                 Target = new Auxiliary2AzureSearchCommand(
                     AuxiliaryFileClient.Object,
                     DownloadDataClient.Object,
+                    VerifiedPackagesDataClient.Object,
                     DownloadSetComparer.Object,
                     SearchDocumentBuilder.Object,
                     IndexActionBuilder.Object,
@@ -239,6 +293,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
 
             public Mock<IAuxiliaryFileClient> AuxiliaryFileClient { get; }
             public Mock<IDownloadDataClient> DownloadDataClient { get; }
+            public Mock<IVerifiedPackagesDataClient> VerifiedPackagesDataClient { get; }
             public Mock<IDownloadSetComparer> DownloadSetComparer { get; }
             public Mock<ISearchDocumentBuilder> SearchDocumentBuilder { get; }
             public Mock<ISearchIndexActionBuilder> IndexActionBuilder { get; }
@@ -248,9 +303,9 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
             public Mock<IAzureSearchTelemetryService> TelemetryService { get; }
             public RecordingLogger<Auxiliary2AzureSearchCommand> Logger { get; }
             public Auxiliary2AzureSearchConfiguration Config { get; }
-            public DownloadData OldData { get; }
-            public ResultAndAccessCondition<DownloadData> OldResult { get; }
-            public DownloadData NewData { get; }
+            public DownloadData OldDownloadData { get; }
+            public ResultAndAccessCondition<DownloadData> OldDownloadResult { get; }
+            public DownloadData NewDownloadData { get; }
             public SortedDictionary<string, long> Changes { get; }
             public Auxiliary2AzureSearchCommand Target { get; }
             public IndexActions IndexActions { get; set; }
@@ -258,6 +313,10 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
             public ConcurrentBag<string> PushedIds { get; }
             public ConcurrentBag<IndexActions> CurrentBatch { get; set; }
             public ConcurrentBag<List<IndexActions>> FinishedBatches { get; }
+            public HashSet<string> OldVerifiedPackagesData { get; }
+            public ResultAndAccessCondition<HashSet<string>> OldVerifiedPackagesResult { get; }
+            public HashSet<string> NewVerifiedPackagesData { get; }
+            public AuxiliaryFileResult<HashSet<string>> NewVerifiedPackagesResult { get; }
 
             public void VerifyCompletedTelemetry(JobOutcome outcome)
             {


### PR DESCRIPTION
Progress on https://github.com/nuget/engineering/issues/2635
Depends on https://github.com/NuGet/NuGet.Services.Metadata/pull/629

The verified packages file will be initialized by Db2AzureSearch and kept up to date by Auxiliary2AzureSearch.