### PR TITLE
Plumb endpoint into the validator for V3 monitoring job

### DIFF
--- a/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Catalog/PackageHasSignatureValidator.cs
+++ b/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Catalog/PackageHasSignatureValidator.cs
@@ -19,9 +19,10 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
         private readonly ILogger<PackageHasSignatureValidator> _logger;
 
         public PackageHasSignatureValidator(
+            CatalogEndpoint endpoint,
             ValidatorConfiguration config,
             ILogger<PackageHasSignatureValidator> logger)
-            : base(config, logger)
+            : base(endpoint, config, logger)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }

--- a/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/FlatContainer/FlatContainerValidator.cs
+++ b/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/FlatContainer/FlatContainerValidator.cs
@@ -11,8 +11,11 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
     /// </summary>
     public abstract class FlatContainerValidator : Validator<FlatContainerEndpoint>
     {
-        public FlatContainerValidator(ValidatorConfiguration config, ILogger<FlatContainerValidator> logger)
-            : base(config, logger)
+        public FlatContainerValidator(
+            FlatContainerEndpoint endpoint,
+            ValidatorConfiguration config,
+            ILogger<FlatContainerValidator> logger)
+            : base(endpoint, config, logger)
         {
         }
 

--- a/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/FlatContainer/PackageIsRepositorySignedValidator.cs
+++ b/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/FlatContainer/PackageIsRepositorySignedValidator.cs
@@ -16,9 +16,10 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
     public class PackageIsRepositorySignedValidator : FlatContainerValidator
     {
         public PackageIsRepositorySignedValidator(
+            FlatContainerEndpoint endpoint,
             ValidatorConfiguration config,
             ILogger<PackageIsRepositorySignedValidator> logger)
-            : base(config, logger)
+            : base(endpoint, config, logger)
         {
         }
 

--- a/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Registration/RegistrationDeprecationValidator.cs
+++ b/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Registration/RegistrationDeprecationValidator.cs
@@ -14,9 +14,10 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring.Validation.Test.Registratio
     public class RegistrationDeprecationValidator : RegistrationIndexValidator
     {
         public RegistrationDeprecationValidator(
+            RegistrationEndpoint endpoint,
             ValidatorConfiguration config,
             ILogger<RegistrationDeprecationValidator> logger)
-            : base(config, logger)
+            : base(endpoint, config, logger)
         {
         }
 

--- a/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Registration/RegistrationExistsValidator.cs
+++ b/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Registration/RegistrationExistsValidator.cs
@@ -8,8 +8,11 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
 {
     public class RegistrationExistsValidator : RegistrationLeafValidator
     {
-        public RegistrationExistsValidator(ValidatorConfiguration config, ILogger<RegistrationExistsValidator> logger)
-            : base(config, logger)
+        public RegistrationExistsValidator(
+            RegistrationEndpoint endpoint,
+            ValidatorConfiguration config,
+            ILogger<RegistrationExistsValidator> logger)
+            : base(endpoint, config, logger)
         {
         }
 

--- a/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Registration/RegistrationIdValidator.cs
+++ b/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Registration/RegistrationIdValidator.cs
@@ -8,8 +8,11 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
 {
     public class RegistrationIdValidator : RegistrationIndexValidator
     {
-        public RegistrationIdValidator(ValidatorConfiguration config, ILogger<RegistrationIdValidator> logger)
-            : base(config, logger)
+        public RegistrationIdValidator(
+            RegistrationEndpoint endpoint,
+            ValidatorConfiguration config,
+            ILogger<RegistrationIdValidator> logger)
+            : base(endpoint, config, logger)
         {
         }
 

--- a/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Registration/RegistrationIndexValidator.cs
+++ b/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Registration/RegistrationIndexValidator.cs
@@ -9,8 +9,11 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
 {
     public abstract class RegistrationIndexValidator : RegistrationValidator
     {
-        public RegistrationIndexValidator(ValidatorConfiguration config, ILogger<RegistrationIndexValidator> logger)
-            : base(config, logger)
+        public RegistrationIndexValidator(
+            RegistrationEndpoint endpoint,
+            ValidatorConfiguration config,
+            ILogger<RegistrationIndexValidator> logger)
+            : base(endpoint, config, logger)
         {
         }
 

--- a/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Registration/RegistrationLeafValidator.cs
+++ b/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Registration/RegistrationLeafValidator.cs
@@ -11,8 +11,11 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
 {
     public abstract class RegistrationLeafValidator : RegistrationValidator
     {
-        public RegistrationLeafValidator(ValidatorConfiguration config, ILogger<RegistrationLeafValidator> logger)
-            : base(config, logger)
+        public RegistrationLeafValidator(
+            RegistrationEndpoint endpoint,
+            ValidatorConfiguration config,
+            ILogger<RegistrationLeafValidator> logger)
+            : base(endpoint, config, logger)
         {
         }
 

--- a/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Registration/RegistrationListedValidator.cs
+++ b/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Registration/RegistrationListedValidator.cs
@@ -9,9 +9,10 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
     public class RegistrationListedValidator : RegistrationLeafValidator
     {
         public RegistrationListedValidator(
+            RegistrationEndpoint endpoint,
             ValidatorConfiguration config,
             ILogger<RegistrationListedValidator> logger)
-            : base(config, logger)
+            : base(endpoint, config, logger)
         {
         }
 

--- a/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Registration/RegistrationRequireLicenseAcceptanceValidator.cs
+++ b/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Registration/RegistrationRequireLicenseAcceptanceValidator.cs
@@ -9,9 +9,10 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
     public class RegistrationRequireLicenseAcceptanceValidator : RegistrationIndexValidator
     {
         public RegistrationRequireLicenseAcceptanceValidator(
+            RegistrationEndpoint endpoint,
             ValidatorConfiguration config,
             ILogger<RegistrationRequireLicenseAcceptanceValidator> logger)
-            : base(config, logger)
+            : base(endpoint, config, logger)
         {
         }
 

--- a/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Registration/RegistrationValidator.cs
+++ b/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Registration/RegistrationValidator.cs
@@ -7,8 +7,11 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
 {
     public abstract class RegistrationValidator : Validator<RegistrationEndpoint>
     {
-        public RegistrationValidator(ValidatorConfiguration config, ILogger<RegistrationValidator> logger)
-            : base(config, logger)
+        public RegistrationValidator(
+            RegistrationEndpoint endpoint,
+            ValidatorConfiguration config,
+            ILogger<RegistrationValidator> logger)
+            : base(endpoint, config, logger)
         {
         }
     }

--- a/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Registration/RegistrationVersionValidator.cs
+++ b/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Registration/RegistrationVersionValidator.cs
@@ -9,9 +9,10 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
     public class RegistrationVersionValidator : RegistrationIndexValidator
     {
         public RegistrationVersionValidator(
+            RegistrationEndpoint endpoint,
             ValidatorConfiguration config,
             ILogger<RegistrationVersionValidator> logger)
-            : base(config, logger)
+            : base(endpoint, config, logger)
         {
         }
 

--- a/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Validator.cs
+++ b/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Validator.cs
@@ -113,11 +113,14 @@ namespace NuGet.Services.Metadata.Catalog.Monitoring
     /// <summary>
     /// Abstract class with the shared functionality between all <see cref="IValidator{T}"/> implementations.
     /// </summary>
-    public abstract class Validator<T> : Validator, IValidator<T> where T : IEndpoint
+    public abstract class Validator<T> : Validator, IValidator<T> where T : class, IEndpoint
     {
-        protected Validator(ValidatorConfiguration config, ILogger<Validator> logger)
+        protected Validator(T endpoint, ValidatorConfiguration config, ILogger<Validator> logger)
             : base(config, logger)
         {
+            Endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
         }
+
+        public T Endpoint { get; }
     }
 }

--- a/tests/NgTests/Validation/PackageHasSignatureValidatorFacts.cs
+++ b/tests/NgTests/Validation/PackageHasSignatureValidatorFacts.cs
@@ -21,11 +21,25 @@ namespace NgTests.Validation
     {
         public class Constructor
         {
+            private readonly CatalogEndpoint _endpoint;
             private readonly ValidatorConfiguration _configuration;
 
             public Constructor()
             {
+                _endpoint = ValidatorTestUtility.CreateCatalogEndpoint();
                 _configuration = new ValidatorConfiguration(packageBaseAddress: "a", requireRepositorySignature: true);
+            }
+
+            [Fact]
+            public void WhenEndpointIsNull_Throws()
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => new PackageHasSignatureValidator(
+                        endpoint: null,
+                        config: _configuration,
+                        logger: Mock.Of<ILogger<PackageHasSignatureValidator>>()));
+
+                Assert.Equal("endpoint", exception.ParamName);
             }
 
             [Fact]
@@ -33,6 +47,7 @@ namespace NgTests.Validation
             {
                 var exception = Assert.Throws<ArgumentNullException>(
                     () => new PackageHasSignatureValidator(
+                        _endpoint,
                         config: null,
                         logger: Mock.Of<ILogger<PackageHasSignatureValidator>>()));
 
@@ -44,6 +59,7 @@ namespace NgTests.Validation
             {
                 var exception = Assert.Throws<ArgumentNullException>(
                     () => new PackageHasSignatureValidator(
+                        _endpoint,
                         _configuration,
                         logger: null));
 
@@ -301,9 +317,10 @@ namespace NgTests.Validation
 
             protected PackageHasSignatureValidator CreateTarget(bool requireRepositorySignature = true)
             {
+                var endpoint = ValidatorTestUtility.CreateCatalogEndpoint();
                 var config = ValidatorTestUtility.CreateValidatorConfig(requireRepositorySignature: requireRepositorySignature);
 
-                return new PackageHasSignatureValidator(config, _logger.Object);
+                return new PackageHasSignatureValidator(endpoint, config, _logger.Object);
             }
 
             protected void AddCatalogLeaf(string path, CatalogLeaf leaf)

--- a/tests/NgTests/Validation/PackageIsRepositorySignedValidatorFacts.cs
+++ b/tests/NgTests/Validation/PackageIsRepositorySignedValidatorFacts.cs
@@ -23,10 +23,24 @@ namespace NgTests.Validation
         public class Constructor
         {
             private readonly ValidatorConfiguration _configuration;
+            private readonly FlatContainerEndpoint _endpoint;
 
             public Constructor()
             {
+                _endpoint = ValidatorTestUtility.CreateFlatContainerEndpoint();
                 _configuration = new ValidatorConfiguration(packageBaseAddress: "a", requireRepositorySignature: true);
+            }
+
+            [Fact]
+            public void WhenEndpointIsNull_Throws()
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => new PackageIsRepositorySignedValidator(
+                        endpoint: null,
+                        config: _configuration,
+                        logger: Mock.Of<ILogger<PackageIsRepositorySignedValidator>>()));
+
+                Assert.Equal("endpoint", exception.ParamName);
             }
 
             [Fact]
@@ -34,6 +48,7 @@ namespace NgTests.Validation
             {
                 var exception = Assert.Throws<ArgumentNullException>(
                     () => new PackageIsRepositorySignedValidator(
+                        _endpoint,
                         config: null,
                         logger: Mock.Of<ILogger<PackageIsRepositorySignedValidator>>()));
 
@@ -45,6 +60,7 @@ namespace NgTests.Validation
             {
                 var exception = Assert.Throws<ArgumentNullException>(
                     () => new PackageIsRepositorySignedValidator(
+                        _endpoint,
                         _configuration,
                         logger: null));
 
@@ -198,10 +214,11 @@ namespace NgTests.Validation
 
             protected PackageIsRepositorySignedValidator CreateTarget(bool requireRepositorySignature = true)
             {
+                var endpoint = ValidatorTestUtility.CreateFlatContainerEndpoint();
                 var logger = Mock.Of<ILogger<PackageIsRepositorySignedValidator>>();
                 var config = ValidatorTestUtility.CreateValidatorConfig(requireRepositorySignature: requireRepositorySignature);
 
-                return new PackageIsRepositorySignedValidator(config, logger);
+                return new PackageIsRepositorySignedValidator(endpoint, config, logger);
             }
 
             protected ValidationContext CreateValidationContext(string packageResource = null)

--- a/tests/NgTests/Validation/RegistrationDeprecationValidatorTestData.cs
+++ b/tests/NgTests/Validation/RegistrationDeprecationValidatorTestData.cs
@@ -17,9 +17,10 @@ namespace NgTests.Validation
         protected override RegistrationDeprecationValidator CreateValidator(
             ILogger<RegistrationDeprecationValidator> logger)
         {
+            var endpoint = ValidatorTestUtility.CreateRegistrationEndpoint();
             var config = new ValidatorConfiguration("https://nuget.test/packages", requireRepositorySignature: false);
 
-            return new RegistrationDeprecationValidator(config, logger);
+            return new RegistrationDeprecationValidator(endpoint, config, logger);
         }
 
         public override IEnumerable<Func<PackageRegistrationIndexMetadata>> CreateIndexes

--- a/tests/NgTests/Validation/RegistrationExistsValidatorTestData.cs
+++ b/tests/NgTests/Validation/RegistrationExistsValidatorTestData.cs
@@ -13,9 +13,10 @@ namespace NgTests
         protected override RegistrationExistsValidator CreateValidator(
             ILogger<RegistrationExistsValidator> logger)
         {
+            var endpoint = ValidatorTestUtility.CreateRegistrationEndpoint();
             var config = ValidatorTestUtility.CreateValidatorConfig();
 
-            return new RegistrationExistsValidator(config, logger);
+            return new RegistrationExistsValidator(endpoint, config, logger);
         }
 
         public override IEnumerable<Func<PackageRegistrationIndexMetadata>> CreateIndexes => new Func<PackageRegistrationIndexMetadata>[]

--- a/tests/NgTests/Validation/RegistrationIdValidatorTestData.cs
+++ b/tests/NgTests/Validation/RegistrationIdValidatorTestData.cs
@@ -13,9 +13,10 @@ namespace NgTests
         protected override RegistrationIdValidator CreateValidator(
             ILogger<RegistrationIdValidator> logger)
         {
+            var endpoint = ValidatorTestUtility.CreateRegistrationEndpoint();
             var config = ValidatorTestUtility.CreateValidatorConfig();
 
-            return new RegistrationIdValidator(config, logger);
+            return new RegistrationIdValidator(endpoint, config, logger);
         }
 
         public override IEnumerable<Func<PackageRegistrationIndexMetadata>> CreateIndexes => new Func<PackageRegistrationIndexMetadata>[]

--- a/tests/NgTests/Validation/RegistrationListedValidatorTestData.cs
+++ b/tests/NgTests/Validation/RegistrationListedValidatorTestData.cs
@@ -13,9 +13,10 @@ namespace NgTests
         protected override RegistrationListedValidator CreateValidator(
             ILogger<RegistrationListedValidator> logger)
         {
+            var endpoint = ValidatorTestUtility.CreateRegistrationEndpoint();
             var config = ValidatorTestUtility.CreateValidatorConfig();
 
-            return new RegistrationListedValidator(config, logger);
+            return new RegistrationListedValidator(endpoint, config, logger);
         }
 
         public override IEnumerable<Func<PackageRegistrationIndexMetadata>> CreateIndexes => new Func<PackageRegistrationIndexMetadata>[]

--- a/tests/NgTests/Validation/RegistrationRequireLicenseAcceptanceValidatorTestData.cs
+++ b/tests/NgTests/Validation/RegistrationRequireLicenseAcceptanceValidatorTestData.cs
@@ -13,9 +13,10 @@ namespace NgTests
         protected override RegistrationRequireLicenseAcceptanceValidator CreateValidator(
             ILogger<RegistrationRequireLicenseAcceptanceValidator> logger)
         {
+            var endpoint = ValidatorTestUtility.CreateRegistrationEndpoint();
             var config = new ValidatorConfiguration("https://nuget.test/packages", requireRepositorySignature: false);
 
-            return new RegistrationRequireLicenseAcceptanceValidator(config, logger);
+            return new RegistrationRequireLicenseAcceptanceValidator(endpoint, config, logger);
         }
 
         public override IEnumerable<Func<PackageRegistrationIndexMetadata>> CreateIndexes => new Func<PackageRegistrationIndexMetadata>[]

--- a/tests/NgTests/Validation/RegistrationVersionValidatorTestData.cs
+++ b/tests/NgTests/Validation/RegistrationVersionValidatorTestData.cs
@@ -14,9 +14,10 @@ namespace NgTests
         protected override RegistrationVersionValidator CreateValidator(
             ILogger<RegistrationVersionValidator> logger)
         {
+            var endpoint = ValidatorTestUtility.CreateRegistrationEndpoint();
             var config = ValidatorTestUtility.CreateValidatorConfig();
 
-            return new RegistrationVersionValidator(config, logger);
+            return new RegistrationVersionValidator(endpoint, config, logger);
         }
 
         public override IEnumerable<Func<PackageRegistrationIndexMetadata>> CreateIndexes => new Func<PackageRegistrationIndexMetadata>[]

--- a/tests/NgTests/Validation/ValidatorTestUtility.cs
+++ b/tests/NgTests/Validation/ValidatorTestUtility.cs
@@ -20,6 +20,32 @@ namespace NgTests
 {
     public static class ValidatorTestUtility
     {
+        public static EndpointConfiguration CreateEndpointConfig()
+        {
+            return new EndpointConfiguration(
+                registrationCursorUri: new Uri("https://example/reg"),
+                flatContainerCursorUri: new Uri("https://example/fc"));
+        }
+
+        public static CatalogEndpoint CreateCatalogEndpoint()
+        {
+            return new CatalogEndpoint();
+        }
+
+        public static FlatContainerEndpoint CreateFlatContainerEndpoint()
+        {
+            return new FlatContainerEndpoint(
+                CreateEndpointConfig(),
+                () => null);
+        }
+
+        public static RegistrationEndpoint CreateRegistrationEndpoint()
+        {
+            return new RegistrationEndpoint(
+                CreateEndpointConfig(),
+                () => null);
+        }
+
         public static ValidatorConfiguration CreateValidatorConfig(
             string packageBaseAddress = "https://nuget.test/packages",
             bool requireRepositorySignature = false)


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/7227.

We will need this information since there are multiple search endpoints that we want to validate. We can't just assume the one arbitrarily picked from the service index is right.

This PR has no behavioral impact. It's just setting things up.