### PR TITLE
Default search should include cases when isExcludedByDefault is null

### DIFF
--- a/src/NuGet.Services.AzureSearch/SearchService/SearchParametersBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchParametersBuilder.cs
@@ -161,7 +161,10 @@ namespace NuGet.Services.AzureSearch.SearchService
         {
             var filterString = $"{IndexFields.Search.SearchFilters} eq '{DocumentUtilities.GetSearchFilterString(searchFilters)}'";
 
-            filterString += excludePackagesHiddenByDefault ? $" and {IndexFields.Search.IsExcludedByDefault} eq false" : "";
+            if (excludePackagesHiddenByDefault)
+            {
+                filterString += $" and ({IndexFields.Search.IsExcludedByDefault} eq false or {IndexFields.Search.IsExcludedByDefault} eq null)";
+            }
 
             return filterString;
         }

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchParametersBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchParametersBuilderFacts.cs
@@ -61,7 +61,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 Assert.Equal(DefaultOrderBy, output.OrderBy.ToArray());
                 Assert.Equal(0, output.Skip);
                 Assert.Equal(0, output.Top);
-                Assert.Equal("searchFilters eq 'Default' and isExcludedByDefault eq false", output.Filter);
+                Assert.Equal("searchFilters eq 'Default' and (isExcludedByDefault eq false or isExcludedByDefault eq null)", output.Filter);
             }
 
             [Fact]
@@ -235,7 +235,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 Assert.Equal(DefaultOrderBy, output.OrderBy.ToArray());
                 Assert.Equal(0, output.Skip);
                 Assert.Equal(0, output.Top);
-                Assert.Equal("searchFilters eq 'Default' and isExcludedByDefault eq false", output.Filter);
+                Assert.Equal("searchFilters eq 'Default' and (isExcludedByDefault eq false or isExcludedByDefault eq null)", output.Filter);
             }
 
             [Fact]
@@ -324,7 +324,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 Assert.Equal(DefaultOrderBy, output.OrderBy.ToArray());
                 Assert.Equal(0, output.Skip);
                 Assert.Equal(0, output.Top);
-                Assert.Equal("searchFilters eq 'Default' and isExcludedByDefault eq false", output.Filter);
+                Assert.Equal("searchFilters eq 'Default' and (isExcludedByDefault eq false or isExcludedByDefault eq null)", output.Filter);
                 Assert.Single(output.Select);
                 Assert.Equal(IndexFields.PackageId, output.Select[0]);
             }
@@ -342,7 +342,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 Assert.Equal(DefaultOrderBy, output.OrderBy.ToArray());
                 Assert.Equal(0, output.Skip);
                 Assert.Equal(1, output.Top);
-                Assert.Equal("searchFilters eq 'Default' and isExcludedByDefault eq false", output.Filter);
+                Assert.Equal("searchFilters eq 'Default' and (isExcludedByDefault eq false or isExcludedByDefault eq null)", output.Filter);
                 Assert.Single(output.Select);
                 Assert.Equal(IndexFields.Search.Versions, output.Select[0]);
             }


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/7506.

I tried `isExcludedByDefault ne true` but that did not perform as well as this approach.