### PR TITLE
[Azure Search 1] Read auxiliary data from local storage in Azure Search Service

### DIFF
--- a/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommand.cs
@@ -14,6 +14,7 @@ using NuGet.Services.AzureSearch.AuxiliaryFiles;
 using NuGet.Services.AzureSearch.Wrappers;
 using NuGet.Services.Metadata.Catalog.Helpers;
 using NuGet.Versioning;
+using NuGetGallery;
 
 namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
 {
@@ -99,14 +100,14 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
         {
             // The "old" data in this case is the latest file that was copied to the region's storage container by this
             // job (or initialized by Db2AzureSearch).
-            var oldResult = await _verifiedPackagesDataClient.ReadLatestAsync();
+            var oldResult = await _verifiedPackagesDataClient.ReadLatestAsync(AccessConditionWrapper.GenerateEmptyCondition());
 
             // The "new" data in this case is from the auxiliary data container that is updated by the
             // Search.GenerateAuxiliaryData job.
-            var newResult = await _auxiliaryFileClient.LoadVerifiedPackagesAsync(etag: null);
+            var newData = await _auxiliaryFileClient.LoadVerifiedPackagesAsync();
 
-            var changes = new HashSet<string>(oldResult.Result, oldResult.Result.Comparer);
-            changes.SymmetricExceptWith(newResult.Data);
+            var changes = new HashSet<string>(oldResult.Data, oldResult.Data.Comparer);
+            changes.SymmetricExceptWith(newData);
             _logger.LogInformation("{Count} package IDs have verified status changes.", changes.Count);
 
             if (changes.Count == 0)
@@ -115,7 +116,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
             }
             else
             {
-                await _verifiedPackagesDataClient.ReplaceLatestAsync(newResult.Data, oldResult.AccessCondition);
+                await _verifiedPackagesDataClient.ReplaceLatestAsync(newData, oldResult.Metadata.GetIfMatchCondition());
                 return true;
             }
         }
@@ -125,20 +126,20 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
             // The "old" data in this case is the download count data that was last indexed by this job (or
             // initialized by Db2AzureSearch).
             _logger.LogInformation("Fetching old download count data from blob storage.");
-            var oldResult = await _downloadDataClient.ReadLatestIndexedAsync();
+            var oldResult = await _downloadDataClient.ReadLatestIndexedAsync(AccessConditionWrapper.GenerateEmptyCondition());
 
             // The "new" data in this case is from the statistics pipeline.
             _logger.LogInformation("Fetching new download count data from blob storage.");
             var newData = await _auxiliaryFileClient.LoadDownloadDataAsync();
 
             _logger.LogInformation("Removing invalid IDs and versions from the old data.");
-            CleanDownloadData(oldResult.Result);
+            CleanDownloadData(oldResult.Data);
 
             _logger.LogInformation("Removing invalid IDs and versions from the new data.");
             CleanDownloadData(newData);
 
             _logger.LogInformation("Detecting download count changes.");
-            var changes = _downloadSetComparer.Compare(oldResult.Result, newData);
+            var changes = _downloadSetComparer.Compare(oldResult.Data, newData);
             var idBag = new ConcurrentBag<string>(changes.Keys);
             _logger.LogInformation("{Count} package IDs have download count changes.", idBag.Count);
 
@@ -156,7 +157,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
             _logger.LogInformation("All of the download count changes have been pushed to Azure Search.");
 
             _logger.LogInformation("Uploading the new download count data to blob storage.");
-            await _downloadDataClient.ReplaceLatestIndexedAsync(newData, oldResult.AccessCondition);
+            await _downloadDataClient.ReplaceLatestIndexedAsync(newData, oldResult.Metadata.GetIfMatchCondition());
             return true;
         }
 

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryFileMetadata.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryFileMetadata.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Newtonsoft.Json;
+using NuGetGallery;
 
 namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 {
@@ -11,12 +12,10 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
         [JsonConstructor]
         public AuxiliaryFileMetadata(
             DateTimeOffset lastModified,
-            DateTimeOffset loaded,
             TimeSpan loadDuration,
             long fileSize,
             string etag)
         {
-            Loaded = loaded;
             LastModified = lastModified;
             LoadDuration = loadDuration;
             FileSize = fileSize;
@@ -24,9 +23,13 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
         }
 
         public DateTimeOffset LastModified { get; }
-        public DateTimeOffset Loaded { get; }
         public TimeSpan LoadDuration { get; }
         public long FileSize { get; }
         public string ETag { get; }
+
+        public IAccessCondition GetIfMatchCondition()
+        {
+            return AccessConditionWrapper.GenerateIfMatchCondition(ETag);
+        }
     }
 }

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryFileResult.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryFileResult.cs
@@ -8,12 +8,17 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
     public class AuxiliaryFileResult<T> where T : class
     {
         public AuxiliaryFileResult(
-            bool notModified,
+            bool modified,
             T data,
             AuxiliaryFileMetadata metadata)
         {
-            NotModified = notModified;
-            if (notModified)
+            Modified = modified;
+            if (modified)
+            {
+                Data = data ?? throw new ArgumentNullException(nameof(data));
+                Metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
+            }
+            else
             {
                 if (data != null)
                 {
@@ -25,15 +30,25 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
                     throw new ArgumentException("The file metadata must be null if it was not modified.", nameof(data));
                 }
             }
-            else
-            {
-                Data = data ?? throw new ArgumentNullException(nameof(data));
-                Metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
-            }
         }
 
-        public bool NotModified { get; }
+        /// <summary>
+        /// Whether or not the data has been modified since the last time this result was fetched. This can be set to
+        /// false by an auxiliary file client by reading an endpoint with an etag, i.e. with the <c>If-Match:</c> HTTP
+        /// request header.
+        /// </summary>
+        public bool Modified { get; }
+
+        /// <summary>
+        /// The data in the auxiliary file. This will be non-null if <see cref="Modified"/> is true and null if it is
+        /// false.
+        /// </summary>
         public T Data { get; }
+
+        /// <summary>
+        /// The metadata about the auxiliary file for no-op and diagnostics purposes. This type has the etag which can
+        /// be used to only download the data if it has changed.
+        /// </summary>
         public AuxiliaryFileMetadata Metadata { get; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/DownloadDataClient.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/DownloadDataClient.cs
@@ -41,7 +41,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 
         private ICloudBlobContainer Container => _lazyContainer.Value;
 
-        public async Task<ResultAndAccessCondition<DownloadData>> ReadLatestIndexedAsync()
+        public async Task<AuxiliaryFileResult<DownloadData>> ReadLatestIndexedAsync(IAccessCondition accessCondition)
         {
             var stopwatch = Stopwatch.StartNew();
             var blobName = GetLatestIndexedBlobName();
@@ -49,28 +49,37 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 
             _logger.LogInformation("Reading the latest indexed downloads from {BlobName}.", blobName);
 
+            bool modified;
             var downloads = new DownloadData();
-            IAccessCondition accessCondition;
+            AuxiliaryFileMetadata metadata;
             try
             {
-                using (var stream = await blobReference.OpenReadAsync(AccessCondition.GenerateEmptyCondition()))
+                using (var stream = await blobReference.OpenReadAsync(accessCondition))
                 {
-                    accessCondition = AccessConditionWrapper.GenerateIfMatchCondition(blobReference.ETag);
                     ReadStream(stream, downloads.SetDownloadCount);
+                    modified = true;
+                    metadata = new AuxiliaryFileMetadata(
+                        lastModified: new DateTimeOffset(blobReference.LastModifiedUtc, TimeSpan.Zero),
+                        loadDuration: stopwatch.Elapsed,
+                        fileSize: blobReference.Properties.Length,
+                        etag: blobReference.ETag);
                 }
             }
-            catch (StorageException ex) when (ex.RequestInformation.HttpStatusCode == (int)HttpStatusCode.NotFound)
+            catch (StorageException ex) when (ex.RequestInformation.HttpStatusCode == (int)HttpStatusCode.NotModified)
             {
-                accessCondition = AccessConditionWrapper.GenerateIfNotExistsCondition();
-                _logger.LogInformation("The blob {BlobName} does not exist.", blobName);
+                _logger.LogInformation("The blob {BlobName} has not changed.", blobName);
+                modified = false;
+                downloads = null;
+                metadata = null;
             }
 
-            var output = new ResultAndAccessCondition<DownloadData>(downloads, accessCondition);
-
             stopwatch.Stop();
-            _telemetryService.TrackReadLatestIndexedDownloads(output.Result.Count, stopwatch.Elapsed);
+            _telemetryService.TrackReadLatestIndexedDownloads(downloads?.Count, modified, stopwatch.Elapsed);
 
-            return output;
+            return new AuxiliaryFileResult<DownloadData>(
+                modified,
+                downloads,
+                metadata);
         }
 
         public async Task ReplaceLatestIndexedAsync(
@@ -82,15 +91,9 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
                 var blobName = GetLatestIndexedBlobName();
                 _logger.LogInformation("Replacing the latest indexed downloads from {BlobName}.", blobName);
 
-                var mappedAccessCondition = new AccessCondition
-                {
-                    IfNoneMatchETag = accessCondition.IfNoneMatchETag,
-                    IfMatchETag = accessCondition.IfMatchETag,
-                };
-
                 var blobReference = Container.GetBlobReference(blobName);
 
-                using (var stream = await blobReference.OpenWriteAsync(mappedAccessCondition))
+                using (var stream = await blobReference.OpenWriteAsync(accessCondition))
                 using (var streamWriter = new StreamWriter(stream))
                 using (var jsonTextWriter = new JsonTextWriter(streamWriter))
                 {

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryFileClient.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryFileClient.cs
@@ -3,15 +3,13 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using NuGet.Indexing;
 
 namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 {
     public interface IAuxiliaryFileClient
     {
         Task<DownloadData> LoadDownloadDataAsync();
-        Task<AuxiliaryFileResult<Downloads>> LoadDownloadsAsync(string etag);
-        Task<AuxiliaryFileResult<HashSet<string>>> LoadVerifiedPackagesAsync(string etag);
-        Task<AuxiliaryFileResult<HashSet<string>>> LoadExcludedPackagesAsync(string etag);
+        Task<HashSet<string>> LoadVerifiedPackagesAsync();
+        Task<HashSet<string>> LoadExcludedPackagesAsync();
     }
 }

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IDownloadDataClient.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IDownloadDataClient.cs
@@ -8,7 +8,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 {
     public interface IDownloadDataClient
     {
-        Task<ResultAndAccessCondition<DownloadData>> ReadLatestIndexedAsync();
+        Task<AuxiliaryFileResult<DownloadData>> ReadLatestIndexedAsync(IAccessCondition accessCondition);
         Task ReplaceLatestIndexedAsync(DownloadData newData, IAccessCondition accessCondition);
     }
 }

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IVerifiedPackagesDataClient.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IVerifiedPackagesDataClient.cs
@@ -9,7 +9,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 {
     public interface IVerifiedPackagesDataClient
     {
-        Task<ResultAndAccessCondition<HashSet<string>>> ReadLatestAsync();
+        Task<AuxiliaryFileResult<HashSet<string>>> ReadLatestAsync(IAccessCondition accessCondition);
         Task ReplaceLatestAsync(HashSet<string> newData, IAccessCondition accessCondition);
     }
 }

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/SimpleCloudBlobExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/SimpleCloudBlobExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage;
+using NuGetGallery;
+
+namespace NuGet.Services.AzureSearch.AuxiliaryFiles
+{
+    internal static class SimpleCloudBlobExtensions
+    {
+        public static async Task<Stream> OpenReadAsync(this ISimpleCloudBlob blob, IAccessCondition accessCondition)
+        {
+            return await blob.OpenReadAsync(MapAccessCondition(accessCondition));
+        }
+
+        public static async Task<Stream> OpenWriteAsync(this ISimpleCloudBlob blob, IAccessCondition accessCondition)
+        {
+            return await blob.OpenWriteAsync(MapAccessCondition(accessCondition));
+        }
+
+        private static AccessCondition MapAccessCondition(IAccessCondition accessCondition)
+        {
+            return new AccessCondition
+            {
+                IfNoneMatchETag = accessCondition.IfNoneMatchETag,
+                IfMatchETag = accessCondition.IfMatchETag,
+            };
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/VerifiedPackagesDataClient.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/VerifiedPackagesDataClient.cs
@@ -42,7 +42,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 
         private ICloudBlobContainer Container => _lazyContainer.Value;
 
-        public async Task<ResultAndAccessCondition<HashSet<string>>> ReadLatestAsync()
+        public async Task<AuxiliaryFileResult<HashSet<string>>> ReadLatestAsync(IAccessCondition accessCondition)
         {
             var stopwatch = Stopwatch.StartNew();
             var blobName = GetLatestIndexedBlobName();
@@ -50,30 +50,37 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 
             _logger.LogInformation("Reading the latest verified packages from {BlobName}.", blobName);
 
-            IAccessCondition accessCondition;
+            bool modified;
             var data = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            AuxiliaryFileMetadata metadata;
             try
             {
-                using (var stream = await blobReference.OpenReadAsync(AccessCondition.GenerateEmptyCondition()))
+                using (var stream = await blobReference.OpenReadAsync(accessCondition))
                 {
-                    accessCondition = AccessConditionWrapper.GenerateIfMatchCondition(blobReference.ETag);
                     ReadStream(stream, id => data.Add(id));
+                    modified = true;
+                    metadata = new AuxiliaryFileMetadata(
+                        lastModified: new DateTimeOffset(blobReference.LastModifiedUtc, TimeSpan.Zero),
+                        loadDuration: stopwatch.Elapsed,
+                        fileSize: blobReference.Properties.Length,
+                        etag: blobReference.ETag);
                 }
             }
-            catch (StorageException ex) when (ex.RequestInformation.HttpStatusCode == (int)HttpStatusCode.NotFound)
+            catch (StorageException ex) when (ex.RequestInformation.HttpStatusCode == (int)HttpStatusCode.NotModified)
             {
-                accessCondition = AccessConditionWrapper.GenerateIfNotExistsCondition();
-                _logger.LogInformation("The blob {BlobName} does not exist.", blobName);
+                _logger.LogInformation("The blob {BlobName} has not changed.", blobName);
+                modified = false;
+                data = null;
+                metadata = null;
             }
 
-            var output = new ResultAndAccessCondition<HashSet<string>>(
-                data,
-                accessCondition);
-
             stopwatch.Stop();
-            _telemetryService.TrackReadLatestVerifiedPackages(output.Result.Count, stopwatch.Elapsed);
+            _telemetryService.TrackReadLatestVerifiedPackages(data?.Count, modified, stopwatch.Elapsed);
 
-            return output;
+            return new AuxiliaryFileResult<HashSet<string>>(
+                modified,
+                data,
+                metadata);
         }
 
         public async Task ReplaceLatestAsync(
@@ -85,15 +92,9 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
                 var blobName = GetLatestIndexedBlobName();
                 _logger.LogInformation("Replacing the latest verified packages from {BlobName}.", blobName);
 
-                var mappedAccessCondition = new AccessCondition
-                {
-                    IfNoneMatchETag = accessCondition.IfNoneMatchETag,
-                    IfMatchETag = accessCondition.IfMatchETag,
-                };
-
                 var blobReference = Container.GetBlobReference(blobName);
 
-                using (var stream = await blobReference.OpenWriteAsync(mappedAccessCondition))
+                using (var stream = await blobReference.OpenWriteAsync(accessCondition))
                 using (var streamWriter = new StreamWriter(stream))
                 using (var jsonTextWriter = new JsonTextWriter(streamWriter))
                 {

--- a/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
@@ -134,17 +134,6 @@ namespace NuGet.Services.AzureSearch
                 });
         }
 
-        public void TrackAuxiliaryFileNotModified(string blobName, TimeSpan elapsed)
-        {
-            _telemetryClient.TrackMetric(
-                Prefix + "AuxiliaryFileNotModifiedSeconds",
-                elapsed.TotalSeconds,
-                new Dictionary<string, string>
-                {
-                    { "BlobName", blobName },
-                });
-        }
-
         public IDisposable TrackUploadOwnerChangeHistory(int packageIdCount)
         {
             return _telemetryClient.TrackDuration(
@@ -286,14 +275,15 @@ namespace NuGet.Services.AzureSearch
                 });
         }
 
-        public void TrackReadLatestIndexedDownloads(int packageIdCount, TimeSpan elapsed)
+        public void TrackReadLatestIndexedDownloads(int? packageIdCount, bool notModified, TimeSpan elapsed)
         {
             _telemetryClient.TrackMetric(
                 Prefix + "ReadLatestIndexedDownloadsSeconds",
                 elapsed.TotalSeconds,
                 new Dictionary<string, string>
                 {
-                    { "PackageIdCount", packageIdCount.ToString() },
+                    { "PackageIdCount", packageIdCount?.ToString() },
+                    { "NotModified", notModified.ToString() },
                 });
         }
 
@@ -378,14 +368,15 @@ namespace NuGet.Services.AzureSearch
                 elapsed.TotalMilliseconds);
         }
 
-        public void TrackReadLatestVerifiedPackages(int packageIdCount, TimeSpan elapsed)
+        public void TrackReadLatestVerifiedPackages(int? packageIdCount, bool notModified, TimeSpan elapsed)
         {
             _telemetryClient.TrackMetric(
                 Prefix + "ReadLatestVerifiedPackagesSeconds",
                 elapsed.TotalSeconds,
                 new Dictionary<string, string>
                 {
-                    { "PackageIdCount", packageIdCount.ToString() },
+                    { "PackageIdCount", packageIdCount?.ToString() },
+                    { "NotModified", notModified.ToString() },
                 });
         }
 

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationProducer.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationProducer.cs
@@ -43,8 +43,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
             var ranges = await GetPackageRegistrationRangesAsync();
 
             // Fetch exclude packages list from auxiliary files.
-            var excludedPackagesResult = await _auxiliaryFileClient.LoadExcludedPackagesAsync(etag: null);
-            var excludedPackages = excludedPackagesResult.Data;
+            var excludedPackages = await _auxiliaryFileClient.LoadExcludedPackagesAsync();
 
             Guard.Assert(
                 excludedPackages.Comparer == StringComparer.OrdinalIgnoreCase,
@@ -58,8 +57,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
             // Fetch the verified packages file. This is not used inside the index but is used at query-time in the
             // Azure Search service. We want to copy this file to the local region's storage container to improve
             // availability and start-up of the service.
-            var verifiedPackagesResult = await _auxiliaryFileClient.LoadVerifiedPackagesAsync(etag: null);
-            var verifiedPackages = verifiedPackagesResult.Data;
+            var verifiedPackages = await _auxiliaryFileClient.LoadVerifiedPackagesAsync();
 
             // Build a list of the owners data as we collect package registrations from the database.
             var ownersBuilder = new PackageIdToOwnersBuilder(_logger);

--- a/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
@@ -10,7 +10,6 @@ namespace NuGet.Services.AzureSearch
     public interface IAzureSearchTelemetryService
     {
         void TrackAuxiliaryFileDownloaded(string blobName, TimeSpan elapsed);
-        void TrackAuxiliaryFileNotModified(string blobName, TimeSpan elapsed);
         void TrackAuxiliaryFilesReload(IReadOnlyList<string> reloadedNames, IReadOnlyList<string> notModifiedNames, TimeSpan elapsed);
         IDisposable TrackGetLatestLeaves(string packageId, int requestedVersions);
         void TrackGetOwnersForPackageId(int ownerCount, TimeSpan elapsed);
@@ -44,13 +43,13 @@ namespace NuGet.Services.AzureSearch
         void TrackWarmQuery(string indexName, TimeSpan elapsed);
         void TrackLastCommitTimestampQuery(string indexName, DateTimeOffset? lastCommitTimestamp, TimeSpan elapsed);
         IDisposable TrackCatalogLeafDownloadBatch(int count);
-        void TrackReadLatestIndexedDownloads(int packageIdCount, TimeSpan elapsed);
+        void TrackReadLatestIndexedDownloads(int? packageIdCount, bool notModified, TimeSpan elapsed);
         IDisposable TrackReplaceLatestIndexedDownloads(int packageIdCount);
         void TrackAuxiliary2AzureSearchCompleted(JobOutcome outcome, TimeSpan elapsed);
         void TrackV3GetDocument(TimeSpan elapsed);
         void TrackV2GetDocumentWithSearchIndex(TimeSpan elapsed);
         void TrackV2GetDocumentWithHijackIndex(TimeSpan elapsed);
-        void TrackReadLatestVerifiedPackages(int packageIdCount, TimeSpan elapsed);
+        void TrackReadLatestVerifiedPackages(int? packageIdCount, bool notModified, TimeSpan elapsed);
         IDisposable TrackReplaceLatestVerifiedPackages(int packageIdCount);
     }
 }

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Auxiliary2AzureSearch\Auxiliary2AzureSearchConfiguration.cs" />
     <Compile Include="Auxiliary2AzureSearch\DownloadSetComparer.cs" />
     <Compile Include="Auxiliary2AzureSearch\IDownloadSetComparer.cs" />
+    <Compile Include="AuxiliaryFiles\SimpleCloudBlobExtensions.cs" />
     <Compile Include="AuxiliaryFiles\DownloadByVersionData.cs" />
     <Compile Include="AuxiliaryFiles\DownloadData.cs" />
     <Compile Include="AuxiliaryFiles\DownloadDataClient.cs" />

--- a/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryData.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryData.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using NuGet.Indexing;
 using NuGet.Services.AzureSearch.AuxiliaryFiles;
 
 namespace NuGet.Services.AzureSearch.SearchService
@@ -11,17 +10,19 @@ namespace NuGet.Services.AzureSearch.SearchService
     public class AuxiliaryData : IAuxiliaryData
     {
         public AuxiliaryData(
-            AuxiliaryFileResult<Downloads> downloads,
+            DateTimeOffset loaded,
+            AuxiliaryFileResult<DownloadData> downloads,
             AuxiliaryFileResult<HashSet<string>> verifiedPackages)
         {
             Downloads = downloads ?? throw new ArgumentNullException(nameof(downloads));
             VerifiedPackages = verifiedPackages ?? throw new ArgumentNullException(nameof(verifiedPackages));
             Metadata = new AuxiliaryFilesMetadata(
+                loaded,
                 Downloads.Metadata,
                 VerifiedPackages.Metadata);
         }
 
-        internal AuxiliaryFileResult<Downloads> Downloads { get; }
+        internal AuxiliaryFileResult<DownloadData> Downloads { get; }
         internal AuxiliaryFileResult<HashSet<string>> VerifiedPackages { get; }
         public AuxiliaryFilesMetadata Metadata { get; }
 
@@ -30,14 +31,14 @@ namespace NuGet.Services.AzureSearch.SearchService
             return VerifiedPackages.Data.Contains(id);
         }
 
-        public int GetTotalDownloadCount(string id)
+        public long GetTotalDownloadCount(string id)
         {
-            return Downloads.Data[id]?.Total ?? 0;
+            return Downloads.Data.GetDownloadCount(id);
         }
 
-        public int GetDownloadCount(string id, string normalizedVersion)
+        public long GetDownloadCount(string id, string normalizedVersion)
         {
-            return Downloads.Data[id]?[normalizedVersion] ?? 0;
+            return Downloads.Data.GetDownloadCount(id, normalizedVersion);
         }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryDataCache.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AuxiliaryDataCache.cs
@@ -8,23 +8,27 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NuGet.Services.AzureSearch.AuxiliaryFiles;
+using NuGetGallery;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
     public class AuxiliaryDataCache : IAuxiliaryDataCache
     {
         private readonly SemaphoreSlim _lock = new SemaphoreSlim(1);
-        private readonly IAuxiliaryFileClient _client;
+        private readonly IDownloadDataClient _downloadDataClient;
+        private readonly IVerifiedPackagesDataClient _verifiedPackagesDataClient;
         private readonly IAzureSearchTelemetryService _telemetryService;
         private readonly ILogger<AuxiliaryDataCache> _logger;
         private AuxiliaryData _data;
 
         public AuxiliaryDataCache(
-            IAuxiliaryFileClient client,
+            IDownloadDataClient downloadDataClient,
+            IVerifiedPackagesDataClient verifiedPackagesDataClient,
             IAzureSearchTelemetryService telemetryService,
             ILogger<AuxiliaryDataCache> logger)
         {
-            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _downloadDataClient = downloadDataClient ?? throw new ArgumentNullException(nameof(downloadDataClient));
+            _verifiedPackagesDataClient = verifiedPackagesDataClient ?? throw new ArgumentNullException(nameof(verifiedPackagesDataClient));
             _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
@@ -68,8 +72,8 @@ namespace NuGet.Services.AzureSearch.SearchService
                     // Load the auxiliary files in parallel.
                     const string downloadsName = nameof(_data.Downloads);
                     const string verifiedPackagesName = nameof(_data.VerifiedPackages);
-                    var downloadsTask = LoadAsync(_data?.Downloads, _client.LoadDownloadsAsync);
-                    var verifiedPackagesTask = LoadAsync(_data?.VerifiedPackages, _client.LoadVerifiedPackagesAsync);
+                    var downloadsTask = LoadAsync(_data?.Downloads, _downloadDataClient.ReadLatestIndexedAsync);
+                    var verifiedPackagesTask = LoadAsync(_data?.VerifiedPackages, _verifiedPackagesDataClient.ReadLatestAsync);
                     await Task.WhenAll(downloadsTask, verifiedPackagesTask);
                     var downloads = await downloadsTask;
                     var verifiedPackages = await verifiedPackagesTask;
@@ -81,7 +85,10 @@ namespace NuGet.Services.AzureSearch.SearchService
                     (ReferenceEquals(_data?.VerifiedPackages, verifiedPackages) ? notModifiedNames : reloadedNames).Add(verifiedPackagesName);
 
                     // Reference assignment is atomic, so this is what makes the data available for readers.
-                    _data = new AuxiliaryData(downloads, verifiedPackages);
+                    _data = new AuxiliaryData(
+                        DateTimeOffset.UtcNow,
+                        downloads,
+                        verifiedPackages);
 
                     stopwatch.Stop();
                     _telemetryService.TrackAuxiliaryFilesReload(reloadedNames, notModifiedNames, stopwatch.Elapsed);
@@ -103,18 +110,28 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         private async Task<AuxiliaryFileResult<T>> LoadAsync<T>(
             AuxiliaryFileResult<T> previousResult,
-            Func<string, Task<AuxiliaryFileResult<T>>> getResult) where T : class
+            Func<IAccessCondition, Task<AuxiliaryFileResult<T>>> getResult) where T : class
         {
             await Task.Yield();
-            var inputETag = previousResult?.Metadata.ETag;
-            var newResult = await getResult(inputETag);
-            if (newResult.NotModified)
+
+            IAccessCondition accessCondition;
+            if (previousResult == null)
             {
-                return previousResult;
+                accessCondition = AccessConditionWrapper.GenerateEmptyCondition();
             }
             else
             {
+                accessCondition = AccessConditionWrapper.GenerateIfNoneMatchCondition(previousResult.Metadata.ETag);
+            }
+
+            var newResult = await getResult(accessCondition);
+            if (newResult.Modified)
+            {
                 return newResult;
+            }
+            else
+            {
+                return previousResult;
             }
         }
 

--- a/src/NuGet.Services.AzureSearch/SearchService/IAuxiliaryData.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IAuxiliaryData.cs
@@ -6,8 +6,8 @@ namespace NuGet.Services.AzureSearch.SearchService
     public interface IAuxiliaryData
     {
         AuxiliaryFilesMetadata Metadata { get; }
-        int GetDownloadCount(string id, string normalizedVersion);
-        int GetTotalDownloadCount(string id);
+        long GetDownloadCount(string id, string normalizedVersion);
+        long GetTotalDownloadCount(string id);
         bool IsVerified(string id);
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/AuxiliaryFilesMetadata.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/AuxiliaryFilesMetadata.cs
@@ -10,12 +10,17 @@ namespace NuGet.Services.AzureSearch.SearchService
     public class AuxiliaryFilesMetadata
     {
         [JsonConstructor]
-        public AuxiliaryFilesMetadata(AuxiliaryFileMetadata downloads, AuxiliaryFileMetadata verifiedPackages)
+        public AuxiliaryFilesMetadata(
+            DateTimeOffset loaded,
+            AuxiliaryFileMetadata downloads,
+            AuxiliaryFileMetadata verifiedPackages)
         {
+            Loaded = loaded;
             Downloads = downloads ?? throw new ArgumentNullException(nameof(downloads));
             VerifiedPackages = verifiedPackages ?? throw new ArgumentNullException(nameof(verifiedPackages));
         }
 
+        public DateTimeOffset Loaded { get; }
         public AuxiliaryFileMetadata Downloads { get; }
         public AuxiliaryFileMetadata VerifiedPackages { get; }
     }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
@@ -2,20 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using NuGet.Services.AzureSearch.AuxiliaryFiles;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
-    public class SearchServiceConfiguration : AzureSearchConfiguration, IAuxiliaryDataStorageConfiguration
+    public class SearchServiceConfiguration : AzureSearchConfiguration
     {
         public float MatchAllTermsBoost { get; set; } = 3;
         public string SemVer1RegistrationsBaseUrl { get; set; }
         public string SemVer2RegistrationsBaseUrl { get; set; }
-        public string AuxiliaryDataStorageConnectionString { get; set; }
-        public string AuxiliaryDataStorageContainer { get; set; }
-        public string AuxiliaryDataStorageDownloadsPath { get; set; }
-        public string AuxiliaryDataStorageVerifiedPackagesPath { get; set; }
-        public string AuxiliaryDataStorageExcludedPackagesPath { get; set; }
         public TimeSpan AuxiliaryDataReloadFrequency { get; set; } = TimeSpan.FromHours(1);
         public TimeSpan AuxiliaryDataReloadFailureRetryFrequency { get; set; } = TimeSpan.FromSeconds(30);
         public TimeSpan SecretRefreshFrequency { get; set; } = TimeSpan.FromHours(12);

--- a/src/NuGet.Services.SearchService/App_Start/WebApiConfig.cs
+++ b/src/NuGet.Services.SearchService/App_Start/WebApiConfig.cs
@@ -21,7 +21,6 @@ using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using NuGet.Services.AzureSearch;
-using NuGet.Services.AzureSearch.AuxiliaryFiles;
 using NuGet.Services.AzureSearch.SearchService;
 using NuGet.Services.Configuration;
 using NuGet.Services.KeyVault;
@@ -133,8 +132,6 @@ namespace NuGet.Services.SearchService
             services.Add(ServiceDescriptor.Scoped(typeof(IOptionsSnapshot<>), typeof(NonCachingOptionsSnapshot<>)));
             services.Configure<AzureSearchConfiguration>(configuration.Root.GetSection(ConfigurationSectionName));
             services.Configure<SearchServiceConfiguration>(configuration.Root.GetSection(ConfigurationSectionName));
-            services.AddScoped<IOptionsSnapshot<IAuxiliaryDataStorageConfiguration>>(
-                p => p.GetRequiredService<IOptionsSnapshot<SearchServiceConfiguration>>());
             services.AddAzureSearch();
             services.AddSingleton(new TelemetryClient());
             services.AddTransient<ITelemetryClient, TelemetryClientWrapper>();

--- a/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommandFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommandFacts.cs
@@ -35,7 +35,9 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
 
                 VerifyCompletedTelemetry(JobOutcome.Success);
                 VerifiedPackagesDataClient.Verify(
-                    x => x.ReplaceLatestAsync(NewVerifiedPackagesData, OldVerifiedPackagesResult.AccessCondition),
+                    x => x.ReplaceLatestAsync(
+                        NewVerifiedPackagesData,
+                        It.Is<IAccessCondition>(a => a.IfMatchETag == OldVerifiedPackagesResult.Metadata.ETag)),
                     Times.Once);
             }
 
@@ -48,7 +50,9 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
 
                 VerifyCompletedTelemetry(JobOutcome.Success);
                 VerifiedPackagesDataClient.Verify(
-                    x => x.ReplaceLatestAsync(NewVerifiedPackagesData, OldVerifiedPackagesResult.AccessCondition),
+                    x => x.ReplaceLatestAsync(
+                        NewVerifiedPackagesData,
+                        It.Is<IAccessCondition>(a => a.IfMatchETag == OldVerifiedPackagesResult.Metadata.ETag)),
                     Times.Once);
             }
 
@@ -121,7 +125,9 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
                 BatchPusher.Verify(x => x.PushFullBatchesAsync(), Times.Never);
                 SystemTime.Verify(x => x.Delay(It.IsAny<TimeSpan>()), Times.Exactly(expectedPushes - 1));
                 DownloadDataClient.Verify(
-                    x => x.ReplaceLatestIndexedAsync(NewDownloadData, OldDownloadResult.AccessCondition),
+                    x => x.ReplaceLatestIndexedAsync(
+                        NewDownloadData,
+                        It.Is<IAccessCondition>(a => a.IfMatchETag == OldDownloadResult.Metadata.ETag)),
                     Times.Once);
 
                 Assert.Equal(
@@ -163,7 +169,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
             {
                 var expected = new InvalidOperationException("Something bad!");
                 DownloadDataClient
-                    .Setup(x => x.ReadLatestIndexedAsync())
+                    .Setup(x => x.ReadLatestIndexedAsync(It.IsAny<IAccessCondition>()))
                     .ThrowsAsync(expected);
 
                 var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => Target.ExecuteAsync());
@@ -219,25 +225,20 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
                 Options.Setup(x => x.Value).Returns(() => Config);
 
                 OldDownloadData = new DownloadData();
-                OldDownloadResult = new ResultAndAccessCondition<DownloadData>(OldDownloadData, Mock.Of<IAccessCondition>());
-                DownloadDataClient.Setup(x => x.ReadLatestIndexedAsync()).ReturnsAsync(() => OldDownloadResult);
+                OldDownloadResult = Data.GetAuxiliaryFileResult(OldDownloadData, "download-data-etag");
+                DownloadDataClient
+                    .Setup(x => x.ReadLatestIndexedAsync(It.IsAny<IAccessCondition>()))
+                    .ReturnsAsync(() => OldDownloadResult);
                 NewDownloadData = new DownloadData();
                 AuxiliaryFileClient.Setup(x => x.LoadDownloadDataAsync()).ReturnsAsync(() => NewDownloadData);
 
                 OldVerifiedPackagesData = new HashSet<string>();
-                OldVerifiedPackagesResult = new ResultAndAccessCondition<HashSet<string>>(OldVerifiedPackagesData, Mock.Of<IAccessCondition>());
-                VerifiedPackagesDataClient.Setup(x => x.ReadLatestAsync()).ReturnsAsync(() => OldVerifiedPackagesResult);
+                OldVerifiedPackagesResult = Data.GetAuxiliaryFileResult(OldVerifiedPackagesData, "verified-packages-etag");
+                VerifiedPackagesDataClient
+                    .Setup(x => x.ReadLatestAsync(It.IsAny<IAccessCondition>()))
+                    .ReturnsAsync(() => OldVerifiedPackagesResult);
                 NewVerifiedPackagesData = new HashSet<string>();
-                NewVerifiedPackagesResult = new AuxiliaryFileResult<HashSet<string>>(
-                    notModified: false,
-                    data: NewVerifiedPackagesData,
-                    metadata: new AuxiliaryFileMetadata(
-                        DateTimeOffset.MinValue,
-                        DateTimeOffset.MinValue,
-                        TimeSpan.Zero,
-                        fileSize: 0,
-                        etag: "etag"));
-                AuxiliaryFileClient.Setup(x => x.LoadVerifiedPackagesAsync(It.IsAny<string>())).ReturnsAsync(() => NewVerifiedPackagesResult);
+                AuxiliaryFileClient.Setup(x => x.LoadVerifiedPackagesAsync()).ReturnsAsync(() => NewVerifiedPackagesData);
 
                 Changes = new SortedDictionary<string, long>();
                 DownloadSetComparer
@@ -307,7 +308,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
             public RecordingLogger<Auxiliary2AzureSearchCommand> Logger { get; }
             public Auxiliary2AzureSearchConfiguration Config { get; }
             public DownloadData OldDownloadData { get; }
-            public ResultAndAccessCondition<DownloadData> OldDownloadResult { get; }
+            public AuxiliaryFileResult<DownloadData> OldDownloadResult { get; }
             public DownloadData NewDownloadData { get; }
             public SortedDictionary<string, long> Changes { get; }
             public Auxiliary2AzureSearchCommand Target { get; }
@@ -317,9 +318,8 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
             public ConcurrentBag<IndexActions> CurrentBatch { get; set; }
             public ConcurrentBag<List<IndexActions>> FinishedBatches { get; }
             public HashSet<string> OldVerifiedPackagesData { get; }
-            public ResultAndAccessCondition<HashSet<string>> OldVerifiedPackagesResult { get; }
+            public AuxiliaryFileResult<HashSet<string>> OldVerifiedPackagesResult { get; }
             public HashSet<string> NewVerifiedPackagesData { get; }
-            public AuxiliaryFileResult<HashSet<string>> NewVerifiedPackagesResult { get; }
 
             public void VerifyCompletedTelemetry(JobOutcome outcome)
             {

--- a/tests/NuGet.Services.AzureSearch.Tests/AuxiliaryFiles/DownloadDataClientFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/AuxiliaryFiles/DownloadDataClientFacts.cs
@@ -37,29 +37,49 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
                     .Setup(x => x.OpenReadAsync(It.IsAny<AccessCondition>()))
                     .ReturnsAsync(() => new MemoryStream(Encoding.UTF8.GetBytes(json)));
 
-                var output = await Target.ReadLatestIndexedAsync();
+                var output = await Target.ReadLatestIndexedAsync(AccessCondition.Object);
 
-                Assert.Empty(output.Result);
-                Assert.Equal(ETag, output.AccessCondition.IfMatchETag);
+                Assert.True(output.Modified);
+                Assert.Empty(output.Data);
+                Assert.Equal(ETag, output.Metadata.ETag);
             }
 
             [Fact]
-            public async Task AllowsMissingBlob()
+            public async Task AllowsNotModifiedBlob()
             {
                 CloudBlob
                     .Setup(x => x.OpenReadAsync(It.IsAny<AccessCondition>()))
                     .ThrowsAsync(new StorageException(
                         new RequestResult
                         {
-                            HttpStatusCode = (int)HttpStatusCode.NotFound,
+                            HttpStatusCode = (int)HttpStatusCode.NotModified,
                         },
-                        message: "Not found.",
+                        message: "Not modified.",
                         inner: null));
 
-                var output = await Target.ReadLatestIndexedAsync();
+                var output = await Target.ReadLatestIndexedAsync(AccessCondition.Object);
 
-                Assert.Empty(output.Result);
-                Assert.Equal("*", output.AccessCondition.IfNoneMatchETag);
+                Assert.False(output.Modified);
+                Assert.Null(output.Data);
+                Assert.Null(output.Metadata);
+            }
+
+            [Fact]
+            public async Task RejectsMissingBlob()
+            {
+                var expected = new StorageException(
+                    new RequestResult
+                    {
+                        HttpStatusCode = (int)HttpStatusCode.NotFound,
+                    },
+                    message: "Not found.",
+                    inner: null);
+                CloudBlob
+                    .Setup(x => x.OpenReadAsync(It.IsAny<AccessCondition>()))
+                    .ThrowsAsync(expected);
+
+                var actual = await Assert.ThrowsAsync<StorageException>(() => Target.ReadLatestIndexedAsync(AccessCondition.Object));
+                Assert.Same(actual, expected);
             }
 
             [Fact]
@@ -89,7 +109,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
                     .ReturnsAsync(() => new MemoryStream(Encoding.UTF8.GetBytes(json)));
 
                 var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => Target.ReadLatestIndexedAsync());
+                    () => Target.ReadLatestIndexedAsync(AccessCondition.Object));
                 Assert.Equal("The first token should be the start of an object.", ex.Message);
             }
 
@@ -122,14 +142,15 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
                     .Setup(x => x.OpenReadAsync(It.IsAny<AccessCondition>()))
                     .ReturnsAsync(() => new MemoryStream(Encoding.UTF8.GetBytes(json)));
 
-                var output = await Target.ReadLatestIndexedAsync();
+                var output = await Target.ReadLatestIndexedAsync(AccessCondition.Object);
 
-                Assert.Equal(new[] { "EntityFramework", "nuget.versioning" }, output.Result.Select(x => x.Key).ToArray());
-                Assert.Equal(6, output.Result.GetDownloadCount("NuGet.Versioning"));
-                Assert.Equal(1, output.Result.GetDownloadCount("NuGet.Versioning", "1.0.0"));
-                Assert.Equal(5, output.Result.GetDownloadCount("NuGet.Versioning", "2.0.0-ALPHA"));
-                Assert.Equal(10, output.Result.GetDownloadCount("EntityFramework"));
-                Assert.Equal(ETag, output.AccessCondition.IfMatchETag);
+                Assert.True(output.Modified);
+                Assert.Equal(new[] { "EntityFramework", "nuget.versioning" }, output.Data.Select(x => x.Key).ToArray());
+                Assert.Equal(6, output.Data.GetDownloadCount("NuGet.Versioning"));
+                Assert.Equal(1, output.Data.GetDownloadCount("NuGet.Versioning", "1.0.0"));
+                Assert.Equal(5, output.Data.GetDownloadCount("NuGet.Versioning", "2.0.0-ALPHA"));
+                Assert.Equal(10, output.Data.GetDownloadCount("EntityFramework"));
+                Assert.Equal(ETag, output.Metadata.ETag);
 
                 CloudBlobContainer.Verify(x => x.GetBlobReference("downloads/downloads.v2.json"), Times.Once);
             }

--- a/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/Db2AzureSearchCommandFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/Db2AzureSearchCommandFacts.cs
@@ -91,13 +91,6 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                 .Setup(x => x.DeleteIfExistsAsync())
                 .ReturnsAsync(true);
 
-            var excludedPackagesMetadata = new AuxiliaryFileMetadata(
-                DateTimeOffset.MinValue,
-                DateTimeOffset.MinValue,
-                TimeSpan.Zero,
-                fileSize: 0,
-                etag: string.Empty);
-
             _target = new Db2AzureSearchCommand(
                 _producer.Object,
                 _builder.Object,

--- a/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/NewPackageRegistrationProducerFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/NewPackageRegistrationProducerFacts.cs
@@ -37,9 +37,8 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
             private readonly NewPackageRegistrationProducer _target;
             private readonly Mock<IAuxiliaryFileClient> _auxiliaryFileClient;
             private readonly DownloadData _downloads;
-            private readonly AuxiliaryFileMetadata _metadata;
             private readonly HashSet<string> _verifiedPackages;
-            private readonly HashSet<string> _excludedPackages;
+            private HashSet<string> _excludedPackages;
 
             public ProduceWorkAsync(ITestOutputHelper output)
             {
@@ -57,24 +56,18 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                 _token = CancellationToken.None;
 
                 _auxiliaryFileClient = new Mock<IAuxiliaryFileClient>();
-                _metadata = new AuxiliaryFileMetadata(
-                    DateTimeOffset.MinValue,
-                    DateTimeOffset.MinValue,
-                    TimeSpan.Zero,
-                    fileSize: 0,
-                    etag: string.Empty);
                 _excludedPackages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 _auxiliaryFileClient
-                    .Setup(x => x.LoadExcludedPackagesAsync(It.IsAny<string>()))
-                    .ReturnsAsync(new AuxiliaryFileResult<HashSet<string>>(false, _excludedPackages, _metadata));
+                    .Setup(x => x.LoadExcludedPackagesAsync())
+                    .ReturnsAsync(() => _excludedPackages);
                 _downloads = new DownloadData();
                 _auxiliaryFileClient
                     .Setup(x => x.LoadDownloadDataAsync())
                     .ReturnsAsync(() => _downloads);
                 _verifiedPackages = new HashSet<string>();
                 _auxiliaryFileClient
-                    .Setup(x => x.LoadVerifiedPackagesAsync(It.IsAny<string>()))
-                    .ReturnsAsync(new AuxiliaryFileResult<HashSet<string>>(false, _verifiedPackages, _metadata));
+                    .Setup(x => x.LoadVerifiedPackagesAsync())
+                    .ReturnsAsync(() => _verifiedPackages);
 
                 _entitiesContextFactory
                    .Setup(x => x.CreateAsync(It.IsAny<bool>()))
@@ -314,10 +307,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
 
                 InitializePackagesFromPackageRegistrations();
 
-                var excludedPackages = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "A", "C" };
-                _auxiliaryFileClient
-                    .Setup(x => x.LoadExcludedPackagesAsync(It.IsAny<string>()))
-                    .ReturnsAsync(new AuxiliaryFileResult<HashSet<string>>(false, excludedPackages, _metadata));
+                _excludedPackages = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "A", "C" };
 
                 await _target.ProduceWorkAsync(_work, _token);
 
@@ -325,7 +315,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                 Assert.Equal(4, work.Count);
                 for (int i = 0; i < work.Count; i++)
                 {
-                    var shouldBeExcluded = excludedPackages.Contains(work[i].PackageId, StringComparer.OrdinalIgnoreCase);
+                    var shouldBeExcluded = _excludedPackages.Contains(work[i].PackageId, StringComparer.OrdinalIgnoreCase);
                     Assert.Equal(shouldBeExcluded, work[i].IsExcludedByDefault);
                 }
             }
@@ -354,19 +344,15 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                 Assert.Contains("A", output.Owners.Keys);
                 Assert.Equal(new[] { "OwnerA" }, output.Owners["A"].ToArray());
 
-                _auxiliaryFileClient.Verify(
-                    x => x.LoadExcludedPackagesAsync(null),
-                    Times.Once);
-                _auxiliaryFileClient.Verify(
-                    x => x.LoadVerifiedPackagesAsync(null),
-                    Times.Once);
+                _auxiliaryFileClient.Verify(x => x.LoadExcludedPackagesAsync(), Times.Once);
+                _auxiliaryFileClient.Verify(x => x.LoadVerifiedPackagesAsync(), Times.Once);
             }
 
             [Fact]
             public async Task ThrowsWhenExcludedPackagesIsMissing()
             {
                 _auxiliaryFileClient
-                    .Setup(x => x.LoadExcludedPackagesAsync(null))
+                    .Setup(x => x.LoadExcludedPackagesAsync())
                     .ThrowsAsync(new StorageException(
                         new RequestResult
                         {

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryDataCacheFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/AuxiliaryDataCacheFacts.cs
@@ -7,9 +7,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
-using NuGet.Indexing;
 using NuGet.Services.AzureSearch.AuxiliaryFiles;
 using NuGet.Services.AzureSearch.Support;
+using NuGetGallery;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -42,10 +42,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 await _target.EnsureInitializedAsync();
 
                 Assert.True(_target.Initialized);
-                _client.Verify(x => x.LoadDownloadsAsync(null), Times.Once);
-                _client.Verify(x => x.LoadDownloadsAsync(It.IsAny<string>()), Times.Once);
-                _client.Verify(x => x.LoadVerifiedPackagesAsync(null), Times.Once);
-                _client.Verify(x => x.LoadVerifiedPackagesAsync(It.IsAny<string>()), Times.Once);
+                VerifyReadWithNoETag();
                 var message = Assert.Single(_logger.Messages.Where(x => x.Contains("Done reloading auxiliary data.")));
                 Assert.EndsWith("Not modified: ", message);
                 Assert.Contains("Reloaded: Downloads, VerifiedPackages", message);
@@ -56,25 +53,25 @@ namespace NuGet.Services.AzureSearch.SearchService
             {
                 // Arrange
                 await _target.EnsureInitializedAsync();
-                _client.Invocations.Clear();
+                _downloadDataClient.Invocations.Clear();
+                _verifiedPackagesDataClient.Invocations.Clear();
 
                 // Act
                 await _target.EnsureInitializedAsync();
 
                 // Assert
                 Assert.True(_target.Initialized);
-                _client.Verify(x => x.LoadDownloadsAsync(It.IsAny<string>()), Times.Never);
-                _client.Verify(x => x.LoadVerifiedPackagesAsync(It.IsAny<string>()), Times.Never);
+                VerifyNoRead();
             }
 
             [Fact]
             public async Task DoesNotInitializeAgainWhenCalledDuringInitialize()
             {
                 // Arrange
-                var downloadsTcs = new TaskCompletionSource<AuxiliaryFileResult<Downloads>>();
+                var downloadsTcs = new TaskCompletionSource<AuxiliaryFileResult<DownloadData>>();
                 var startedDownloadTcs = new TaskCompletionSource<bool>();
-                _client
-                    .Setup(x => x.LoadDownloadsAsync(It.IsAny<string>()))
+                _downloadDataClient
+                    .Setup(x => x.ReadLatestIndexedAsync(It.IsAny<IAccessCondition>()))
                     .Returns(async () =>
                     {
                         startedDownloadTcs.TrySetResult(true);
@@ -85,13 +82,12 @@ namespace NuGet.Services.AzureSearch.SearchService
                 // Act
                 var thisTask = _target.EnsureInitializedAsync();
                 await startedDownloadTcs.Task;
-                downloadsTcs.TrySetResult(_downloads);
+                downloadsTcs.TrySetResult(_downloadData);
                 await thisTask;
 
                 // Assert
                 Assert.True(_target.Initialized);
-                _client.Verify(x => x.LoadDownloadsAsync(It.IsAny<string>()), Times.Once);
-                _client.Verify(x => x.LoadVerifiedPackagesAsync(It.IsAny<string>()), Times.Once);
+                VerifyReadWithNoETag();
             }
         }
 
@@ -107,10 +103,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 await _target.TryLoadAsync(_token);
 
                 Assert.True(_target.Initialized);
-                _client.Verify(x => x.LoadDownloadsAsync(null), Times.Once);
-                _client.Verify(x => x.LoadDownloadsAsync(It.IsAny<string>()), Times.Once);
-                _client.Verify(x => x.LoadVerifiedPackagesAsync(null), Times.Once);
-                _client.Verify(x => x.LoadVerifiedPackagesAsync(It.IsAny<string>()), Times.Once);
+                VerifyReadWithNoETag();
             }
 
             [Fact]
@@ -118,17 +111,15 @@ namespace NuGet.Services.AzureSearch.SearchService
             {
                 // Arrange
                 await _target.TryLoadAsync(_token);
-                _client.Invocations.Clear();
+                _downloadDataClient.Invocations.Clear();
+                _verifiedPackagesDataClient.Invocations.Clear();
 
                 // Act
                 await _target.TryLoadAsync(_token);
 
                 // Assert
                 Assert.True(_target.Initialized);
-                _client.Verify(x => x.LoadDownloadsAsync("downloads-etag"), Times.Once);
-                _client.Verify(x => x.LoadDownloadsAsync(It.IsAny<string>()), Times.Once);
-                _client.Verify(x => x.LoadVerifiedPackagesAsync("verified-packages-etag"), Times.Once);
-                _client.Verify(x => x.LoadVerifiedPackagesAsync(It.IsAny<string>()), Times.Once);
+                VerifyReadWithETag();
             }
         }
 
@@ -155,58 +146,73 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 Assert.True(_target.Initialized);
                 Assert.NotNull(value);
-                Assert.Same(_downloads.Metadata, value.Metadata.Downloads);
+                Assert.Same(_downloadData.Metadata, value.Metadata.Downloads);
                 Assert.Same(_verifiedPackages.Metadata, value.Metadata.VerifiedPackages);
             }
         }
 
         public abstract class BaseFacts
         {
-            protected readonly Mock<IAuxiliaryFileClient> _client;
+            protected readonly Mock<IDownloadDataClient> _downloadDataClient;
+            protected readonly Mock<IVerifiedPackagesDataClient> _verifiedPackagesDataClient;
             protected readonly Mock<IAzureSearchTelemetryService> _telemetryService;
             protected readonly RecordingLogger<AuxiliaryDataCache> _logger;
             protected readonly CancellationToken _token;
-            protected readonly AuxiliaryFileResult<Downloads> _downloads;
+            protected readonly AuxiliaryFileResult<DownloadData> _downloadData;
             protected readonly AuxiliaryFileResult<HashSet<string>> _verifiedPackages;
             protected readonly AuxiliaryDataCache _target;
 
             public BaseFacts(ITestOutputHelper output)
             {
-                _client = new Mock<IAuxiliaryFileClient>();
+                _downloadDataClient = new Mock<IDownloadDataClient>();
+                _verifiedPackagesDataClient = new Mock<IVerifiedPackagesDataClient>();
                 _telemetryService = new Mock<IAzureSearchTelemetryService>();
                 _logger = output.GetLogger<AuxiliaryDataCache>();
 
                 _token = CancellationToken.None;
-                _downloads = new AuxiliaryFileResult<Downloads>(
-                    notModified: false,
-                    data: new Downloads(),
-                    metadata: new AuxiliaryFileMetadata(
-                        lastModified: DateTimeOffset.MinValue,
-                        loaded: DateTimeOffset.MinValue,
-                        loadDuration: TimeSpan.Zero,
-                        fileSize: 0,
-                        etag: "downloads-etag"));
-                _verifiedPackages = new AuxiliaryFileResult<HashSet<string>>(
-                    notModified: false,
-                    data: new HashSet<string>(StringComparer.OrdinalIgnoreCase),
-                    metadata: new AuxiliaryFileMetadata(
-                        lastModified: DateTimeOffset.MinValue,
-                        loaded: DateTimeOffset.MinValue,
-                        loadDuration: TimeSpan.Zero,
-                        fileSize: 0,
-                        etag: "verified-packages-etag"));
+                _downloadData = Data.GetAuxiliaryFileResult(new DownloadData(), "downloads-etag");
+                _verifiedPackages = Data.GetAuxiliaryFileResult(new HashSet<string>(StringComparer.OrdinalIgnoreCase), "verified-packages-etag");
 
-                _client
-                    .Setup(x => x.LoadDownloadsAsync(It.IsAny<string>()))
-                    .ReturnsAsync(() => _downloads);
-                _client
-                    .Setup(x => x.LoadVerifiedPackagesAsync(It.IsAny<string>()))
+                _downloadDataClient
+                    .Setup(x => x.ReadLatestIndexedAsync(It.IsAny<IAccessCondition>()))
+                    .ReturnsAsync(() => _downloadData);
+                _verifiedPackagesDataClient
+                    .Setup(x => x.ReadLatestAsync(It.IsAny<IAccessCondition>()))
                     .ReturnsAsync(() => _verifiedPackages);
 
                 _target = new AuxiliaryDataCache(
-                    _client.Object,
+                    _downloadDataClient.Object,
+                    _verifiedPackagesDataClient.Object,
                     _telemetryService.Object,
                     _logger);
+            }
+
+            public void VerifyReadWithNoETag()
+            {
+                VerifyReadWithETags(null, null);
+            }
+
+            public void VerifyReadWithETag()
+            {
+                VerifyReadWithETags(_downloadData.Metadata.ETag, _verifiedPackages.Metadata.ETag);
+            }
+
+            private void VerifyReadWithETags(string downloadETag, string verifiedPackagesETag)
+            {
+                _downloadDataClient.Verify(
+                    x => x.ReadLatestIndexedAsync(It.Is<IAccessCondition>(a => a.IfMatchETag == null && a.IfNoneMatchETag == downloadETag)),
+                    Times.Once);
+                _downloadDataClient.Verify(x => x.ReadLatestIndexedAsync(It.IsAny<IAccessCondition>()), Times.Once);
+                _verifiedPackagesDataClient.Verify(x => x.ReadLatestAsync(
+                    It.Is<IAccessCondition>(a => a.IfMatchETag == null && a.IfNoneMatchETag == verifiedPackagesETag)),
+                    Times.Once);
+                _verifiedPackagesDataClient.Verify(x => x.ReadLatestAsync(It.IsAny<IAccessCondition>()), Times.Once);
+            }
+
+            public void VerifyNoRead()
+            {
+                _downloadDataClient.Verify(x => x.ReadLatestIndexedAsync(It.IsAny<IAccessCondition>()), Times.Never);
+                _verifiedPackagesDataClient.Verify(x => x.ReadLatestAsync(It.IsAny<IAccessCondition>()), Times.Never);
             }
         }
     }

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -161,16 +161,15 @@ namespace NuGet.Services.AzureSearch.SearchService
   },
   ""QueryDuration"": ""00:00:00.2500000"",
   ""AuxiliaryFilesMetadata"": {
+    ""Loaded"": ""2019-01-03T11:00:00+00:00"",
     ""Downloads"": {
       ""LastModified"": ""2019-01-01T11:00:00+00:00"",
-      ""Loaded"": ""2019-01-01T12:00:00+00:00"",
       ""LoadDuration"": ""00:00:15"",
       ""FileSize"": 1234,
       ""ETag"": ""\""etag-a\""""
     },
     ""VerifiedPackages"": {
       ""LastModified"": ""2019-01-02T11:00:00+00:00"",
-      ""Loaded"": ""2019-01-02T12:00:00+00:00"",
       ""LoadDuration"": ""00:00:30"",
       ""FileSize"": 5678,
       ""ETag"": ""\""etag-b\""""
@@ -337,16 +336,15 @@ namespace NuGet.Services.AzureSearch.SearchService
   },
   ""QueryDuration"": ""00:00:00.2500000"",
   ""AuxiliaryFilesMetadata"": {
+    ""Loaded"": ""2019-01-03T11:00:00+00:00"",
     ""Downloads"": {
       ""LastModified"": ""2019-01-01T11:00:00+00:00"",
-      ""Loaded"": ""2019-01-01T12:00:00+00:00"",
       ""LoadDuration"": ""00:00:15"",
       ""FileSize"": 1234,
       ""ETag"": ""\""etag-a\""""
     },
     ""VerifiedPackages"": {
       ""LastModified"": ""2019-01-02T11:00:00+00:00"",
-      ""Loaded"": ""2019-01-02T12:00:00+00:00"",
       ""LoadDuration"": ""00:00:30"",
       ""FileSize"": 5678,
       ""ETag"": ""\""etag-b\""""
@@ -542,16 +540,15 @@ namespace NuGet.Services.AzureSearch.SearchService
   },
   ""QueryDuration"": ""00:00:00.2500000"",
   ""AuxiliaryFilesMetadata"": {
+    ""Loaded"": ""2019-01-03T11:00:00+00:00"",
     ""Downloads"": {
       ""LastModified"": ""2019-01-01T11:00:00+00:00"",
-      ""Loaded"": ""2019-01-01T12:00:00+00:00"",
       ""LoadDuration"": ""00:00:15"",
       ""FileSize"": 1234,
       ""ETag"": ""\""etag-a\""""
     },
     ""VerifiedPackages"": {
       ""LastModified"": ""2019-01-02T11:00:00+00:00"",
-      ""Loaded"": ""2019-01-02T12:00:00+00:00"",
       ""LoadDuration"": ""00:00:30"",
       ""FileSize"": 5678,
       ""ETag"": ""\""etag-b\""""
@@ -666,16 +663,15 @@ namespace NuGet.Services.AzureSearch.SearchService
   ""DocumentKey"": ""windowsazure_storage-d2luZG93c2F6dXJlLnN0b3JhZ2U1-IncludePrereleaseAndSemVer2"",
   ""QueryDuration"": ""00:00:00.2500000"",
   ""AuxiliaryFilesMetadata"": {
+    ""Loaded"": ""2019-01-03T11:00:00+00:00"",
     ""Downloads"": {
       ""LastModified"": ""2019-01-01T11:00:00+00:00"",
-      ""Loaded"": ""2019-01-01T12:00:00+00:00"",
       ""LoadDuration"": ""00:00:15"",
       ""FileSize"": 1234,
       ""ETag"": ""\""etag-a\""""
     },
     ""VerifiedPackages"": {
       ""LastModified"": ""2019-01-02T11:00:00+00:00"",
-      ""Loaded"": ""2019-01-02T12:00:00+00:00"",
       ""LoadDuration"": ""00:00:30"",
       ""FileSize"": 5678,
       ""ETag"": ""\""etag-b\""""
@@ -1023,15 +1019,14 @@ namespace NuGet.Services.AzureSearch.SearchService
                 _options = new Mock<IOptionsSnapshot<SearchServiceConfiguration>>();
                 _options.Setup(x => x.Value).Returns(() => _config);
                 _auxiliaryMetadata = new AuxiliaryFilesMetadata(
+                    new DateTimeOffset(2019, 1, 3, 11, 0, 0, TimeSpan.Zero),
                     new AuxiliaryFileMetadata(
                         new DateTimeOffset(2019, 1, 1, 11, 0, 0, TimeSpan.Zero),
-                        new DateTimeOffset(2019, 1, 1, 12, 0, 0, TimeSpan.Zero),
                         TimeSpan.FromSeconds(15),
                         1234,
                         "\"etag-a\""),
                     new AuxiliaryFileMetadata(
                         new DateTimeOffset(2019, 1, 2, 11, 0, 0, TimeSpan.Zero),
-                        new DateTimeOffset(2019, 1, 2, 12, 0, 0, TimeSpan.Zero),
                         TimeSpan.FromSeconds(30),
                         5678,
                         "\"etag-b\""));

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchStatusServiceFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchStatusServiceFacts.cs
@@ -237,14 +237,13 @@ namespace NuGet.Services.AzureSearch.SearchService
                 _logger = output.GetLogger<SearchStatusService>();
 
                 _auxiliaryFilesMetadata = new AuxiliaryFilesMetadata(
+                    DateTimeOffset.MinValue,
                     new AuxiliaryFileMetadata(
-                        DateTimeOffset.MinValue,
                         DateTimeOffset.MinValue,
                         TimeSpan.Zero,
                         0,
                         string.Empty),
                     new AuxiliaryFileMetadata(
-                        DateTimeOffset.MinValue,
                         DateTimeOffset.MinValue,
                         TimeSpan.Zero,
                         0,

--- a/tests/NuGet.Services.AzureSearch.Tests/Support/Data.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Support/Data.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Microsoft.Extensions.Options;
 using Moq;
 using NuGet.Protocol.Catalog;
+using NuGet.Services.AzureSearch.AuxiliaryFiles;
 using NuGet.Services.Entities;
 using NuGet.Versioning;
 using NuGetGallery;
@@ -186,5 +187,19 @@ namespace NuGet.Services.AzureSearch.Support
             Title = "Windows Azure Storage",
             VerbatimVersion = "7.1.2.0-alpha+git",
         };
+
+        public static AuxiliaryFileMetadata GetAuxiliaryFileMetadata(string etag) => new AuxiliaryFileMetadata(
+            DateTimeOffset.MinValue,
+            TimeSpan.Zero,
+            fileSize: 0,
+            etag: etag);
+
+        public static AuxiliaryFileResult<T> GetAuxiliaryFileResult<T>(T data, string etag) where T : class
+        {
+            return new AuxiliaryFileResult<T>(
+                modified: true,
+                data: data,
+                metadata: GetAuxiliaryFileMetadata(etag));
+        }
     }
 }


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/2635

The goal of this PR is to make Azure Search Service read auxiliary data from the local (region-wise) storage account instead of from the shared (USNC) auxiliary data storage account. These files are kept up to date in the local storage account via Auxiliary2AzureSearch.

Some significant model changes were necessary so that the `AuxiliaryFileMetadata` is returned for the downloads.v2.json file and the verified packages file. This metadata is like "last modified" and "file size" blob details which are displayed on the `/search/diag` page.

This change requires a configuration update for Azure Search Service so that it has the connection string for the local storage account. I have a PR out for that in NuGetDeployment internal repo.

There will be subsequent PRs: 

1. Move from `SortedDictionary` to `Dictionary` in `DownloadData`
2. Allow the auxiliary reloader to control the lifetime of deduped string instances (big memory win)