### PR TITLE
Increase Auxiliary2AzureSearch max download count decrease safety valve

### DIFF
--- a/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchConfiguration.cs
@@ -14,5 +14,6 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
         public string AuxiliaryDataStorageExcludedPackagesPath { get; }
         public string AuxiliaryDataStorageVerifiedPackagesPath { get; set; }
         public TimeSpan MinPushPeriod { get; set; }
+        public int MaxDownloadCountDecreases { get; set; } = 15000;
     }
 }


### PR DESCRIPTION
There 10,603 decreases in PROD right now related to the stats pipeline outage. Right now the job halts if there are 5,000 or more decreases. I made this max configurable and increases the default to 15,000.

Address https://github.com/NuGet/NuGetGallery/issues/7610