### PR TITLE
Support autocomplete on tokenized package ID

### DIFF
--- a/tests/BasicSearchTests.FunctionalTests.Core/TestSupport/AutocompleteBuilder.cs
+++ b/tests/BasicSearchTests.FunctionalTests.Core/TestSupport/AutocompleteBuilder.cs
@@ -1,12 +1,43 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
+using System.Collections.Specialized;
+using System.Web;
 
 namespace BasicSearchTests.FunctionalTests.Core.TestSupport
 {
     public class AutocompleteBuilder : QueryBuilder
     {
+        public int? Skip { get; set; }
+
+        public int? Take { get; set; }
+
+        public bool IncludeSemVer2 { get; set; }
+
         public AutocompleteBuilder() : base("/autocomplete?") { }
+
+        protected override NameValueCollection GetQueryString()
+        {
+            var queryString = HttpUtility.ParseQueryString(string.Empty);
+            queryString["q"] = Query;
+            queryString["prerelease"] = Prerelease.ToString();
+
+            if (Skip.HasValue)
+            {
+                queryString["skip"] = Skip.ToString();
+            }
+
+            if (Take.HasValue)
+            {
+                queryString["take"] = Take.ToString();
+            }
+
+            if (IncludeSemVer2)
+            {
+                queryString["semVerLevel"] = "2.0.0";
+            }
+
+            return queryString;
+        }
     }
 }

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/NuGet.Services.AzureSearch.FunctionalTests.csproj
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/NuGet.Services.AzureSearch.FunctionalTests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="BasicTests\V3SearchProtocolTests.cs" />
     <Compile Include="BasicTests\V2SearchProtocolTests.cs" />
     <Compile Include="BasicTests\SearchAvailabilityTests.cs" />
+    <Compile Include="Relevancy\AutocompleteRelevancyFunctionalTests.cs" />
     <Compile Include="Support\TestUtilities.cs" />
     <Compile Include="Support\RelevancyTheoryAttribute.cs" />
     <Compile Include="Support\RelevancyFactAttribute.cs" />

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/Relevancy/AutocompleteRelevancyFunctionalTests.cs
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/Relevancy/AutocompleteRelevancyFunctionalTests.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.AzureSearch.FunctionalTests
+{
+    public class AutocompleteRelevancyFunctionalTests : NuGetSearchFunctionalTestBase
+    {
+        public AutocompleteRelevancyFunctionalTests(CommonFixture fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture, testOutputHelper)
+        {
+        }
+
+        [RelevancyTheory]
+        [MemberData(nameof(EnsureFirstResultsData))]
+        public async Task EnsureFirstResults(string searchTerm, string[] expectedFirstResults)
+        {
+            var results = await AutocompleteAsync(searchTerm, take: 10);
+
+            Assert.True(results.Count > expectedFirstResults.Length);
+
+            for (var i = 0; i < expectedFirstResults.Length; i++)
+            {
+                Assert.True(expectedFirstResults[i] == results[i], $"Expected result '{expectedFirstResults[i]}' at index #{i} for query '{searchTerm}'");
+            }
+        }
+
+        [RelevancyTheory]
+        [MemberData(nameof(EnsureTopResultsData))]
+        public async Task EnsureTopResults(string searchTerm, string[] expectedTopResults)
+        {
+            var results = await AutocompleteAsync(searchTerm, take: 10);
+
+            Assert.True(results.Count > expectedTopResults.Length);
+
+            foreach (var expectedTopResult in expectedTopResults)
+            {
+                Assert.True(results.Contains(expectedTopResult), $"Expected result '{expectedTopResult}' for query '{searchTerm}'");
+            }
+        }
+
+        public static IEnumerable<object[]> EnsureFirstResultsData()
+        {
+            yield return new object[] { "aws", new[] { "awssdk.core" } };
+            yield return new object[] { "log4", new[] { "log4net" } };
+            yield return new object[] { "dap", new[] { "dapper" } };
+            yield return new object[] { "json", new[] { "json" } };
+            yield return new object[] { "jso", new[] { "newtonsoft.json" } };
+            yield return new object[] { "entityframeworkcore.relational", new[] { "microsoft.entityframeworkcore.relational" } };
+            yield return new object[] { "core.mvc.razor", new[] { "microsoft.aspnetcore.mvc.razor" } };
+            yield return new object[] { "microsoft.aspnet.mvc", new[] { "microsoft.aspnet.mvc" } };
+        }
+
+        public static IEnumerable<object[]> EnsureTopResultsData()
+        {
+            yield return new object[] { "extensions.log", new[] { "microsoft.extensions.logging" } };
+            yield return new object[] { "extensions.logging", new[] { "microsoft.extensions.logging" } };
+            yield return new object[] { "microsoft.extensio", new[] { "microsoft.extensions.logging.abstractions" } };
+            yield return new object[] { "depen", new[] { "microsoft.extensions.dependencyinjection" } };
+            yield return new object[] { "ent", new[] { "entityframework", "microsoft.entityframeworkcore" } };
+            yield return new object[] { "entity", new[] { "entityframework", "microsoft.entityframeworkcore" } };
+            yield return new object[] { "json", new[] { "newtonsoft.json" } };
+            yield return new object[] { "logging", new[] { "microsoft.extensions.logging" } };
+            yield return new object[] { "aut", new[] { "autofac", "automapper" } };
+            yield return new object[] { "mysql", new[] { "mysql.data", "mysqlconnector" } };
+            yield return new object[] { "redi", new[] { "stackexchange.redis" } };
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/Support/NuGetSearchFunctionalTestBase.cs
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/Support/NuGetSearchFunctionalTestBase.cs
@@ -31,6 +31,33 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
 
         protected CommonFixture Fixture { get; private set; }
 
+        protected async Task<IReadOnlyList<string>> AutocompleteAsync(
+            string query,
+            int? skip = 0,
+            int? take = 20,
+            bool includePrerelease = true,
+            bool includeSemVer2 = true)
+        {
+            var results = await AutocompleteAsync(new AutocompleteBuilder()
+            {
+                Query = query,
+                Skip = skip,
+                Take = take,
+                Prerelease = includePrerelease,
+                IncludeSemVer2 = includeSemVer2,
+            });
+
+            var ids = results.Data.Select(t => t.ToLowerInvariant()).ToList();
+
+            _testOutputHelper.WriteLine("Got IDs:");
+            for (var i = 0; i < ids.Count; i++)
+            {
+                _testOutputHelper.WriteLine($"{i + 1}. {ids[i]}");
+            }
+
+            return ids;
+        }
+
         /// <summary>
         /// Queries the NuGet Search API.
         /// See: https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource#search-for-packages
@@ -76,7 +103,12 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
             return await SearchAsync<V3SearchResult>(searchBuilder);
         }
 
-        private async Task<T> SearchAsync<T>(QueryBuilder searchBuilder) where T: SearchResult
+        private async Task<AutocompleteResult> AutocompleteAsync(AutocompleteBuilder searchBuilder)
+        {
+            return await SearchAsync<AutocompleteResult>(searchBuilder);
+        }
+
+        private async Task<T> SearchAsync<T>(QueryBuilder searchBuilder)
         {
             var queryUrl = searchBuilder.RequestUri;
             _testOutputHelper.WriteLine($"Fetching: {queryUrl}");

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/Support/TokenizationData.cs
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/Support/TokenizationData.cs
@@ -47,6 +47,7 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
 
         public static readonly IEnumerable<object[]> LowercasesAndAddsTokensOnCasingAndNonAlphaNumeric = ToMemberData(new Dictionary<string, string[]>
         {
+            { "Microsoft.EntityFrameworkCore.SqlServer.Design", new[] { "microsoft", "entityframeworkcore", "entity", "framework", "core", "sqlserver", "sql", "server", "design" } },
             { "HelloWorld", new[] { "helloworld", "hello", "world" } },
             { "foo2bar", new[] { "foo2bar", "foo", "2", "bar" } },
             { "HTML", new[] { "html"} },

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
@@ -117,14 +117,14 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         public class Autocomplete : FactsBase
         {
-            // TODO: This should use the autocomplete package id field
-            // See https://github.com/NuGet/NuGetGallery/issues/6972
             [Theory]
-            [InlineData("Test", "packageId:Test*")]
-            [InlineData("Test ", "packageId:Test*")]
-            [InlineData("title:test", "packageId:title\\:test*")]
-            [InlineData("Hello world", "packageId:Hello\\ world*")]
-            [InlineData("Hello world ", "packageId:Hello\\ world*")]
+            [InlineData("Test", "packageId:Test* +tokenizedPackageId:Test* packageId:Test^1000")]
+            [InlineData("Test ", "packageId:Test* +tokenizedPackageId:Test* packageId:Test^1000")]
+            [InlineData("title:test", "packageId:title\\:test* +tokenizedPackageId:title\\:test*")]
+            [InlineData("Hello world", "packageId:Hello\\ world* +tokenizedPackageId:Hello\\ world*")]
+            [InlineData("Hello world ", "packageId:Hello\\ world* +tokenizedPackageId:Hello\\ world*")]
+            [InlineData("Hello.world", "packageId:Hello.world* +tokenizedPackageId:Hello* +tokenizedPackageId:world* packageId:Hello.world^1000")]
+            [InlineData("Foo.BarBaz", "packageId:Foo.BarBaz* +tokenizedPackageId:Foo* +tokenizedPackageId:BarBaz* packageId:Foo.BarBaz^1000")]
             public void PackageIdAutocomplete(string input, string expected)
             {
                 var request = new AutocompleteRequest


### PR DESCRIPTION
There are some top autocomplete queries that match the beginning of tokens but don't match the first token. Examples:
`entity` -> Microsoft.EntityFrameworkCore
`sqlite` -> Microsoft.Data.Sqlite
`http` -> System.Net.Http

Take a look at the autocomplete relevancy tests I added for more examples.

In short, I looked at the top 600 autocomplete queries with of length greater than 1 and looked for patterns. By in large, most queries start at the beginning of the package ID which the existing Azure Search implementation covered. However, there were several (e.g. "entityfra" or "aspnet") where the most popular matches don't have this as a prefix on the whole ID but rather a prefix of a token. This reality is what motivated the change.

Also note that I added the exact match mega boost for ALL packages IDs. The rationale here is that the user is certainly searching for a package ID (not a tag or text in the description) so a search like "JSON" is certainly looking for a package with "JSON" in the ID. To allow any package to be install-able, we don't just mega boost exact matches with symbols in search. Additionally, the `packageid:` workaround (or any field scoped term) is not supported on the autocomplete endpoint so there is no workaround.

Offline validation of this change is the added autocomplete relevancy tests. Online validation will be observing no major change in weekly query volume. In short, we expect no better or worse than parity.

Progress on https://github.com/NuGet/NuGetGallery/issues/7190.
