### PR TITLE
[Azure Search 2] Use Dictionary instead of SortedDictionary in DownloadData

### DIFF
--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/DownloadByVersionData.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/DownloadByVersionData.cs
@@ -9,8 +9,8 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 {
     public class DownloadByVersionData : IReadOnlyDictionary<string, long>
     {
-        private readonly SortedDictionary<string, long> _versions
-            = new SortedDictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, long> _versions
+            = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
 
         public long Total { get; private set; }
 

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/DownloadData.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/DownloadData.cs
@@ -18,8 +18,8 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
         /// </summary>
         private readonly Dictionary<string, string> _uniqueVersions = new Dictionary<string, string>();
 
-        private readonly SortedDictionary<string, DownloadByVersionData> _ids
-            = new SortedDictionary<string, DownloadByVersionData>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, DownloadByVersionData> _ids
+            = new Dictionary<string, DownloadByVersionData>(StringComparer.OrdinalIgnoreCase);
 
         public long GetDownloadCount(string id)
         {

--- a/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommandFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommandFacts.cs
@@ -193,7 +193,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
                 await Target.ExecuteAsync();
 
                 Assert.Equal(new[] { "ValidId" }, downloadData.Keys.ToArray());
-                Assert.Equal(new[] { "1.0.0-NonNormalized", "1.0.0-ValidVersion" }, downloadData["ValidId"].Keys.ToArray());
+                Assert.Equal(new[] { "1.0.0-NonNormalized", "1.0.0-ValidVersion" }, downloadData["ValidId"].Keys.OrderBy(x => x).ToArray());
                 Assert.Equal(10, downloadData.GetDownloadCount("ValidId"));
                 Assert.Contains("There were 1 invalid IDs, 2 invalid versions, and 1 non-normalized IDs.", Logger.Messages);
             }

--- a/tests/NuGet.Services.AzureSearch.Tests/AuxiliaryFiles/DownloadByVersionDataFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/AuxiliaryFiles/DownloadByVersionDataFacts.cs
@@ -107,14 +107,14 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
         public class EnumerableImplementation : Facts
         {
             [Fact]
-            public void ReturnsVersionsInOrder()
+            public void ReturnsAllVersions()
             {
                 Target.SetDownloadCount(V2, 2);
                 Target.SetDownloadCount(V3, 3);
                 Target.SetDownloadCount(V0, 0);
                 Target.SetDownloadCount(V1Upper, 1);
 
-                var items = Target.ToArray();
+                var items = Target.OrderBy(x => x.Key).ToArray();
 
                 Assert.Equal(
                     new[]

--- a/tests/NuGet.Services.AzureSearch.Tests/AuxiliaryFiles/DownloadDataClientFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/AuxiliaryFiles/DownloadDataClientFacts.cs
@@ -145,7 +145,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
                 var output = await Target.ReadLatestIndexedAsync(AccessCondition.Object);
 
                 Assert.True(output.Modified);
-                Assert.Equal(new[] { "EntityFramework", "nuget.versioning" }, output.Data.Select(x => x.Key).ToArray());
+                Assert.Equal(new[] { "EntityFramework", "nuget.versioning" }, output.Data.Select(x => x.Key).OrderBy(x => x).ToArray());
                 Assert.Equal(6, output.Data.GetDownloadCount("NuGet.Versioning"));
                 Assert.Equal(1, output.Data.GetDownloadCount("NuGet.Versioning", "1.0.0"));
                 Assert.Equal(5, output.Data.GetDownloadCount("NuGet.Versioning", "2.0.0-ALPHA"));
@@ -198,7 +198,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
             }
 
             [Fact]
-            public async Task SerializesInSortedOrder()
+            public async Task Serializes()
             {
                 var newData = new DownloadData();
                 newData.SetDownloadCount("ZZZ", "9.0.0", 23);
@@ -210,9 +210,10 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 
                 await Target.ReplaceLatestIndexedAsync(newData, AccessCondition.Object);
 
-                // Pretty-ify the JSON to make the assertion clearer.
+                // Pretty-ify and sort the JSON to make the assertion clearer.
                 var json = Assert.Single(SavedStrings);
-                json = JsonConvert.DeserializeObject<JObject>(json).ToString();
+                var dictionary = JsonConvert.DeserializeObject<SortedDictionary<string, SortedDictionary<string, int>>>(json);
+                json = JsonConvert.SerializeObject(dictionary, Formatting.Indented);
 
                 Assert.Equal(@"{
   ""EntityFramework"": {


### PR DESCRIPTION
Depends on https://github.com/NuGet/NuGet.Services.Metadata/pull/632.

Dictionary lookup time is O(1) since it is hash-based.
SortedDictionary lookup time is O(log(n)) since it is tree-based.
We want the faster lookup time since this is now used in the Azure Search Service
Progress on https://github.com/NuGet/Engineering/issues/2635

I was previously using `SortedDictionary` so that I could optimize the download count diff code in Auxiliary2AzureSearch. This proved to be unnecessary.