### PR TITLE
ExistsAsync in IStorage

### DIFF
--- a/src/Catalog/Persistence/AggregateStorage.cs
+++ b/src/Catalog/Persistence/AggregateStorage.cs
@@ -94,6 +94,11 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             return _primaryStorage.Exists(fileName);
         }
 
+        public override async Task<bool> ExistsAsync(string filename, CancellationToken cancellationToken)
+        {
+            return await _primaryStorage.ExistsAsync(filename, cancellationToken);
+        }
+
         public override Task<IEnumerable<StorageListItem>> ListAsync(CancellationToken cancellationToken)
         {
             return _primaryStorage.ListAsync(cancellationToken);

--- a/src/Catalog/Persistence/AzureStorage.cs
+++ b/src/Catalog/Persistence/AzureStorage.cs
@@ -179,6 +179,23 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             return false;
         }
 
+        public override async Task<bool> ExistsAsync(string fileName, CancellationToken cancellationToken)
+        {
+            var packageRegistrationUri = ResolveUri(fileName);
+            string blobName = GetName(packageRegistrationUri);
+            var blob = GetBlockBlobReference(blobName);
+
+            if (await blob.ExistsAsync(cancellationToken))
+            {
+                return true;
+            }
+            if (Verbose)
+            {
+                Trace.WriteLine(string.Format("The blob {0} does not exist.", packageRegistrationUri));
+            }
+            return false;
+        }
+
         public override async Task<IEnumerable<StorageListItem>> ListAsync(CancellationToken cancellationToken)
         {
             var files = await _directory.ListBlobsAsync(cancellationToken);

--- a/src/Catalog/Persistence/FileStorage.cs
+++ b/src/Catalog/Persistence/FileStorage.cs
@@ -37,6 +37,11 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             return File.Exists(fileName);
         }
 
+        public override Task<bool> ExistsAsync(string filename, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Exists(filename));
+        }
+
         public override Task<IEnumerable<StorageListItem>> ListAsync(CancellationToken cancellationToken)
         {
             DirectoryInfo directoryInfo = new DirectoryInfo(Path);

--- a/src/Catalog/Persistence/IStorage.cs
+++ b/src/Catalog/Persistence/IStorage.cs
@@ -27,5 +27,6 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
         Task<string> LoadStringAsync(Uri resourceUri, CancellationToken cancellationToken);
         Uri ResolveUri(string relativeUri);
         Task SaveAsync(Uri resourceUri, StorageContent content, CancellationToken cancellationToken);
+        Task<bool> ExistsAsync(string fileName, CancellationToken cancellationToken);
     }
 }

--- a/src/Catalog/Persistence/Storage.cs
+++ b/src/Catalog/Persistence/Storage.cs
@@ -167,6 +167,7 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
         public abstract Task<IEnumerable<StorageListItem>> ListAsync(CancellationToken cancellationToken);
 
         public abstract bool Exists(string fileName);
+        public abstract Task<bool> ExistsAsync(string fileName, CancellationToken cancellationToken);
 
         public Uri ResolveUri(string relativeUri)
         {

--- a/src/Catalog/Registration/RecordingStorage.cs
+++ b/src/Catalog/Registration/RecordingStorage.cs
@@ -81,5 +81,10 @@ namespace NuGet.Services.Metadata.Catalog.Registration
         {
             return _innerStorage.ListAsync(cancellationToken);
         }
+
+        public Task<bool> ExistsAsync(string fileName, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/tests/CatalogTests/Icons/CatalogLeafDataProcessorFacts.cs
+++ b/tests/CatalogTests/Icons/CatalogLeafDataProcessorFacts.cs
@@ -518,6 +518,11 @@ namespace CatalogTests.Icons
             {
                 throw new NotImplementedException();
             }
+
+            public override Task<bool> ExistsAsync(string fileName, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/tests/NgTests/Infrastructure/MemoryStorage.cs
+++ b/tests/NgTests/Infrastructure/MemoryStorage.cs
@@ -191,5 +191,10 @@ namespace NgTests.Infrastructure
                 return false;
             }
         }
+
+        public override Task<bool> ExistsAsync(string fileName, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Exists(fileName));
+        }
     }
 }

--- a/tests/NuGet.Services.AzureSearch.Tests/Support/TestCursorStorage.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Support/TestCursorStorage.cs
@@ -61,5 +61,10 @@ namespace NuGet.Services.AzureSearch.Support
             Uri resourceUri, 
             DeleteRequestOptions deleteRequestOptions,
             CancellationToken cancellationToken) => throw new NotImplementedException();
+
+        public override Task<bool> ExistsAsync(string fileName, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
Currently, `Exists` (non-async) only exists in `Storage`. So if one wants to call it in their code, they have to use `Storage` instead of `IStorage` and then suffer with tests.
This change adds async version to the interface and implementation, leaving existing as is.