### PR TITLE
Fix for icon ingestor to store icon cache explitcitly in its own storage.

### DIFF
--- a/src/Catalog/Icons/CatalogLeafDataProcessor.cs
+++ b/src/Catalog/Icons/CatalogLeafDataProcessor.cs
@@ -48,7 +48,7 @@ namespace NuGet.Services.Metadata.Catalog.Icons
             // so can't remove anything. Will rely on the copy code to catch the copy failure and cleanup the cache appropriately.
         }
 
-        public async Task ProcessPackageDetailsLeafAsync(IStorage destinationStorage, CatalogCommitItem item, string iconUrlString, string iconFile, CancellationToken cancellationToken)
+        public async Task ProcessPackageDetailsLeafAsync(IStorage destinationStorage, IStorage iconCacheStorage, CatalogCommitItem item, string iconUrlString, string iconFile, CancellationToken cancellationToken)
         {
             var hasExternalIconUrl = !string.IsNullOrWhiteSpace(iconUrlString);
             var hasEmbeddedIcon = !string.IsNullOrWhiteSpace(iconFile);
@@ -56,7 +56,7 @@ namespace NuGet.Services.Metadata.Catalog.Icons
             {
                 using (_logger.BeginScope("Processing icon url {IconUrl}", iconUrl))
                 {
-                    await ProcessExternalIconUrlAsync(destinationStorage, item, iconUrl, cancellationToken);
+                    await ProcessExternalIconUrlAsync(destinationStorage, iconCacheStorage, item, iconUrl, cancellationToken);
                 }
             }
             else if (hasEmbeddedIcon)
@@ -65,7 +65,7 @@ namespace NuGet.Services.Metadata.Catalog.Icons
             }
         }
 
-        private async Task ProcessExternalIconUrlAsync(IStorage destinationStorage, CatalogCommitItem item, Uri iconUrl, CancellationToken cancellationToken)
+        private async Task ProcessExternalIconUrlAsync(IStorage destinationStorage, IStorage iconCacheStorage, CatalogCommitItem item, Uri iconUrl, CancellationToken cancellationToken)
         {
             _logger.LogInformation("Found external icon url {IconUrl} for {PackageId} {PackageVersion}",
                 iconUrl,
@@ -83,11 +83,11 @@ namespace NuGet.Services.Metadata.Catalog.Icons
             }
             using (_telemetryService.TrackExternalIconProcessingDuration(item.PackageIdentity.Id, item.PackageIdentity.Version.ToNormalizedString()))
             {
-                await CopyIcon(iconUrl, destinationStorage, item, cancellationToken);
+                await CopyIcon(iconUrl, destinationStorage, iconCacheStorage, item, cancellationToken);
             }
         }
 
-        private async Task CopyIcon(Uri iconUrl, IStorage destinationStorage, CatalogCommitItem item, CancellationToken cancellationToken)
+        private async Task CopyIcon(Uri iconUrl, IStorage destinationStorage, IStorage iconCacheStorage, CatalogCommitItem item, CancellationToken cancellationToken)
         {
             var ingestionResult = await Retry.IncrementalAsync(
                 async () => await TryIngestExternalIconAsync(item, iconUrl, destinationStorage, cancellationToken),
@@ -97,17 +97,24 @@ namespace NuGet.Services.Metadata.Catalog.Icons
                 initialWaitInterval: TimeSpan.FromSeconds(5),
                 waitIncrement: TimeSpan.FromSeconds(1));
 
-            ExternalIconCopyResult cacheItem;
             if (ingestionResult.Result == AttemptResult.Success)
             {
-                cacheItem = ExternalIconCopyResult.Success(iconUrl, ingestionResult.ResultUrl);
+                try
+                {
+                    await _iconCopyResultCache.SaveExternalIcon(iconUrl, ingestionResult.ResultUrl, iconCacheStorage, cancellationToken);
+                }
+                catch (Exception e)
+                {
+                    // we will report and ignore such exceptions. Failure to store icon will cause the original icon
+                    // to be re-retrieved next time it is encountered.
+                    _logger.LogWarning(0, e, "Failed to store icon in the cache");
+                }
             }
             else
             {
                 _telemetryService.TrackExternalIconIngestionFailure(item.PackageIdentity.Id, item.PackageIdentity.Version.ToNormalizedString());
-                cacheItem = ExternalIconCopyResult.Fail(iconUrl);
+                _iconCopyResultCache.SaveExternalCopyFailure(iconUrl);
             }
-            _iconCopyResultCache.Set(iconUrl, cacheItem);
         }
 
         private async Task<bool> TryTakeFromCache(Uri iconUrl, ExternalIconCopyResult cachedResult, IStorage destinationStorage, CatalogCommitItem item, CancellationToken cancellationToken)
@@ -140,7 +147,7 @@ namespace NuGet.Services.Metadata.Catalog.Icons
                     _logger.LogWarning(0, e, "Copy from cache failed after {NumRetries} attempts. Falling back to copy from external URL. {StorageUrl}",
                         MaxBlobStorageCopyAttempts,
                         storageUrl);
-                    _iconCopyResultCache.Clear(iconUrl, storageUrl);
+                    _iconCopyResultCache.Clear(iconUrl);
                     return false;
                 }
             }

--- a/src/Catalog/Icons/CatalogLeafDataProcessor.cs
+++ b/src/Catalog/Icons/CatalogLeafDataProcessor.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.WindowsAzure.Storage.DataMovement;
 using NuGet.Services.Metadata.Catalog.Helpers;
 using NuGet.Services.Metadata.Catalog.Persistence;
 
@@ -102,6 +103,11 @@ namespace NuGet.Services.Metadata.Catalog.Icons
                 try
                 {
                     await _iconCopyResultCache.SaveExternalIcon(iconUrl, ingestionResult.ResultUrl, destinationStorage, iconCacheStorage, cancellationToken);
+                }
+                catch (TransferException e) when (e.ErrorCode == TransferErrorCode.MismatchCopyId && _iconCopyResultCache.Get(iconUrl)?.IsCopySucceeded == true)
+                {
+                    // There was a concurrent cache save request and this thread lost.
+                    // Cache was properly updated, so we'll just ignore that exception.
                 }
                 catch (Exception e)
                 {

--- a/src/Catalog/Icons/CatalogLeafDataProcessor.cs
+++ b/src/Catalog/Icons/CatalogLeafDataProcessor.cs
@@ -77,7 +77,7 @@ namespace NuGet.Services.Metadata.Catalog.Icons
                 return;
             }
             var cachedResult = _iconCopyResultCache.Get(iconUrl);
-            if (cachedResult != null && await TryTakeFromCache(iconUrl, cachedResult, destinationStorage, item, cancellationToken))
+            if (cachedResult != null && await TryTakeFromCache(iconUrl, cachedResult, iconCacheStorage, destinationStorage, item, cancellationToken))
             {
                 return;
             }
@@ -101,7 +101,7 @@ namespace NuGet.Services.Metadata.Catalog.Icons
             {
                 try
                 {
-                    await _iconCopyResultCache.SaveExternalIcon(iconUrl, ingestionResult.ResultUrl, iconCacheStorage, cancellationToken);
+                    await _iconCopyResultCache.SaveExternalIcon(iconUrl, ingestionResult.ResultUrl, destinationStorage, iconCacheStorage, cancellationToken);
                 }
                 catch (Exception e)
                 {
@@ -117,7 +117,7 @@ namespace NuGet.Services.Metadata.Catalog.Icons
             }
         }
 
-        private async Task<bool> TryTakeFromCache(Uri iconUrl, ExternalIconCopyResult cachedResult, IStorage destinationStorage, CatalogCommitItem item, CancellationToken cancellationToken)
+        private async Task<bool> TryTakeFromCache(Uri iconUrl, ExternalIconCopyResult cachedResult, IStorage iconCacheStorage, IStorage destinationStorage, CatalogCommitItem item, CancellationToken cancellationToken)
         {
             if (cachedResult.IsCopySucceeded)
             {
@@ -136,7 +136,7 @@ namespace NuGet.Services.Metadata.Catalog.Icons
                 try
                 {
                     await Retry.IncrementalAsync(
-                        async () => await destinationStorage.CopyAsync(storageUrl, destinationStorage, destinationUrl, null, cancellationToken),
+                        async () => await iconCacheStorage.CopyAsync(storageUrl, destinationStorage, destinationUrl, null, cancellationToken),
                         e => { _logger.LogWarning(0, e, "Exception while copying from cache {StorageUrl}", storageUrl); return true; },
                         MaxBlobStorageCopyAttempts,
                         initialWaitInterval: TimeSpan.FromSeconds(5),

--- a/src/Catalog/Icons/CatalogLeafDataProcessor.cs
+++ b/src/Catalog/Icons/CatalogLeafDataProcessor.cs
@@ -104,11 +104,6 @@ namespace NuGet.Services.Metadata.Catalog.Icons
                 {
                     await _iconCopyResultCache.SaveExternalIcon(iconUrl, ingestionResult.ResultUrl, destinationStorage, iconCacheStorage, cancellationToken);
                 }
-                catch (TransferException e) when (e.ErrorCode == TransferErrorCode.MismatchCopyId && _iconCopyResultCache.Get(iconUrl)?.IsCopySucceeded == true)
-                {
-                    // There was a concurrent cache save request and this thread lost.
-                    // Cache was properly updated, so we'll just ignore that exception.
-                }
                 catch (Exception e)
                 {
                     // we will report and ignore such exceptions. Failure to store icon will cause the original icon

--- a/src/Catalog/Icons/ICatalogLeafDataProcessor.cs
+++ b/src/Catalog/Icons/ICatalogLeafDataProcessor.cs
@@ -10,6 +10,6 @@ namespace NuGet.Services.Metadata.Catalog.Icons
     public interface ICatalogLeafDataProcessor
     {
         Task ProcessPackageDeleteLeafAsync(Storage storage, CatalogCommitItem item, CancellationToken cancellationToken);
-        Task ProcessPackageDetailsLeafAsync(IStorage destinationStorage, CatalogCommitItem item, string iconUrlString, string iconFile, CancellationToken cancellationToken);
+        Task ProcessPackageDetailsLeafAsync(IStorage destinationStorage, IStorage iconCacheStorage, CatalogCommitItem item, string iconUrlString, string iconFile, CancellationToken cancellationToken);
     }
 }

--- a/src/Catalog/Icons/IIconCopyResultCache.cs
+++ b/src/Catalog/Icons/IIconCopyResultCache.cs
@@ -19,17 +19,18 @@ namespace NuGet.Services.Metadata.Catalog.Icons
         /// <param name="iconUrl">External icon URL</param>
         /// <returns>Previous copy result if we have any, null if nothing is associated with specified <paramref name="iconUrl"/>.</returns>
         ExternalIconCopyResult Get(Uri iconUrl);
-        
+
         /// <summary>
         /// Copies the successfully retrieved icon blob from destination storage to the cache and
         /// takes note of success so it could be reused later.
         /// </summary>
         /// <param name="originalIconUrl">The original URL of an icon.</param>
         /// <param name="storageUrl">Storage URL where icon was copied to.</param>
+        /// <param name="mainDestinationStorage">Storage to which <paramref name="storageUrl"/> points to.</param>
         /// <param name="cacheStorage">Storage to use for icon cache.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Uri of the icon in the cache storage.</returns>
-        Task<Uri> SaveExternalIcon(Uri originalIconUrl, Uri storageUrl, IStorage cacheStorage, CancellationToken cancellationToken);
+        Task<Uri> SaveExternalIcon(Uri originalIconUrl, Uri storageUrl, IStorage mainDestinationStorage, IStorage cacheStorage, CancellationToken cancellationToken);
 
         /// <summary>
         /// Takes note of a failure to copy the external package icon so it's not retried later.

--- a/src/Catalog/Icons/IIconCopyResultCache.cs
+++ b/src/Catalog/Icons/IIconCopyResultCache.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Services.Metadata.Catalog.Persistence;
 
 namespace NuGet.Services.Metadata.Catalog.Icons
 {
@@ -16,19 +19,29 @@ namespace NuGet.Services.Metadata.Catalog.Icons
         /// <param name="iconUrl">External icon URL</param>
         /// <returns>Previous copy result if we have any, null if nothing is associated with specified <paramref name="iconUrl"/>.</returns>
         ExternalIconCopyResult Get(Uri iconUrl);
-
+        
         /// <summary>
-        /// Stores the copy result for a given external icon URL.
+        /// Copies the successfully retrieved icon blob from destination storage to the cache and
+        /// takes note of success so it could be reused later.
         /// </summary>
-        /// <param name="iconUrl">External icon URL.</param>
-        /// <param name="newItem">Copy attempt result.</param>
-        void Set(Uri iconUrl, ExternalIconCopyResult newItem);
+        /// <param name="originalIconUrl">The original URL of an icon.</param>
+        /// <param name="storageUrl">Storage URL where icon was copied to.</param>
+        /// <param name="cacheStorage">Storage to use for icon cache.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Uri of the icon in the cache storage.</returns>
+        Task<Uri> SaveExternalIcon(Uri originalIconUrl, Uri storageUrl, IStorage cacheStorage, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Removes the copy result URL (if we have one cached) if destination URL is the expected one. Useful when the package is deleted to prevent subsequent failures.
+        /// Takes note of a failure to copy the external package icon so it's not retried later.
+        /// </summary>
+        /// <param name="iconUrl">The external icon URL.</param>
+        void SaveExternalCopyFailure(Uri iconUrl);
+
+
+        /// <summary>
+        /// Removes the copy result URL (if we have one cached).
         /// </summary>
         /// <param name="externalIconUrl">External icon URL.</param>
-        /// <param name="targetStorageUrl">Expected storage URL for the icon. Item will only be removed if the cached result is successful copy and target URL is the same as supplied.</param>
-        void Clear(Uri externalIconUrl, Uri targetStorageUrl);
+        void Clear(Uri externalIconUrl);
     }
 }

--- a/src/Catalog/Icons/IconCopyResultCache.cs
+++ b/src/Catalog/Icons/IconCopyResultCache.cs
@@ -74,7 +74,7 @@ namespace NuGet.Services.Metadata.Catalog.Icons
             return null;
         }
 
-        public async Task<Uri> SaveExternalIcon(Uri originalIconUrl, Uri storageUrl, IStorage cacheStorage, CancellationToken cancellationToken)
+        public async Task<Uri> SaveExternalIcon(Uri originalIconUrl, Uri storageUrl, IStorage mainDestinationStorage, IStorage cacheStorage, CancellationToken cancellationToken)
         {
             if (_externalIconCopyResults == null)
             {
@@ -95,7 +95,7 @@ namespace NuGet.Services.Metadata.Catalog.Icons
             var cacheStoragePath = GetCachePath(originalIconUrl);
             var cacheUrl = cacheStorage.ResolveUri(cacheStoragePath);
 
-            await cacheStorage.CopyAsync(storageUrl, cacheStorage, cacheUrl, null, cancellationToken);
+            await mainDestinationStorage.CopyAsync(storageUrl, cacheStorage, cacheUrl, null, cancellationToken);
             // Technically, we could get away without storing the success in the dictionary,
             // but then each get attempt from the cache would result in HTTP request to cache
             // storage that drastically reduces usefulness of the cache (we trade one HTTP request

--- a/src/Catalog/Icons/IconCopyResultCache.cs
+++ b/src/Catalog/Icons/IconCopyResultCache.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -72,31 +74,71 @@ namespace NuGet.Services.Metadata.Catalog.Icons
             return null;
         }
 
-        public void Set(Uri iconUrl, ExternalIconCopyResult newItem)
+        public async Task<Uri> SaveExternalIcon(Uri originalIconUrl, Uri storageUrl, IStorage cacheStorage, CancellationToken cancellationToken)
         {
             if (_externalIconCopyResults == null)
             {
                 throw new InvalidOperationException("Object was not initialized");
             }
 
-            _externalIconCopyResults.AddOrUpdate(iconUrl, newItem, (_, v) => v); // will not overwrite existing entries
+            if (_externalIconCopyResults.TryGetValue(originalIconUrl, out var copyResult))
+            {
+                if (copyResult.IsCopySucceeded)
+                {
+                    return copyResult.StorageUrl;
+                }
+
+                // if we have failure stored, we'll try to replace it with success,
+                // now that we've seen one.
+            }
+
+            var cacheStoragePath = GetCachePath(originalIconUrl);
+            var cacheUrl = cacheStorage.ResolveUri(cacheStoragePath);
+
+            await cacheStorage.CopyAsync(storageUrl, cacheStorage, cacheUrl, null, cancellationToken);
+            // Technically, we could get away without storing the success in the dictionary,
+            // but then each get attempt from the cache would result in HTTP request to cache
+            // storage that drastically reduces usefulness of the cache (we trade one HTTP request
+            // for another).
+            Set(originalIconUrl, ExternalIconCopyResult.Success(originalIconUrl, cacheUrl));
+            return cacheUrl;
         }
 
-        public void Clear(Uri externalIconUrl, Uri targetStorageUrl)
+        public void SaveExternalCopyFailure(Uri iconUrl)
         {
             if (_externalIconCopyResults == null)
             {
                 throw new InvalidOperationException("Object was not initialized");
             }
 
-            if (_externalIconCopyResults.TryRemove(externalIconUrl, out var removedValue))
+            Set(iconUrl, ExternalIconCopyResult.Fail(iconUrl));
+        }
+
+        private void Set(Uri iconUrl, ExternalIconCopyResult newItem)
+        {
+            _externalIconCopyResults.AddOrUpdate(iconUrl, newItem, (_, v) => v.IsCopySucceeded ? v : newItem); // will only overwrite failure results
+        }
+
+        public void Clear(Uri externalIconUrl)
+        {
+            if (_externalIconCopyResults == null)
             {
-                if (removedValue.StorageUrl != targetStorageUrl)
-                {
-                    // if we removed item that does not match the target URL, put it back.
-                    Set(externalIconUrl, removedValue);
-                }
+                throw new InvalidOperationException("Object was not initialized");
             }
+
+            // Cache results are immutable, so we'll remove looking only at the key
+            _externalIconCopyResults.TryRemove(externalIconUrl, out var _);
+        }
+
+        private string GetCachePath(Uri iconUrl)
+        {
+            var hash = (byte[])null;
+            using (var sha512 = new SHA512Managed())
+            {
+                var absoluteUriBytes = Encoding.UTF8.GetBytes(iconUrl.AbsoluteUri);
+                hash = sha512.ComputeHash(absoluteUriBytes);
+            }
+            return "icon-cache/" + BitConverter.ToString(hash).Replace("-", "");
         }
     }
 }

--- a/src/Ng/Jobs/Catalog2IconJob.cs
+++ b/src/Ng/Jobs/Catalog2IconJob.cs
@@ -69,6 +69,7 @@ namespace Ng.Jobs
                 catalogClient,
                 leafProcessor,
                 iconCopyResultCache,
+                auxStorageFactory,
                 CommandHelpers.GetHttpMessageHandlerFactory(TelemetryService, verbose),
                 LoggerFactory.CreateLogger<IconsCollector>());
             var cursorStorage = auxStorageFactory.Create();

--- a/src/Ng/Jobs/Catalog2IconJob.cs
+++ b/src/Ng/Jobs/Catalog2IconJob.cs
@@ -52,7 +52,7 @@ namespace Ng.Jobs
             var catalogClient = new CatalogClient(simpleHttpClient, LoggerFactory.CreateLogger<CatalogClient>());
             var httpResponseProvider = new HttpClientWrapper(httpClient);
             var externalIconProvider = new ExternalIconContentProvider(httpResponseProvider, LoggerFactory.CreateLogger<ExternalIconContentProvider>());
-            var iconCopyResultCache = new IconCopyResultCache(auxStorageFactory.Create());
+            var iconCopyResultCache = new IconCopyResultCache(auxStorageFactory.Create(), LoggerFactory.CreateLogger<IconCopyResultCache>());
 
             var leafProcessor = new CatalogLeafDataProcessor(
                 packageStorage,

--- a/tests/CatalogTests/Icons/CatalogLeafDataProcessorFacts.cs
+++ b/tests/CatalogTests/Icons/CatalogLeafDataProcessorFacts.cs
@@ -206,6 +206,15 @@ namespace CatalogTests.Icons
                 IconCopyResultCacheMock
                     .Setup(c => c.Get(It.Is<Uri>(u => u.AbsoluteUri == IconUrlString)))
                     .Returns(ExternalIconCopyResult.Success(new Uri(IconUrlString), new Uri(CachedResult)));
+                IconCacheStorageMock
+                    .Setup(
+                        ds => ds.CopyAsync(
+                            It.Is<Uri>(u => u.AbsoluteUri == CachedResult),
+                            DestinationStorageMock.Object,
+                            It.Is<Uri>(u => u.AbsoluteUri == ResolvedUriString),
+                            It.IsAny<IReadOnlyDictionary<string, string>>(),
+                            CancellationToken.None))
+                    .Returns(Task.CompletedTask);
 
                 await Target.ProcessPackageDetailsLeafAsync(
                     DestinationStorageMock.Object,
@@ -215,7 +224,7 @@ namespace CatalogTests.Icons
                     null,
                     CancellationToken.None);
 
-                DestinationStorageMock
+                IconCacheStorageMock
                     .Verify(
                         ds => ds.CopyAsync(
                             It.Is<Uri>(u => u.AbsoluteUri == CachedResult),
@@ -267,7 +276,7 @@ namespace CatalogTests.Icons
                     .Setup(c => c.Get(It.Is<Uri>(u => u.AbsoluteUri == IconUrlString)))
                     .Returns(ExternalIconCopyResult.Success(new Uri(IconUrlString), new Uri(CachedResult)));
 
-                DestinationStorageMock
+                IconCacheStorageMock
                     .SetupSequence(
                         ds => ds.CopyAsync(
                             It.Is<Uri>(u => u.AbsoluteUri == CachedResult),
@@ -286,7 +295,7 @@ namespace CatalogTests.Icons
                     null,
                     CancellationToken.None);
 
-                DestinationStorageMock
+                IconCacheStorageMock
                     .Verify(
                         ds => ds.CopyAsync(
                             It.Is<Uri>(u => u.AbsoluteUri == CachedResult),
@@ -308,7 +317,7 @@ namespace CatalogTests.Icons
                     .Setup(c => c.Get(It.Is<Uri>(u => u.AbsoluteUri == IconUrlString)))
                     .Returns(ExternalIconCopyResult.Success(new Uri(IconUrlString), new Uri(CachedResult)));
 
-                DestinationStorageMock
+                IconCacheStorageMock
                     .Setup(
                         ds => ds.CopyAsync(
                             It.Is<Uri>(u => u.AbsoluteUri == CachedResult),
@@ -337,7 +346,7 @@ namespace CatalogTests.Icons
                     null,
                     CancellationToken.None);
 
-                DestinationStorageMock
+                IconCacheStorageMock
                     .Verify(
                         ds => ds.CopyAsync(
                             It.Is<Uri>(u => u.AbsoluteUri == CachedResult),

--- a/tests/CatalogTests/Icons/CatalogLeafDataProcessorFacts.cs
+++ b/tests/CatalogTests/Icons/CatalogLeafDataProcessorFacts.cs
@@ -61,6 +61,7 @@ namespace CatalogTests.Icons
 
                 await Target.ProcessPackageDetailsLeafAsync(
                     DestinationStorageMock.Object,
+                    IconCacheStorageMock.Object,
                     leaf,
                     hasIconUrl ? IconUrlString : null,
                     iconFilename,
@@ -100,6 +101,7 @@ namespace CatalogTests.Icons
 
                 await Target.ProcessPackageDetailsLeafAsync(
                     DestinationStorageMock.Object,
+                    IconCacheStorageMock.Object,
                     leaf,
                     IconUrlString,
                     null,
@@ -136,6 +138,7 @@ namespace CatalogTests.Icons
 
                 await Target.ProcessPackageDetailsLeafAsync(
                     DestinationStorageMock.Object,
+                    IconCacheStorageMock.Object,
                     leaf,
                     IconUrlString,
                     null,
@@ -179,6 +182,7 @@ namespace CatalogTests.Icons
 
                 await Target.ProcessPackageDetailsLeafAsync(
                     DestinationStorageMock.Object,
+                    IconCacheStorageMock.Object,
                     leaf,
                     IconUrlString,
                     null,
@@ -205,6 +209,7 @@ namespace CatalogTests.Icons
 
                 await Target.ProcessPackageDetailsLeafAsync(
                     DestinationStorageMock.Object,
+                    IconCacheStorageMock.Object,
                     leaf,
                     IconUrlString,
                     null,
@@ -234,6 +239,7 @@ namespace CatalogTests.Icons
 
                 await Target.ProcessPackageDetailsLeafAsync(
                     DestinationStorageMock.Object,
+                    IconCacheStorageMock.Object,
                     leaf,
                     IconUrlString,
                     null,
@@ -274,6 +280,7 @@ namespace CatalogTests.Icons
 
                 await Target.ProcessPackageDetailsLeafAsync(
                     DestinationStorageMock.Object,
+                    IconCacheStorageMock.Object,
                     leaf,
                     IconUrlString,
                     null,
@@ -324,6 +331,7 @@ namespace CatalogTests.Icons
                 
                 await Target.ProcessPackageDetailsLeafAsync(
                     DestinationStorageMock.Object,
+                    IconCacheStorageMock.Object,
                     leaf,
                     IconUrlString,
                     null,
@@ -402,6 +410,7 @@ namespace CatalogTests.Icons
             protected Mock<ITelemetryService> TelemetryServiceMock { get; set; }
             protected Mock<ILogger<CatalogLeafDataProcessor>> LoggerMock { get; set; }
             protected Mock<IStorage> DestinationStorageMock { get; set; }
+            protected Mock<IStorage> IconCacheStorageMock { get; set; }
             protected CatalogLeafDataProcessor Target { get; set; }
 
             public TestBase()
@@ -413,6 +422,7 @@ namespace CatalogTests.Icons
                 TelemetryServiceMock = new Mock<ITelemetryService>();
                 LoggerMock = new Mock<ILogger<CatalogLeafDataProcessor>>();
                 DestinationStorageMock = new Mock<IStorage>();
+                IconCacheStorageMock = new Mock<IStorage>();
 
                 TelemetryServiceMock
                     .Setup(ts => ts.TrackEmbeddedIconProcessingDuration(It.IsAny<string>(), It.IsAny<string>()))

--- a/tests/CatalogTests/Icons/IconCopyResultCacheFacts.cs
+++ b/tests/CatalogTests/Icons/IconCopyResultCacheFacts.cs
@@ -40,7 +40,7 @@ namespace CatalogTests.Icons
         [Fact]
         public async Task SaveExternalIconThrowsIfNotInitialized()
         {
-            await Assert.ThrowsAsync<InvalidOperationException>(() => Target.SaveExternalIcon(new Uri("https://whatever"), new Uri("https://storage.test"), Mock.Of<IStorage>(), CancellationToken.None));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => Target.SaveExternalIcon(new Uri("https://whatever"), new Uri("https://storage.test"), Mock.Of<IStorage>(), Mock.Of<IStorage>(), CancellationToken.None));
         }
 
         [Fact]
@@ -68,8 +68,8 @@ namespace CatalogTests.Icons
 
             if (success)
             {
-                await Target.SaveExternalIcon(new Uri(sourceUrl), storageUrl, IconCacheStorageMock.Object, CancellationToken.None);
-                IconCacheStorageMock
+                await Target.SaveExternalIcon(new Uri(sourceUrl), storageUrl, StorageMock.Object, IconCacheStorageMock.Object, CancellationToken.None);
+                StorageMock
                     .Verify(ics => ics.CopyAsync(storageUrl, IconCacheStorageMock.Object, It.IsAny<Uri>(), It.IsAny<IReadOnlyDictionary<string, string>>(), CancellationToken.None));
             }
             else
@@ -108,13 +108,13 @@ namespace CatalogTests.Icons
             var firstSucessStorageUrl = new Uri(firstSuccessStorageUrlString);
             var secondSuccessStorageUrl = new Uri("https://storage2");
 
-            await Target.SaveExternalIcon(originalIconUrl, firstSucessStorageUrl, IconCacheStorageMock.Object, CancellationToken.None);
-            IconCacheStorageMock
+            await Target.SaveExternalIcon(originalIconUrl, firstSucessStorageUrl, StorageMock.Object, IconCacheStorageMock.Object, CancellationToken.None);
+            StorageMock
                 .Verify(
                     ics => ics.CopyAsync(firstSucessStorageUrl, IconCacheStorageMock.Object, It.IsAny<Uri>(), It.IsAny<IReadOnlyDictionary<string, string>>(), CancellationToken.None),
                     Times.Once);
-            await Target.SaveExternalIcon(originalIconUrl, secondSuccessStorageUrl, IconCacheStorageMock.Object, CancellationToken.None);
-            IconCacheStorageMock
+            await Target.SaveExternalIcon(originalIconUrl, secondSuccessStorageUrl, StorageMock.Object, IconCacheStorageMock.Object, CancellationToken.None);
+            StorageMock
                 .Verify(
                     ics => ics.CopyAsync(secondSuccessStorageUrl, It.IsAny<IStorage>(), It.IsAny<Uri>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()),
                     Times.Never);
@@ -138,8 +138,8 @@ namespace CatalogTests.Icons
             var successStorageUrl = new Uri(successStorageUrlString);
 
             Target.SaveExternalCopyFailure(originalIconUrl);
-            await Target.SaveExternalIcon(originalIconUrl, successStorageUrl, IconCacheStorageMock.Object, CancellationToken.None);
-            IconCacheStorageMock
+            await Target.SaveExternalIcon(originalIconUrl, successStorageUrl, StorageMock.Object, IconCacheStorageMock.Object, CancellationToken.None);
+            StorageMock
                 .Verify(
                     ics => ics.CopyAsync(successStorageUrl, IconCacheStorageMock.Object, It.IsAny<Uri>(), It.IsAny<IReadOnlyDictionary<string, string>>(), CancellationToken.None),
                     Times.Once);
@@ -158,7 +158,7 @@ namespace CatalogTests.Icons
 
             await Target.InitializeAsync(CancellationToken.None);
 
-            await Target.SaveExternalIcon(new Uri("https://sourcez"), new Uri("https://storage1/d"), IconCacheStorageMock.Object, CancellationToken.None);
+            await Target.SaveExternalIcon(new Uri("https://sourcez"), new Uri("https://storage1/d"), StorageMock.Object, IconCacheStorageMock.Object, CancellationToken.None);
             Target.SaveExternalCopyFailure(new Uri("https://sourcey"));
 
             string savedContent = null;
@@ -189,9 +189,6 @@ namespace CatalogTests.Icons
                 .Verifiable();
 
             IconCacheStorageMock = new Mock<IStorage>();
-            IconCacheStorageMock
-                .Setup(ics => ics.CopyAsync(It.IsAny<Uri>(), It.IsAny<IStorage>(), It.IsAny<Uri>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
             IconCacheStorageMock
                 .Setup(ics => ics.ResolveUri(It.IsAny<string>()))
                 .Returns(new Uri(DefaultResolvedUrlString));

--- a/tests/CatalogTests/Icons/IconCopyResultCacheFacts.cs
+++ b/tests/CatalogTests/Icons/IconCopyResultCacheFacts.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NuGet.Services.Metadata.Catalog.Icons;
 using NuGet.Services.Metadata.Catalog.Persistence;
@@ -203,7 +204,9 @@ namespace CatalogTests.Icons
                 .Setup(s => s.LoadAsync(new Uri("https://cache.test/blob"), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(responseStreamContentMock.Object);
 
-            Target = new IconCopyResultCache(StorageMock.Object);
+            Target = new IconCopyResultCache(
+                StorageMock.Object,
+                Mock.Of<ILogger<IconCopyResultCache>>());
         }
 
         private const string DefaultResolvedUrlString = "https://resolved.test/uri";

--- a/tests/CatalogTests/Icons/IconCopyResultCacheFacts.cs
+++ b/tests/CatalogTests/Icons/IconCopyResultCacheFacts.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -37,15 +38,21 @@ namespace CatalogTests.Icons
         }
 
         [Fact]
-        public void SetThrowsIfNotInitialized()
+        public async Task SaveExternalIconThrowsIfNotInitialized()
         {
-            Assert.Throws<InvalidOperationException>(() => Target.Set(new Uri("https://whatever"), ExternalIconCopyResult.Fail(new Uri("https://another"))));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => Target.SaveExternalIcon(new Uri("https://whatever"), new Uri("https://storage.test"), Mock.Of<IStorage>(), CancellationToken.None));
+        }
+
+        [Fact]
+        public void SaveExternalCopyFailureThrowsIfNotInitialized()
+        {
+            Assert.Throws<InvalidOperationException>(() => Target.SaveExternalCopyFailure(new Uri("https://whatever")));
         }
 
         [Fact]
         public void ClearThrowsIfNotInitialized()
         {
-            Assert.Throws<InvalidOperationException>(() => Target.Clear(new Uri("https://whatever"), new Uri("https://another")));
+            Assert.Throws<InvalidOperationException>(() => Target.Clear(new Uri("https://whatever")));
         }
 
         [Theory]
@@ -54,73 +61,94 @@ namespace CatalogTests.Icons
         public async Task SmokeTest(string sourceUrl, string storageUrlString, bool expectedSuccess)
         {
             Data = "{}";
-
             await Target.InitializeAsync(CancellationToken.None);
 
             var storageUrl = storageUrlString == null ? null : new Uri(storageUrlString);
-            Target.Set(new Uri(sourceUrl), new ExternalIconCopyResult { SourceUrl = new Uri(sourceUrl), StorageUrl = storageUrl });
-            var item = Target.Get(new Uri(sourceUrl));
-            Assert.Equal(sourceUrl, item.SourceUrl.AbsoluteUri);
-            if (storageUrlString == null)
+            var success = storageUrlString != null;
+
+            if (success)
             {
-                Assert.Null(item.StorageUrl);
+                await Target.SaveExternalIcon(new Uri(sourceUrl), storageUrl, IconCacheStorageMock.Object, CancellationToken.None);
+                IconCacheStorageMock
+                    .Verify(ics => ics.CopyAsync(storageUrl, IconCacheStorageMock.Object, It.IsAny<Uri>(), It.IsAny<IReadOnlyDictionary<string, string>>(), CancellationToken.None));
             }
             else
             {
-                Assert.Equal(storageUrlString, item.StorageUrl.AbsoluteUri);
+                Target.SaveExternalCopyFailure(new Uri(sourceUrl));
+            }
+            var item = Target.Get(new Uri(sourceUrl));
+            Assert.Equal(sourceUrl, item.SourceUrl.AbsoluteUri);
+            if (success)
+            {
+                Assert.True(item.IsCopySucceeded);
+                Assert.Equal(DefaultResolvedUrlString, item.StorageUrl.AbsoluteUri);
+            }
+            else
+            {
+                Assert.False(item.IsCopySucceeded);
+                Assert.Null(item.StorageUrl);
             }
             Assert.Equal(expectedSuccess, item.IsCopySucceeded);
 
-            Target.Clear(new Uri(sourceUrl), storageUrl);
+            Target.Clear(new Uri(sourceUrl));
             item = Target.Get(new Uri(sourceUrl));
             Assert.Null(item);
         }
 
         [Fact]
-        public async Task SetDoesNotOverwrite()
+        public async Task SaveExternalIconDoesNotOverwriteSuccess()
         {
             Data = "{}";
 
             await Target.InitializeAsync(CancellationToken.None);
 
-            Target.Set(new Uri("https://source"), ExternalIconCopyResult.Success(new Uri("https://source1/d"), new Uri("https://storage1/d")));
-            Target.Set(new Uri("https://source"), ExternalIconCopyResult.Success(new Uri("https://source2"), new Uri("https://storage2")));
-            var item = Target.Get(new Uri("https://source"));
+            const string originalIconUrlString = "https://source/";
+            var originalIconUrl = new Uri(originalIconUrlString);
+            const string firstSuccessStorageUrlString = "https://storage1/d";
+            var firstSucessStorageUrl = new Uri(firstSuccessStorageUrlString);
+            var secondSuccessStorageUrl = new Uri("https://storage2");
 
-            Assert.Equal("https://source1/d", item.SourceUrl.AbsoluteUri);
-            Assert.Equal("https://storage1/d", item.StorageUrl.AbsoluteUri);
+            await Target.SaveExternalIcon(originalIconUrl, firstSucessStorageUrl, IconCacheStorageMock.Object, CancellationToken.None);
+            IconCacheStorageMock
+                .Verify(
+                    ics => ics.CopyAsync(firstSucessStorageUrl, IconCacheStorageMock.Object, It.IsAny<Uri>(), It.IsAny<IReadOnlyDictionary<string, string>>(), CancellationToken.None),
+                    Times.Once);
+            await Target.SaveExternalIcon(originalIconUrl, secondSuccessStorageUrl, IconCacheStorageMock.Object, CancellationToken.None);
+            IconCacheStorageMock
+                .Verify(
+                    ics => ics.CopyAsync(secondSuccessStorageUrl, It.IsAny<IStorage>(), It.IsAny<Uri>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()),
+                    Times.Never);
+
+            var item = Target.Get(originalIconUrl);
+            Assert.True(item.IsCopySucceeded);
+            Assert.Equal(originalIconUrlString, item.SourceUrl.AbsoluteUri);
+            Assert.Equal(DefaultResolvedUrlString, item.StorageUrl.AbsoluteUri);
         }
 
         [Fact]
-        public async Task ClearsWhenStorageMatches()
+        public async Task SaveExternalIconOverwritesFailures()
         {
             Data = "{}";
 
             await Target.InitializeAsync(CancellationToken.None);
 
-            Target.Set(new Uri("https://source"), ExternalIconCopyResult.Success(new Uri("https://source1"), new Uri("https://storage1")));
-            var item = Target.Get(new Uri("https://source"));
-            Assert.NotNull(item);
-            Target.Clear(new Uri("https://source"), new Uri("https://storage1"));
-            item = Target.Get(new Uri("https://source"));
-            Assert.Null(item);
-        }
+            const string originalIconUrlString = "https://source/";
+            var originalIconUrl = new Uri(originalIconUrlString);
+            const string successStorageUrlString = "https://storage2/";
+            var successStorageUrl = new Uri(successStorageUrlString);
 
-        [Fact]
-        public async Task NotClearsWhenStorageNotMatch()
-        {
-            Data = "{}";
+            Target.SaveExternalCopyFailure(originalIconUrl);
+            await Target.SaveExternalIcon(originalIconUrl, successStorageUrl, IconCacheStorageMock.Object, CancellationToken.None);
+            IconCacheStorageMock
+                .Verify(
+                    ics => ics.CopyAsync(successStorageUrl, IconCacheStorageMock.Object, It.IsAny<Uri>(), It.IsAny<IReadOnlyDictionary<string, string>>(), CancellationToken.None),
+                    Times.Once);
 
-            await Target.InitializeAsync(CancellationToken.None);
+            var item = Target.Get(originalIconUrl);
 
-            Target.Set(new Uri("https://source"), ExternalIconCopyResult.Success(new Uri("https://source1/d"), new Uri("https://storage1/d")));
-            var item = Target.Get(new Uri("https://source"));
-            Assert.NotNull(item);
-            Target.Clear(new Uri("https://source"), new Uri("https://storage2"));
-            item = Target.Get(new Uri("https://source"));
-            Assert.NotNull(item);
-            Assert.Equal("https://source1/d", item.SourceUrl.AbsoluteUri);
-            Assert.Equal("https://storage1/d", item.StorageUrl.AbsoluteUri);
+            Assert.True(item.IsCopySucceeded);
+            Assert.Equal(originalIconUrlString, item.SourceUrl.AbsoluteUri);
+            Assert.Equal(DefaultResolvedUrlString, item.StorageUrl.AbsoluteUri);
         }
 
         [Fact]
@@ -130,8 +158,8 @@ namespace CatalogTests.Icons
 
             await Target.InitializeAsync(CancellationToken.None);
 
-            Target.Set(new Uri("https://sourcez"), ExternalIconCopyResult.Success(new Uri("https://source1/d"), new Uri("https://storage1/d")));
-            Target.Set(new Uri("https://sourcey"), ExternalIconCopyResult.Success(new Uri("https://source2/d"), new Uri("https://storage2/d")));
+            await Target.SaveExternalIcon(new Uri("https://sourcez"), new Uri("https://storage1/d"), IconCacheStorageMock.Object, CancellationToken.None);
+            Target.SaveExternalCopyFailure(new Uri("https://sourcey"));
 
             string savedContent = null;
 
@@ -146,11 +174,9 @@ namespace CatalogTests.Icons
                 .Verify(s => s.SaveAsync(new Uri("https://cache.test/blob"), It.IsAny<StringStorageContent>(), CancellationToken.None), Times.Once);
 
             Assert.Contains("https://sourcez", savedContent);
+            Assert.DoesNotContain("https://storage1/d", savedContent); // this url is only used for copying blob
+            Assert.Contains(DefaultResolvedUrlString, savedContent);
             Assert.Contains("https://sourcey", savedContent);
-            Assert.Contains("https://source1/d", savedContent);
-            Assert.Contains("https://source2/d", savedContent);
-            Assert.Contains("https://storage1/d", savedContent);
-            Assert.Contains("https://storage2/d", savedContent);
         }
 
         public IconCopyResultCacheFacts()
@@ -161,6 +187,14 @@ namespace CatalogTests.Icons
                 .Setup(s => s.ResolveUri("c2i_cache.json"))
                 .Returns(new Uri("https://cache.test/blob"))
                 .Verifiable();
+
+            IconCacheStorageMock = new Mock<IStorage>();
+            IconCacheStorageMock
+                .Setup(ics => ics.CopyAsync(It.IsAny<Uri>(), It.IsAny<IStorage>(), It.IsAny<Uri>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            IconCacheStorageMock
+                .Setup(ics => ics.ResolveUri(It.IsAny<string>()))
+                .Returns(new Uri(DefaultResolvedUrlString));
 
             var responseStreamContentMock = new Mock<StorageContent>();
             responseStreamContentMock
@@ -175,9 +209,12 @@ namespace CatalogTests.Icons
             Target = new IconCopyResultCache(StorageMock.Object);
         }
 
+        private const string DefaultResolvedUrlString = "https://resolved.test/uri";
+
         private string Data { get; set; }
 
         private Mock<IStorage> StorageMock { get; set; }
         private IconCopyResultCache Target { get; set; }
+        private Mock<IStorage> IconCacheStorageMock { get; set; }
     }
 }


### PR DESCRIPTION
The idea to use destination storage as the cache at the same time was wrong because we allowed editing metadata for a long time.