### PR TITLE
[Hotfix] Don't allow skip value over 100k

### DIFF
--- a/src/NuGet.Services.AzureSearch/SearchService/AzureSearchService.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AzureSearchService.cs
@@ -77,6 +77,10 @@ namespace NuGet.Services.AzureSearch.SearchService
                     _telemetryService.TrackV3SearchQuery(result.Duration);
                     break;
 
+                case IndexOperationType.Empty:
+                    output = _responseBuilder.EmptyV3(request);
+                    break;
+
                 default:
                     throw UnsupportedOperation(operation);
             }
@@ -104,6 +108,10 @@ namespace NuGet.Services.AzureSearch.SearchService
                         result.Duration);
 
                     _telemetryService.TrackAutocompleteQuery(result.Duration);
+                    break;
+
+                case IndexOperationType.Empty:
+                    output = _responseBuilder.EmptyAutocomplete(request);
                     break;
 
                 default:
@@ -171,6 +179,10 @@ namespace NuGet.Services.AzureSearch.SearchService
                     _telemetryService.TrackV2SearchQueryWithHijackIndex(result.Duration);
                     break;
 
+                case IndexOperationType.Empty:
+                    output = _responseBuilder.EmptyV2(request);
+                    break;
+
                 default:
                     throw UnsupportedOperation(operation);
             }
@@ -211,6 +223,10 @@ namespace NuGet.Services.AzureSearch.SearchService
                         result.Duration);
 
                     _telemetryService.TrackV2SearchQueryWithSearchIndex(result.Duration);
+                    break;
+
+                case IndexOperationType.Empty:
+                    output = _responseBuilder.EmptyV2(request);
                     break;
 
                 default:

--- a/src/NuGet.Services.AzureSearch/SearchService/ISearchResponseBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/ISearchResponseBuilder.cs
@@ -47,5 +47,8 @@ namespace NuGet.Services.AzureSearch.SearchService
             SearchParameters parameters,
             DocumentSearchResult<SearchDocument.Full> result,
             TimeSpan duration);
+        V2SearchResponse EmptyV2(V2SearchRequest request);
+        V3SearchResponse EmptyV3(V3SearchRequest request);
+        AutocompleteResponse EmptyAutocomplete(AutocompleteRequest request);
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/IndexOperation.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IndexOperation.cs
@@ -59,5 +59,14 @@ namespace NuGet.Services.AzureSearch.SearchService
                 searchText: text,
                 searchParameters: parameters);
         }
+
+        public static IndexOperation Empty()
+        {
+            return new IndexOperation(
+                IndexOperationType.Empty,
+                documentKey: null,
+                searchText: null,
+                searchParameters: null);
+        }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/IndexOperationBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IndexOperationBuilder.cs
@@ -11,6 +11,12 @@ namespace NuGet.Services.AzureSearch.SearchService
 {
     public class IndexOperationBuilder : IIndexOperationBuilder
     {
+        /// <summary>
+        /// Azure Search can only skip up to 100,000 documents.
+        /// https://docs.microsoft.com/en-us/rest/api/searchservice/search-documents#skip-optional
+        /// </summary>
+        private const int MaximumSkip = 100000;
+
         private readonly ISearchTextBuilder _textBuilder;
         private readonly ISearchParametersBuilder _parametersBuilder;
 
@@ -24,6 +30,11 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         public IndexOperation V3Search(V3SearchRequest request)
         {
+            if (request.Skip > MaximumSkip)
+            {
+                return IndexOperation.Empty();
+            }
+
             var parsed = _textBuilder.ParseV3Search(request);
 
             IndexOperation indexOperation;
@@ -39,6 +50,11 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         public IndexOperation V2SearchWithSearchIndex(V2SearchRequest request)
         {
+            if (request.Skip > MaximumSkip)
+            {
+                return IndexOperation.Empty();
+            }
+
             var parsed = _textBuilder.ParseV2Search(request);
 
             IndexOperation indexOperation;
@@ -54,6 +70,11 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         public IndexOperation V2SearchWithHijackIndex(V2SearchRequest request)
         {
+            if (request.Skip > MaximumSkip)
+            {
+                return IndexOperation.Empty();
+            }
+
             var parsed = _textBuilder.ParseV2Search(request);
 
             IndexOperation indexOperation;
@@ -69,6 +90,11 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         public IndexOperation Autocomplete(AutocompleteRequest request)
         {
+            if (request.Skip > MaximumSkip)
+            {
+                return IndexOperation.Empty();
+            }
+
             var text = _textBuilder.Autocomplete(request);
             var parameters = _parametersBuilder.Autocomplete(request, IsEmptySearchQuery(text));
             return IndexOperation.Search(text, parameters);

--- a/src/NuGet.Services.AzureSearch/SearchService/IndexOperationType.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IndexOperationType.cs
@@ -17,5 +17,10 @@ namespace NuGet.Services.AzureSearch.SearchService
         /// https://docs.microsoft.com/en-us/rest/api/searchservice/search-documents
         /// </summary>
         Search,
+
+        /// <summary>
+        /// The request should yield an empty response so no Azure Search query is necessary.
+        /// </summary>
+        Empty,
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/DebugInformation.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/DebugInformation.cs
@@ -15,8 +15,22 @@ namespace NuGet.Services.AzureSearch.SearchService
         public SearchParameters SearchParameters { get; set; }
         public string SearchText { get; set; }
         public object DocumentSearchResult { get; set; }
-        public TimeSpan QueryDuration { get; set; }
+        public TimeSpan? QueryDuration { get; set; }
         public AuxiliaryFilesMetadata AuxiliaryFilesMetadata { get; set; }
+
+        public static DebugInformation CreateFromEmptyOrNull(SearchRequest request)
+        {
+            if (!request.ShowDebug)
+            {
+                return null;
+            }
+
+            return new DebugInformation
+            {
+                SearchRequest = request,
+                IndexOperationType = IndexOperationType.Empty,
+            };
+        }
 
         public static DebugInformation CreateFromSearchOrNull<T>(
             SearchRequest request,

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
@@ -150,11 +150,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 
             return new V3SearchResponse
             {
-                Context = new V3SearchContext
-                {
-                    Vocab = "http://schema.nuget.org/schema#",
-                    Base = registrationsBaseUrl,
-                },
+                Context = GetV3SearchContext(registrationsBaseUrl),
                 TotalHits = result.Count.Value,
                 Data = results
                     .Select(x =>
@@ -209,10 +205,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 
             return new AutocompleteResponse
             {
-                Context = new AutocompleteContext
-                {
-                    Vocab = "http://schema.nuget.org/schema#",
-                },
+                Context = GetAutocompleteContext(),
                 TotalHits = result.Count.Value,
                 Data = data,
                 Debug = DebugInformation.CreateFromSearchOrNull(
@@ -442,6 +435,57 @@ namespace NuGet.Services.AzureSearch.SearchService
             var url = includeSemVer2 ? _options.Value.SemVer2RegistrationsBaseUrl : _options.Value.SemVer1RegistrationsBaseUrl;
 
             return url.TrimEnd('/') + '/';
+        }
+
+        public V2SearchResponse EmptyV2(V2SearchRequest request)
+        {
+            return new V2SearchResponse
+            {
+                TotalHits = 0,
+                Data = new List<V2SearchPackage>(),
+                Debug = DebugInformation.CreateFromEmptyOrNull(request),
+            };
+        }
+
+        public V3SearchResponse EmptyV3(V3SearchRequest request)
+        {
+            var registrationsBaseUrl = GetRegistrationsBaseUrl(request.IncludeSemVer2);
+
+            return new V3SearchResponse
+            {
+                Context = GetV3SearchContext(registrationsBaseUrl),
+                TotalHits = 0,
+                Data = new List<V3SearchPackage>(),
+                Debug = DebugInformation.CreateFromEmptyOrNull(request),
+            };
+        }
+
+        public AutocompleteResponse EmptyAutocomplete(AutocompleteRequest request)
+        {
+            return new AutocompleteResponse
+            {
+                Context = GetAutocompleteContext(),
+                TotalHits = 0,
+                Data = new List<string>(),
+                Debug = DebugInformation.CreateFromEmptyOrNull(request),
+            };
+        }
+
+        private static V3SearchContext GetV3SearchContext(string registrationsBaseUrl)
+        {
+            return new V3SearchContext
+            {
+                Vocab = "http://schema.nuget.org/schema#",
+                Base = registrationsBaseUrl,
+            };
+        }
+
+        private static AutocompleteContext GetAutocompleteContext()
+        {
+            return new AutocompleteContext
+            {
+                Vocab = "http://schema.nuget.org/schema#",
+            };
         }
     }
 }

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -869,6 +869,126 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
         }
 
+        public class EmptyV3 : BaseFacts
+        {
+            [Fact]
+            public void ProducesExpectedResponse()
+            {
+                var response = _target.EmptyV3(_v3Request);
+
+                var actualJson = JsonConvert.SerializeObject(response, _jsonSerializerSettings);
+                Assert.Equal(@"{
+  ""@context"": {
+    ""@vocab"": ""http://schema.nuget.org/schema#"",
+    ""@base"": ""https://example/reg-gz-semver2/""
+  },
+  ""totalHits"": 0,
+  ""data"": []
+}", actualJson);
+            }
+
+            [Fact]
+            public void CanIncludeDebugInformation()
+            {
+                _v3Request.ShowDebug = true;
+
+                var response = _target.EmptyV3(_v3Request);
+
+                Assert.NotNull(response.Debug);
+                var actualJson = JsonConvert.SerializeObject(response.Debug, _jsonSerializerSettings);
+                Assert.Equal(@"{
+  ""SearchRequest"": {
+    ""Skip"": 0,
+    ""Take"": 0,
+    ""IncludePrerelease"": true,
+    ""IncludeSemVer2"": true,
+    ""ShowDebug"": true
+  },
+  ""IndexOperationType"": ""Empty""
+}", actualJson);
+            }
+        }
+
+        public class EmptyV2 : BaseFacts
+        {
+            [Fact]
+            public void ProducesExpectedResponse()
+            {
+                var response = _target.EmptyV2(_v2Request);
+
+                var actualJson = JsonConvert.SerializeObject(response, _jsonSerializerSettings);
+                Assert.Equal(@"{
+  ""totalHits"": 0,
+  ""data"": []
+}", actualJson);
+            }
+
+            [Fact]
+            public void CanIncludeDebugInformation()
+            {
+                _v2Request.ShowDebug = true;
+
+                var response = _target.EmptyV2(_v2Request);
+
+                Assert.NotNull(response.Debug);
+                var actualJson = JsonConvert.SerializeObject(response.Debug, _jsonSerializerSettings);
+                Assert.Equal(@"{
+  ""SearchRequest"": {
+    ""IgnoreFilter"": false,
+    ""CountOnly"": false,
+    ""SortBy"": ""Popularity"",
+    ""LuceneQuery"": false,
+    ""Skip"": 0,
+    ""Take"": 0,
+    ""IncludePrerelease"": true,
+    ""IncludeSemVer2"": true,
+    ""ShowDebug"": true
+  },
+  ""IndexOperationType"": ""Empty""
+}", actualJson);
+            }
+        }
+
+        public class EmptyAutocomplete : BaseFacts
+        {
+            [Fact]
+            public void ProducesExpectedResponse()
+            {
+                var response = _target.EmptyAutocomplete(_autocompleteRequest);
+
+                var actualJson = JsonConvert.SerializeObject(response, _jsonSerializerSettings);
+                Assert.Equal(@"{
+  ""@context"": {
+    ""@vocab"": ""http://schema.nuget.org/schema#""
+  },
+  ""totalHits"": 0,
+  ""data"": []
+}", actualJson);
+            }
+
+            [Fact]
+            public void CanIncludeDebugInformation()
+            {
+                _autocompleteRequest.ShowDebug = true;
+
+                var response = _target.EmptyAutocomplete(_autocompleteRequest);
+
+                Assert.NotNull(response.Debug);
+                var actualJson = JsonConvert.SerializeObject(response.Debug, _jsonSerializerSettings);
+                Assert.Equal(@"{
+  ""SearchRequest"": {
+    ""Type"": ""PackageIds"",
+    ""Skip"": 0,
+    ""Take"": 0,
+    ""IncludePrerelease"": true,
+    ""IncludeSemVer2"": true,
+    ""ShowDebug"": true
+  },
+  ""IndexOperationType"": ""Empty""
+}", actualJson);
+            }
+        }
+
         public abstract class BaseFacts
         {
             protected readonly Mock<IAuxiliaryData> _auxiliaryData;
@@ -1010,6 +1130,5 @@ namespace NuGet.Services.AzureSearch.SearchService
                     _options.Object);
             }
         }
-
     }
 }


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/7466.

Tested:

- nuget.exe list (reduced max to 200)
- VS PM UI against V3 (reduced max to 200)
- VS PM UI against V2 (reduced max to 200)
- gallery (skipped page 5000 then next'ed forward twice)
- ran Azure Search functional tests