### PR TITLE
[SDL] Catalog2Dnx uses SHA512 rather than MD5

### DIFF
--- a/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
+++ b/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
@@ -300,6 +300,9 @@
     <PackageReference Include="NuGet.Services.Logging">
       <Version>2.25.0-master-30088</Version>
     </PackageReference>
+    <PackageReference Include="NuGetGallery.Core">
+      <Version>4.4.5-master-39280</Version>
+    </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>
     </PackageReference>

--- a/src/Catalog/Persistence/AzureStorage.cs
+++ b/src/Catalog/Persistence/AzureStorage.cs
@@ -15,6 +15,7 @@ using Microsoft.WindowsAzure.Storage.Blob;
 using Microsoft.WindowsAzure.Storage.DataMovement;
 using Microsoft.WindowsAzure.Storage.RetryPolicies;
 using NuGet.Protocol;
+using NuGetGallery;
 
 namespace NuGet.Services.Metadata.Catalog.Persistence
 {
@@ -389,7 +390,12 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             {
                 if (await source.ExistsAsync())
                 {
-                    return !string.IsNullOrEmpty(source.Properties.ContentMD5) && source.Properties.ContentMD5 == destination.Properties.ContentMD5;
+                    var sourceBlobMetadata = source.Metadata;
+                    var destinationBlobMetadata = destination.Metadata;
+
+                    return ((sourceBlobMetadata != null && sourceBlobMetadata.TryGetValue(CoreConstants.Sha512HashAlgorithmId, out var sourceHashValue)) &&
+                        (destinationBlobMetadata != null && destinationBlobMetadata.TryGetValue(CoreConstants.Sha512HashAlgorithmId, out var destinationHashValue)) &&
+                        sourceHashValue == destinationHashValue);
                 }
                 return true;
             }


### PR DESCRIPTION
Update the corresponding "AreSynchronized" method to use SHA512 for source/destination blob check of Catalog2Dnx. Test coverage is not easy to achieve because of the dependency on the blob itself and SDK. 

Not sure whether this will break anything. Need to fully test it before the merge and the deployment. 
