### PR TITLE
Add support for sorting by "created" (for hijack) and use it for tie-breaking in other cases

### DIFF
--- a/src/NuGet.Services.AzureSearch/Models/BaseMetadataDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/BaseMetadataDocument.cs
@@ -18,6 +18,8 @@ namespace NuGet.Services.AzureSearch
         public string Authors { get; set; }
 
         public string Copyright { get; set; }
+
+        [IsSortable]
         public DateTimeOffset? Created { get; set; }
 
         [IsSearchable]

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V2SortBy.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V2SortBy.cs
@@ -6,9 +6,11 @@ namespace NuGet.Services.AzureSearch.SearchService
     public enum V2SortBy
     {
         Popularity,
-        LastEditedDescending,
-        PublishedDescending,
+        LastEditedDesc,
+        PublishedDesc,
         SortableTitleAsc,
         SortableTitleDesc,
+        CreatedAsc,
+        CreatedDesc,
     }
 }

--- a/src/NuGet.Services.SearchService/Controllers/SearchController.cs
+++ b/src/NuGet.Services.SearchService/Controllers/SearchController.cs
@@ -21,10 +21,12 @@ namespace NuGet.Services.SearchService.Controllers
 
         private static readonly IReadOnlyDictionary<string, V2SortBy> SortBy = new Dictionary<string, V2SortBy>(StringComparer.OrdinalIgnoreCase)
         {
-            { "lastEdited", V2SortBy.LastEditedDescending },
-            { "published", V2SortBy.PublishedDescending },
+            { "lastEdited", V2SortBy.LastEditedDesc },
+            { "published", V2SortBy.PublishedDesc },
             { "title-asc", V2SortBy.SortableTitleAsc },
             { "title-desc", V2SortBy.SortableTitleDesc },
+            { "created-asc", V2SortBy.CreatedAsc },
+            { "created-desc", V2SortBy.CreatedDesc },
         };
 
         private readonly IAuxiliaryDataCache _auxiliaryDataCache;

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/V2SearchProtocolTests.cs
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/V2SearchProtocolTests.cs
@@ -516,6 +516,8 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
                 yield return new object[] { "published", (Func<V2SearchResultEntry, object>)((V2SearchResultEntry data) => { return data.Published; }) };
                 yield return new object[] { "title-asc", (Func<V2SearchResultEntry, object>)((V2SearchResultEntry data) => { return data.Title; }), true };
                 yield return new object[] { "title-desc", (Func<V2SearchResultEntry, object>)((V2SearchResultEntry data) => { return data.Title; }) };
+                yield return new object[] { "created-asc", (Func<V2SearchResultEntry, object>)((V2SearchResultEntry data) => { return data.Created; }), true };
+                yield return new object[] { "created-desc", (Func<V2SearchResultEntry, object>)((V2SearchResultEntry data) => { return data.Created; }) };
             }
         }
     }

--- a/tests/NuGet.Services.SearchService.Tests/Controllers/SearchControllerFacts.cs
+++ b/tests/NuGet.Services.SearchService.Tests/Controllers/SearchControllerFacts.cs
@@ -230,14 +230,19 @@ namespace NuGet.Services.SearchService.Controllers
             [InlineData("popularity", V2SortBy.Popularity)]
             [InlineData("POPULARITY", V2SortBy.Popularity)]
             [InlineData(" lastEdited ", V2SortBy.Popularity)]
-            [InlineData("lastEdited", V2SortBy.LastEditedDescending)]
-            [InlineData("LASTEDITED", V2SortBy.LastEditedDescending)]
-            [InlineData("published", V2SortBy.PublishedDescending)]
-            [InlineData("puBLISHed", V2SortBy.PublishedDescending)]
+            [InlineData("lastEdited", V2SortBy.LastEditedDesc)]
+            [InlineData("LASTEDITED", V2SortBy.LastEditedDesc)]
+            [InlineData("published", V2SortBy.PublishedDesc)]
+            [InlineData("puBLISHed", V2SortBy.PublishedDesc)]
             [InlineData("title-asc", V2SortBy.SortableTitleAsc)]
             [InlineData("TITLE-asc", V2SortBy.SortableTitleAsc)]
             [InlineData("title-desc", V2SortBy.SortableTitleDesc)]
             [InlineData("title-DESC", V2SortBy.SortableTitleDesc)]
+            [InlineData("CREATED", V2SortBy.Popularity)]
+            [InlineData("created-asc", V2SortBy.CreatedAsc)]
+            [InlineData("Created-asc", V2SortBy.CreatedAsc)]
+            [InlineData("CREATED-desc", V2SortBy.CreatedDesc)]
+            [InlineData("Created-desc", V2SortBy.CreatedDesc)]
             public async Task ParsesSortBy(string sortBy, V2SortBy expected)
             {
                 await _target.V2SearchAsync(sortBy: sortBy);


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/5432

See https://stackoverflow.com/a/34234258 for more context. This _is not_ expected to fix https://github.com/NuGet/NuGetGallery/issues/7494 since the root cause of that is jitter in the scores themselves.