### PR TITLE
[Azure Search 3] Dedupe auxiliary data strings in Azure Search Service

### DIFF
--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/DownloadData.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/DownloadData.cs
@@ -9,15 +9,6 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 {
     public class DownloadData : IReadOnlyDictionary<string, DownloadByVersionData>
     {
-        /// <summary>
-        /// Maintain a lookup of version strings for de-duping. We maintain the original case for de-duping purposes
-        /// by using the default string comparer. As of July of 2019 in PROD, maintaining original case adds less than
-        /// 0.3% extra strings. De-duping version strings in general however removes 87.0% of the string allocations.
-        /// Intuitively this means most people use the same case of a given version string and a lot of people use
-        /// the same versions strings (common ones are 1.0.0, 1.0.1, 1.0.2, 1.1.0, etc).
-        /// </summary>
-        private readonly Dictionary<string, string> _uniqueVersions = new Dictionary<string, string>();
-
         private readonly Dictionary<string, DownloadByVersionData> _ids
             = new Dictionary<string, DownloadByVersionData>(StringComparer.OrdinalIgnoreCase);
 
@@ -59,13 +50,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
                 versions = new DownloadByVersionData();
             }
 
-            if (!_uniqueVersions.TryGetValue(version, out var dedupedVersion))
-            {
-                _uniqueVersions.Add(version, version);
-                dedupedVersion = version;
-            }
-
-            versions.SetDownloadCount(dedupedVersion, downloads);
+            versions.SetDownloadCount(version, downloads);
 
             // Only store the download count if the value is not zero.
             if (versions.Total != 0)

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IDownloadDataClient.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IDownloadDataClient.cs
@@ -8,7 +8,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 {
     public interface IDownloadDataClient
     {
-        Task<AuxiliaryFileResult<DownloadData>> ReadLatestIndexedAsync(IAccessCondition accessCondition);
+        Task<AuxiliaryFileResult<DownloadData>> ReadLatestIndexedAsync(IAccessCondition accessCondition, StringCache stringCache);
         Task ReplaceLatestIndexedAsync(DownloadData newData, IAccessCondition accessCondition);
     }
 }

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IVerifiedPackagesDataClient.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IVerifiedPackagesDataClient.cs
@@ -9,7 +9,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 {
     public interface IVerifiedPackagesDataClient
     {
-        Task<AuxiliaryFileResult<HashSet<string>>> ReadLatestAsync(IAccessCondition accessCondition);
+        Task<AuxiliaryFileResult<HashSet<string>>> ReadLatestAsync(IAccessCondition accessCondition, StringCache stringCache);
         Task ReplaceLatestAsync(HashSet<string> newData, IAccessCondition accessCondition);
     }
 }

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/StringCache.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/StringCache.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace NuGet.Services.AzureSearch.AuxiliaryFiles
+{
+    public class StringCache
+    {
+        /// <summary>
+        /// Maintain a lookup of strings for de-duping. We maintain the original case for de-duping purposes by using
+        /// the default string comparer. As of July of 2019 in PROD, maintaining original case of version
+        /// string adds less than 0.3% extra strings. De-duping version strings in a case-sensitive manner removes
+        /// 87.0% of the string allocations. Intuitively this means most people use the same case of a given version
+        /// string and a lot of people use the same versions strings (common ones are 1.0.0, 1.0.1, 1.0.2, 1.1.0, etc).
+        /// </summary>
+        private readonly ConcurrentDictionary<string, string> _values = new ConcurrentDictionary<string, string>();
+
+        /// <summary>
+        /// Keep track of the number of requests for a string. This is the number of times <see cref="Dedupe(string)"/>
+        /// has been called.
+        /// </summary>
+        private int _requestCount = 0;
+
+        /// <summary>
+        /// Keep track of the number of string de-duped, i.e. "cache hits".
+        /// </summary>
+        private int _hitCount = 0;
+
+        /// <summary>
+        /// Keep track of the number of characters in the cache.
+        /// </summary>
+        private long _charCount = 0;
+
+        public int StringCount => _values.Count;
+        public int RequestCount => _requestCount;
+        public int HitCount => _hitCount;
+        public long CharCount => _charCount;
+
+        public string Dedupe(string value)
+        {
+            Interlocked.Increment(ref _requestCount);
+
+            if (value == null)
+            {
+                return null;
+            }
+
+            // Inspired by:
+            // https://devblogs.microsoft.com/pfxteam/building-a-custom-getoradd-method-for-concurrentdictionarytkeytvalue/
+            while (true)
+            {
+                if (_values.TryGetValue(value, out var existingValue))
+                {
+                    Interlocked.Increment(ref _hitCount);
+                    return existingValue;
+                }
+
+                if (_values.TryAdd(value, value))
+                {
+                    Interlocked.Add(ref _charCount, value.Length);
+                    return value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Resets <see cref="RequestCount"/> and <see cref="HitCount"/> back to zero.
+        /// </summary>
+        public void ResetCounts()
+        {
+            _requestCount = 0;
+            _hitCount = 0;
+        }
+    }
+}
+

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/VerifiedPackagesDataClient.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/VerifiedPackagesDataClient.cs
@@ -42,7 +42,9 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 
         private ICloudBlobContainer Container => _lazyContainer.Value;
 
-        public async Task<AuxiliaryFileResult<HashSet<string>>> ReadLatestAsync(IAccessCondition accessCondition)
+        public async Task<AuxiliaryFileResult<HashSet<string>>> ReadLatestAsync(
+            IAccessCondition accessCondition,
+            StringCache stringCache)
         {
             var stopwatch = Stopwatch.StartNew();
             var blobName = GetLatestIndexedBlobName();
@@ -57,7 +59,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
             {
                 using (var stream = await blobReference.OpenReadAsync(accessCondition))
                 {
-                    ReadStream(stream, id => data.Add(id));
+                    ReadStream(stream, id => data.Add(stringCache.Dedupe(id)));
                     modified = true;
                     metadata = new AuxiliaryFileMetadata(
                         lastModified: new DateTimeOffset(blobReference.LastModifiedUtc, TimeSpan.Zero),

--- a/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
@@ -389,5 +389,19 @@ namespace NuGet.Services.AzureSearch
                     { "PackageIdCount", packageIdCount.ToString() },
                 });
         }
+
+        public void TrackAuxiliaryFilesStringCache(int stringCount, long charCount, int requestCount, int hitCount)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "AuxiliaryFilesStringCache",
+                1,
+                new Dictionary<string, string>
+                {
+                    { "StringCount", stringCount.ToString() },
+                    { "CharCount", charCount.ToString() },
+                    { "RequestCount", requestCount.ToString() },
+                    { "HitCount", hitCount.ToString() },
+                });
+        }
     }
 }

--- a/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
@@ -51,5 +51,6 @@ namespace NuGet.Services.AzureSearch
         void TrackV2GetDocumentWithHijackIndex(TimeSpan elapsed);
         void TrackReadLatestVerifiedPackages(int? packageIdCount, bool notModified, TimeSpan elapsed);
         IDisposable TrackReplaceLatestVerifiedPackages(int packageIdCount);
+        void TrackAuxiliaryFilesStringCache(int stringCount, long charCount, int requestCount, int hitCount);
     }
 }

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -59,6 +59,7 @@
     <Compile Include="AuxiliaryFiles\IAuxiliaryDataStorageConfiguration.cs" />
     <Compile Include="AuxiliaryFiles\IDownloadDataClient.cs" />
     <Compile Include="AuxiliaryFiles\IVerifiedPackagesDataClient.cs" />
+    <Compile Include="AuxiliaryFiles\StringCache.cs" />
     <Compile Include="AuxiliaryFiles\VerifiedPackagesDataClient.cs" />
     <Compile Include="AzureSearchScoringConfiguration.cs" />
     <Compile Include="BaseDocumentBuilder.cs" />

--- a/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommandFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommandFacts.cs
@@ -169,7 +169,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
             {
                 var expected = new InvalidOperationException("Something bad!");
                 DownloadDataClient
-                    .Setup(x => x.ReadLatestIndexedAsync(It.IsAny<IAccessCondition>()))
+                    .Setup(x => x.ReadLatestIndexedAsync(It.IsAny<IAccessCondition>(), It.IsAny<StringCache>()))
                     .ThrowsAsync(expected);
 
                 var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => Target.ExecuteAsync());
@@ -227,7 +227,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
                 OldDownloadData = new DownloadData();
                 OldDownloadResult = Data.GetAuxiliaryFileResult(OldDownloadData, "download-data-etag");
                 DownloadDataClient
-                    .Setup(x => x.ReadLatestIndexedAsync(It.IsAny<IAccessCondition>()))
+                    .Setup(x => x.ReadLatestIndexedAsync(It.IsAny<IAccessCondition>(), It.IsAny<StringCache>()))
                     .ReturnsAsync(() => OldDownloadResult);
                 NewDownloadData = new DownloadData();
                 AuxiliaryFileClient.Setup(x => x.LoadDownloadDataAsync()).ReturnsAsync(() => NewDownloadData);
@@ -235,7 +235,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
                 OldVerifiedPackagesData = new HashSet<string>();
                 OldVerifiedPackagesResult = Data.GetAuxiliaryFileResult(OldVerifiedPackagesData, "verified-packages-etag");
                 VerifiedPackagesDataClient
-                    .Setup(x => x.ReadLatestAsync(It.IsAny<IAccessCondition>()))
+                    .Setup(x => x.ReadLatestAsync(It.IsAny<IAccessCondition>(), It.IsAny<StringCache>()))
                     .ReturnsAsync(() => OldVerifiedPackagesResult);
                 NewVerifiedPackagesData = new HashSet<string>();
                 AuxiliaryFileClient.Setup(x => x.LoadVerifiedPackagesAsync()).ReturnsAsync(() => NewVerifiedPackagesData);

--- a/tests/NuGet.Services.AzureSearch.Tests/AuxiliaryFiles/DownloadDataFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/AuxiliaryFiles/DownloadDataFacts.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
-using System.Text;
 using Xunit;
 
 namespace NuGet.Services.AzureSearch.AuxiliaryFiles
@@ -103,23 +101,6 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
                 var ex = Assert.Throws<ArgumentOutOfRangeException>(() => Target.SetDownloadCount(IdA, V1, -1));
                 Assert.Contains("The download count must not be negative.", ex.Message);
                 Assert.Equal("downloads", ex.ParamName);
-            }
-
-            [Fact]
-            public void DedupesVersionStrings()
-            {
-                var v1A = new StringBuilder(V1).Append(string.Empty).ToString();
-                var v1B = new StringBuilder(V1).Append(string.Empty).ToString();
-                Assert.NotSame(v1A, v1B);
-
-                Target.SetDownloadCount(IdA, v1A, 1);
-                Target.SetDownloadCount(IdB, v1B, 10);
-
-                var records = Target
-                    .SelectMany(i => i.Value.Select(v => new { Id = i.Key, Version = v.Key, Downloads = v.Key }))
-                    .ToList();
-                Assert.Equal(2, records.Count);
-                Assert.Same(records[0].Version, records[1].Version);
             }
         }
 

--- a/tests/NuGet.Services.AzureSearch.Tests/AuxiliaryFiles/StringCacheFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/AuxiliaryFiles/StringCacheFacts.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Text;
+using Xunit;
+
+namespace NuGet.Services.AzureSearch.AuxiliaryFiles
+{
+    public class StringCacheFacts
+    {
+        public class Dedupe : Facts
+        {
+            [Fact]
+            public void DedupesStrings()
+            {
+                var a1 = MakeString("aaa");
+                var a2 = MakeString("aaa");
+                var a3 = Target.Dedupe(a1);
+
+                var a4 = Target.Dedupe(a2);
+
+                Assert.NotSame(a1, a2);
+                Assert.Same(a1, a3);
+                Assert.Same(a1, a4);
+            }
+            [Fact]
+            public void DedupesCaseSensitively()
+            {
+                var a1 = MakeString("aaa");
+                var a2 = MakeString("AAA");
+
+                var a3 = Target.Dedupe(a2);
+
+                Assert.NotEqual(a1, a3);
+            }
+        }
+
+        public class StringCount : Facts
+        {
+            [Fact]
+            public void CountsUniqueStrings()
+            {
+                Target.Dedupe(MakeString("aaa"));
+                Target.Dedupe(MakeString("bbb"));
+                Target.Dedupe(MakeString("aaa"));
+                Target.Dedupe(MakeString("AAA"));
+
+                Assert.Equal(3, Target.StringCount);
+            }
+        }
+
+        public class RequestCount : Facts
+        {
+            [Fact]
+            public void CountsNumberOfCalls()
+            {
+                Target.Dedupe(MakeString("aaa"));
+                Target.Dedupe(MakeString("bbb"));
+                Target.Dedupe(MakeString("aaa"));
+                Target.Dedupe(MakeString("AAA"));
+
+                Assert.Equal(4, Target.RequestCount);
+            }
+        }
+
+        public class HitCount : Facts
+        {
+            [Fact]
+            public void CountsNumberOfDedupedStrings()
+            {
+                Target.Dedupe(MakeString("aaa"));
+                Target.Dedupe(MakeString("bbb"));
+                Target.Dedupe(MakeString("aaa"));
+                Target.Dedupe(MakeString("AAA"));
+
+                Assert.Equal(1, Target.HitCount);
+            }
+        }
+
+        public class CharCount : Facts
+        {
+            [Fact]
+            public void CountsNumberOfCharactersInDedupedStrings()
+            {
+                Target.Dedupe(MakeString("a"));
+                Target.Dedupe(MakeString("bb"));
+                Target.Dedupe(MakeString("ccc"));
+                Target.Dedupe(MakeString("dddd"));
+                Target.Dedupe(MakeString("a"));
+                Target.Dedupe(MakeString("bb"));
+                Target.Dedupe(MakeString("ccc"));
+                Target.Dedupe(MakeString("dddd"));
+
+                Assert.Equal(10, Target.CharCount);
+            }
+        }
+
+        public class ResetCounts : Facts
+        {
+            [Fact]
+            public void CountsNumberOfDedupedStrings()
+            {
+                Target.Dedupe(MakeString("aaa"));
+                Target.Dedupe(MakeString("bbb"));
+                Target.Dedupe(MakeString("aaa"));
+                Target.Dedupe(MakeString("AAA"));
+
+                Target.ResetCounts();
+
+                Assert.Equal(3, Target.StringCount);
+                Assert.Equal(0, Target.RequestCount);
+                Assert.Equal(0, Target.HitCount);
+                Assert.Equal(9, Target.CharCount);
+            }
+        }
+
+        public class Facts
+        {
+            public Facts()
+            {
+                Target = new StringCache();
+            }
+
+            public StringCache Target { get; }
+
+            /// <summary>
+            /// Make sure there's no funny compile time string de-duping.
+            /// </summary>
+            public string MakeString(string input)
+            {
+                var sb = new StringBuilder();
+                foreach (var c in input)
+                {
+                    sb.Append(c);
+                }
+
+                return sb.ToString();
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/AuxiliaryFiles/VerifiedPackagesDataClientFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/AuxiliaryFiles/VerifiedPackagesDataClientFacts.cs
@@ -36,7 +36,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
                     .Setup(x => x.OpenReadAsync(It.IsAny<AccessCondition>()))
                     .ReturnsAsync(() => new MemoryStream(Encoding.UTF8.GetBytes(json)));
 
-                var output = await Target.ReadLatestAsync(AccessCondition.Object);
+                var output = await Target.ReadLatestAsync(AccessCondition.Object, StringCache);
 
                 Assert.True(output.Modified);
                 Assert.Empty(output.Data);
@@ -56,7 +56,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
                         message: "Not modified.",
                         inner: null));
 
-                var output = await Target.ReadLatestAsync(AccessCondition.Object);
+                var output = await Target.ReadLatestAsync(AccessCondition.Object, StringCache);
 
                 Assert.False(output.Modified);
                 Assert.Null(output.Data);
@@ -77,7 +77,8 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
                     .Setup(x => x.OpenReadAsync(It.IsAny<AccessCondition>()))
                     .ThrowsAsync(expected);
 
-                var actual = await Assert.ThrowsAsync<StorageException>(() => Target.ReadLatestAsync(AccessCondition.Object));
+                var actual = await Assert.ThrowsAsync<StorageException>(
+                    () => Target.ReadLatestAsync(AccessCondition.Object, StringCache));
                 Assert.Same(actual, expected);
             }
 
@@ -95,7 +96,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 
 
                 var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => Target.ReadLatestAsync(AccessCondition.Object));
+                    () => Target.ReadLatestAsync(AccessCondition.Object, StringCache));
                 Assert.Equal("The first token should be the start of an array.", ex.Message);
             }
 
@@ -112,7 +113,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
                     .Setup(x => x.OpenReadAsync(It.IsAny<AccessCondition>()))
                     .ReturnsAsync(() => new MemoryStream(Encoding.UTF8.GetBytes(json)));
 
-                var output = await Target.ReadLatestAsync(AccessCondition.Object);
+                var output = await Target.ReadLatestAsync(AccessCondition.Object, StringCache);
 
                 Assert.True(output.Modified);
                 Assert.Equal(new[] { "EntityFramework", "NuGet.Core", "nuget.versioning" }, output.Data.OrderBy(x => x).ToArray());
@@ -132,7 +133,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
                     .Setup(x => x.OpenReadAsync(It.IsAny<AccessCondition>()))
                     .ReturnsAsync(() => new MemoryStream(Encoding.UTF8.GetBytes(json)));
 
-                var output = await Target.ReadLatestAsync(AccessCondition.Object);
+                var output = await Target.ReadLatestAsync(AccessCondition.Object, StringCache);
 
                 Assert.True(output.Modified);
                 Assert.Single(output.Data);
@@ -228,6 +229,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 
                 ETag = "\"some-etag\"";
                 AccessCondition = new Mock<IAccessCondition>();
+                StringCache = new StringCache();
 
                 Options
                     .Setup(x => x.Value)
@@ -269,6 +271,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
             public AzureSearchConfiguration Config { get; }
             public string ETag { get; }
             public Mock<IAccessCondition> AccessCondition { get; }
+            public StringCache StringCache { get; }
             public VerifiedPackagesDataClient Target { get; }
 
             public List<string> BlobNames { get; } = new List<string>();

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="AuxiliaryFiles\DownloadByVersionDataFacts.cs" />
     <Compile Include="AuxiliaryFiles\DownloadDataClientFacts.cs" />
     <Compile Include="AuxiliaryFiles\DownloadDataFacts.cs" />
+    <Compile Include="AuxiliaryFiles\StringCacheFacts.cs" />
     <Compile Include="AuxiliaryFiles\VerifiedPackagesDataClientFacts.cs" />
     <Compile Include="BaseDocumentBuilderFacts.cs" />
     <Compile Include="BatchPusherFacts.cs" />


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/2635
Depends on https://github.com/NuGet/NuGet.Services.Metadata/pull/633

This saves 87.0% of string allocations due to versions found in the `DownloadData` type from my last test. I am emitting a counter to measure this over time.

The auxiliary file cache used in the Azure Search Service holds on to the string cache as a instance field but since the cache is a singleton in DI, this cache lives forever and will "leak" package IDs that are removed from the data file. This is existing behavior from the auxiliary data file reader but was done with `string.Intern` which _cannot_ be purged. This leak is acceptable because the number of deleted package IDs is very low. In general the number of package IDs in the download data file will always go up since deletes do not propagate to the statistics DB.

We're still ahead memory wise from the previous implementation because we filter out invalid package IDs.