### PR TITLE
Don't allow retries or wrap exceptions when pushing to Azure Search

### DIFF
--- a/src/NuGet.Services.AzureSearch/Wrappers/DocumentsOperationsWrapper.cs
+++ b/src/NuGet.Services.AzureSearch/Wrappers/DocumentsOperationsWrapper.cs
@@ -26,10 +26,7 @@ namespace NuGet.Services.AzureSearch.Wrappers
 
         public async Task<DocumentIndexResult> IndexAsync<T>(IndexBatch<T> batch) where T : class
         {
-            return await RetryAsync(
-                nameof(IndexAsync),
-                () => _inner.IndexAsync(batch),
-                allow404: false);
+            return await _inner.IndexAsync(batch);
         }
 
         public async Task<T> GetOrNullAsync<T>(string key) where T : class

--- a/src/NuGet.Services.SearchService/Web.config
+++ b/src/NuGet.Services.SearchService/Web.config
@@ -14,7 +14,7 @@
       <customHeaders>
         <remove name="X-Powered-By"/>
         <add name="Strict-Transport-Security" value="max-age=31536000"/>
-        <add name="X-Content-Type-Options" value="nosniff" />
+        <add name="X-Content-Type-Options" value="nosniff"/>
       </customHeaders>
     </httpProtocol>
     <applicationInitialization>
@@ -76,32 +76,24 @@
         <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="NuGet.Services.Validation.Issues" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.53.0.0" newVersion="2.53.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="NuGet.Services.Validation" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.53.0.0" newVersion="2.53.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="NuGet.Services.Sql" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.53.0.0" newVersion="2.53.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.54.0.0" newVersion="2.54.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Services.Logging" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.53.0.0" newVersion="2.53.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.54.0.0" newVersion="2.54.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.53.0.0" newVersion="2.53.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.54.0.0" newVersion="2.54.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Services.Contracts" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.53.0.0" newVersion="2.53.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.54.0.0" newVersion="2.54.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Services.Configuration" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.53.0.0" newVersion="2.53.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.54.0.0" newVersion="2.54.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Protocol" publicKeyToken="31BF3856AD364E35" culture="neutral"/>


### PR DESCRIPTION
Help the debugging of https://github.com/NuGet/Engineering/issues/2664

This broke the expectation of `BatchPusher`:
https://github.com/NuGet/NuGet.Services.Metadata/blob/c6e3f85d41549d24b7c19d7c21ff740598965a1d/src/NuGet.Services.AzureSearch/BatchPusher.cs#L217-L230

This made debugging harder because the individual failure messages were not logged since they not part of the `Exception` string. `BatchPusher` handles the `IndexBatchException` exception and gives useful logging.