### PR TITLE
Fix name of "RequireLicenseAcceptance" property in catalog

### DIFF
--- a/src/NuGet.Protocol.Catalog/Models/PackageDetailsCatalogLeaf.cs
+++ b/src/NuGet.Protocol.Catalog/Models/PackageDetailsCatalogLeaf.cs
@@ -64,8 +64,8 @@ namespace NuGet.Protocol.Catalog
         [JsonProperty("releaseNotes")]
         public string ReleaseNotes { get; set; }
 
-        [JsonProperty("requireLicenseAgreement")]
-        public bool? RequireLicenseAgreement { get; set; }
+        [JsonProperty("requireLicenseAcceptance")]
+        public bool? RequireLicenseAcceptance { get; set; }
 
         [JsonProperty("summary")]
         public string Summary { get; set; }

--- a/src/NuGet.Services.AzureSearch/BaseDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/BaseDocumentBuilder.cs
@@ -158,7 +158,7 @@ namespace NuGet.Services.AzureSearch
             document.ProjectUrl = leaf.ProjectUrl;
             document.Published = leaf.Published;
             document.ReleaseNotes = leaf.ReleaseNotes;
-            document.RequiresLicenseAcceptance = leaf.RequireLicenseAgreement;
+            document.RequiresLicenseAcceptance = leaf.RequireLicenseAcceptance;
             document.SemVerLevel = leaf.IsSemVer2() ? SemVerLevelKey.SemVer2 : SemVerLevelKey.Unknown;
             document.SortableTitle = GetSortableTitle(leaf.Title, leaf.PackageId);
             document.Summary = leaf.Summary;

--- a/tests/NuGet.Protocol.Catalog.Tests/CatalogClientFacts.cs
+++ b/tests/NuGet.Protocol.Catalog.Tests/CatalogClientFacts.cs
@@ -92,6 +92,23 @@ namespace NuGet.Protocol.Catalog
             }
 
             [Fact]
+            public async Task ParsesRequiresLicenseAcceptance()
+            {
+                // Arrange
+                using (var httpClient = new HttpClient(new TestDataHttpMessageHandler()))
+                {
+                    var client = GetCatalogClient(httpClient);
+
+                    // Act
+                    var actual = await client.GetPackageDetailsLeafAsync(TestData.PackageDetailsLeafWithRequireLicenseAcceptanceUrl);
+
+                    // Assert
+                    Assert.NotNull(actual);
+                    Assert.True(actual.RequireLicenseAcceptance);
+                }
+            }
+
+            [Fact]
             public async Task WorksWithNuGetOrgDependencyVersionRangeArraySnapshot()
             {
                 // Arrange

--- a/tests/NuGet.Protocol.Catalog.Tests/TestData.Designer.cs
+++ b/tests/NuGet.Protocol.Catalog.Tests/TestData.Designer.cs
@@ -196,6 +196,34 @@ namespace NuGet.Protocol.Catalog {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;@id&quot;: &quot;https://api.nuget.org/v3/catalog0/data/2015.02.01.06.22.45/antixss.4.0.1.json&quot;,
+        ///  &quot;@type&quot;: [
+        ///    &quot;PackageDetails&quot;,
+        ///    &quot;catalog:Permalink&quot;
+        ///  ],
+        ///  &quot;authors&quot;: &quot;Microsoft&quot;,
+        ///  &quot;catalog:commitId&quot;: &quot;b3f4fc8a-7522-42a3-8fee-a91d5488c0b1&quot;,
+        ///  &quot;catalog:commitTimeStamp&quot;: &quot;2015-02-01T06:22:45.8488496Z&quot;,
+        ///  &quot;created&quot;: &quot;2011-01-07T07:49:50.307Z&quot;,
+        ///  &quot;description&quot;: &quot;AntiXSS is an encoding library which uses a safe list approach to encoding. It provides Html, XML, Url, Form, LDAP, CSS, JScript and VBScr [rest of string was truncated]&quot;;.
+        /// </summary>
+        public static string PackageDetailsLeafWithRequireLicenseAcceptance {
+            get {
+                return ResourceManager.GetString("PackageDetailsLeafWithRequireLicenseAcceptance", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to https://api.nuget.org/v3/catalog0/data/2015.02.01.06.22.45/antixss.4.0.1.json.
+        /// </summary>
+        public static string PackageDetailsLeafWithRequireLicenseAcceptanceUrl {
+            get {
+                return ResourceManager.GetString("PackageDetailsLeafWithRequireLicenseAcceptanceUrl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {&quot;@id&quot;:&quot;https://api.nuget.org/v3/registration3-gz-semver2/microbuild.core/index.json&quot;,&quot;@type&quot;:[&quot;catalog:CatalogRoot&quot;,&quot;PackageRegistration&quot;,&quot;catalog:Permalink&quot;],&quot;commitId&quot;:&quot;bef2767e-f5ae-4713-b5fc-510945bacdf9&quot;,&quot;commitTimeStamp&quot;:&quot;2018-11-26T19:53:07.9393299Z&quot;,&quot;count&quot;:1,&quot;items&quot;:[{&quot;@id&quot;:&quot;https://api.nuget.org/v3/registration3-gz-semver2/microbuild.core/index.json#page/0.1.1/0.3.1&quot;,&quot;@type&quot;:&quot;catalog:CatalogPage&quot;,&quot;commitId&quot;:&quot;bef2767e-f5ae-4713-b5fc-510945bacdf9&quot;,&quot;commitTimeStamp&quot;:&quot;2018-11-26T19:53:07.9393299Z&quot;,&quot;c [rest of string was truncated]&quot;;.
         /// </summary>
         public static string RegistrationIndexInlinedItems {

--- a/tests/NuGet.Protocol.Catalog.Tests/TestData.resx
+++ b/tests/NuGet.Protocol.Catalog.Tests/TestData.resx
@@ -462,6 +462,72 @@
   <data name="PackageDetailsCatalogLeafUrl" xml:space="preserve">
     <value>https://api.nuget.org/v3/catalog0/data/2017.11.06.22.07.49/dotnettency.container.1.3.2.json</value>
   </data>
+  <data name="PackageDetailsLeafWithRequireLicenseAcceptance" xml:space="preserve">
+    <value>{
+  "@id": "https://api.nuget.org/v3/catalog0/data/2015.02.01.06.22.45/antixss.4.0.1.json",
+  "@type": [
+    "PackageDetails",
+    "catalog:Permalink"
+  ],
+  "authors": "Microsoft",
+  "catalog:commitId": "b3f4fc8a-7522-42a3-8fee-a91d5488c0b1",
+  "catalog:commitTimeStamp": "2015-02-01T06:22:45.8488496Z",
+  "created": "2011-01-07T07:49:50.307Z",
+  "description": "AntiXSS is an encoding library which uses a safe list approach to encoding. It provides Html, XML, Url, Form, LDAP, CSS, JScript and VBScript encoding methods to allow \nyou to avoid Cross Site Scripting attacks. This library is part of the Microsoft SDL tools.",
+  "id": "AntiXSS",
+  "isPrerelease": false,
+  "language": "en-US",
+  "lastEdited": "0001-01-01T00:00:00Z",
+  "licenseUrl": "http://wpl.codeplex.com/license",
+  "packageHash": "Yim7Vde4dMtYF2mASw881JHKqs/TJ70O8QSIXAETYjznpKGxOXx46nbKbuldU9OgFqHcXabMZJWu8MVU4/uHOg==",
+  "packageHashAlgorithm": "SHA512",
+  "packageSize": 329780,
+  "published": "1900-01-01T00:00:00Z",
+  "requireLicenseAcceptance": true,
+  "summary": "AntiXSS is an encoding library which uses a safe list approach to encoding. It provides Html, XML, Url, Form, LDAP, CSS, JScript and VBScript encoding methods to allow \nyou to avoid Cross Site Scripting attacks. This library is part of the Microsoft SDL tools.",
+  "version": "4.0.1",
+  "@context": {
+    "@vocab": "http://schema.nuget.org/schema#",
+    "catalog": "http://schema.nuget.org/catalog#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "dependencies": {
+      "@id": "dependency",
+      "@container": "@set"
+    },
+    "dependencyGroups": {
+      "@id": "dependencyGroup",
+      "@container": "@set"
+    },
+    "packageEntries": {
+      "@id": "packageEntry",
+      "@container": "@set"
+    },
+    "supportedFrameworks": {
+      "@id": "supportedFramework",
+      "@container": "@set"
+    },
+    "tags": {
+      "@id": "tag",
+      "@container": "@set"
+    },
+    "published": {
+      "@type": "xsd:dateTime"
+    },
+    "created": {
+      "@type": "xsd:dateTime"
+    },
+    "lastEdited": {
+      "@type": "xsd:dateTime"
+    },
+    "catalog:commitTimeStamp": {
+      "@type": "xsd:dateTime"
+    }
+  }
+}</value>
+  </data>
+  <data name="PackageDetailsLeafWithRequireLicenseAcceptanceUrl" xml:space="preserve">
+    <value>https://api.nuget.org/v3/catalog0/data/2015.02.01.06.22.45/antixss.4.0.1.json</value>
+  </data>
   <data name="RegistrationIndexInlinedItems" xml:space="preserve">
     <value>{"@id":"https://api.nuget.org/v3/registration3-gz-semver2/microbuild.core/index.json","@type":["catalog:CatalogRoot","PackageRegistration","catalog:Permalink"],"commitId":"bef2767e-f5ae-4713-b5fc-510945bacdf9","commitTimeStamp":"2018-11-26T19:53:07.9393299Z","count":1,"items":[{"@id":"https://api.nuget.org/v3/registration3-gz-semver2/microbuild.core/index.json#page/0.1.1/0.3.1","@type":"catalog:CatalogPage","commitId":"bef2767e-f5ae-4713-b5fc-510945bacdf9","commitTimeStamp":"2018-11-26T19:53:07.9393299Z","count":4,"items":[{"@id":"https://api.nuget.org/v3/registration3-gz-semver2/microbuild.core/0.1.1.json","@type":"Package","commitId":"bef2767e-f5ae-4713-b5fc-510945bacdf9","commitTimeStamp":"2018-11-26T19:53:07.9393299Z","catalogEntry":{"@id":"https://api.nuget.org/v3/catalog0/data/2018.11.13.04.43.04/microbuild.core.0.1.1.json","@type":"PackageDetails","authors":"Microsoft","description":"MicroBuild bootstrapper package which wires up build targets that load and execute other MicroBuild plugins during the build","iconUrl":"","id":"MicroBuild.Core","language":"","licenseUrl":"","listed":false,"minClientVersion":"","packageContent":"https://api.nuget.org/v3-flatcontainer/microbuild.core/0.1.1/microbuild.core.0.1.1.nupkg","projectUrl":"","published":"1900-01-01T00:00:00+00:00","requireLicenseAcceptance":false,"summary":"","tags":["MicroBuild"],"title":"","version":"0.1.1"},"packageContent":"https://api.nuget.org/v3-flatcontainer/microbuild.core/0.1.1/microbuild.core.0.1.1.nupkg","registration":"https://api.nuget.org/v3/registration3-gz-semver2/microbuild.core/index.json"},{"@id":"https://api.nuget.org/v3/registration3-gz-semver2/microbuild.core/0.2.0.json","@type":"Package","commitId":"bef2767e-f5ae-4713-b5fc-510945bacdf9","commitTimeStamp":"2018-11-26T19:53:07.9393299Z","catalogEntry":{"@id":"https://api.nuget.org/v3/catalog0/data/2018.11.13.04.43.04/microbuild.core.0.2.0.json","@type":"PackageDetails","authors":"Microsoft","description":"MicroBuild bootstrapper package which wires up build targets that load and execute other MicroBuild plugins during the build","iconUrl":"","id":"MicroBuild.Core","language":"","licenseUrl":"http://microsoft.mit-license.org/","listed":false,"minClientVersion":"","packageContent":"https://api.nuget.org/v3-flatcontainer/microbuild.core/0.2.0/microbuild.core.0.2.0.nupkg","projectUrl":"","published":"1900-01-01T00:00:00+00:00","requireLicenseAcceptance":false,"summary":"","tags":["MicroBuild"],"title":"","version":"0.2.0"},"packageContent":"https://api.nuget.org/v3-flatcontainer/microbuild.core/0.2.0/microbuild.core.0.2.0.nupkg","registration":"https://api.nuget.org/v3/registration3-gz-semver2/microbuild.core/index.json"},{"@id":"https://api.nuget.org/v3/registration3-gz-semver2/microbuild.core/0.3.0.json","@type":"Package","commitId":"bef2767e-f5ae-4713-b5fc-510945bacdf9","commitTimeStamp":"2018-11-26T19:53:07.9393299Z","catalogEntry":{"@id":"https://api.nuget.org/v3/catalog0/data/2018.11.26.19.52.28/microbuild.core.0.3.0.json","@type":"PackageDetails","authors":"Microsoft","description":"MicroBuild bootstrapper package which wires up build targets that load and execute other MicroBuild plugins during the build","iconUrl":"","id":"MicroBuild.Core","language":"","licenseUrl":"http://microsoft.mit-license.org/","listed":false,"minClientVersion":"","packageContent":"https://api.nuget.org/v3-flatcontainer/microbuild.core/0.3.0/microbuild.core.0.3.0.nupkg","projectUrl":"","published":"1900-01-01T00:00:00+00:00","requireLicenseAcceptance":false,"summary":"","tags":["MicroBuild"],"title":"","version":"0.3.0"},"packageContent":"https://api.nuget.org/v3-flatcontainer/microbuild.core/0.3.0/microbuild.core.0.3.0.nupkg","registration":"https://api.nuget.org/v3/registration3-gz-semver2/microbuild.core/index.json"},{"@id":"https://api.nuget.org/v3/registration3-gz-semver2/microbuild.core/0.3.1.json","@type":"Package","commitId":"bef2767e-f5ae-4713-b5fc-510945bacdf9","commitTimeStamp":"2018-11-26T19:53:07.9393299Z","catalogEntry":{"@id":"https://api.nuget.org/v3/catalog0/data/2018.11.26.19.49.07/microbuild.core.0.3.1.json","@type":"PackageDetails","authors":"Microsoft","description":"MicroBuild bootstrapper package which wires up build targets that load and execute other MicroBuild plugins during the build","iconUrl":"https://github.com/MicrosoftDocs/Microbuild.Core/blob/master/extension-icon.png?raw=true","id":"MicroBuild.Core","language":"en-US","licenseUrl":"http://microsoft.mit-license.org/","listed":true,"minClientVersion":"","packageContent":"https://api.nuget.org/v3-flatcontainer/microbuild.core/0.3.1/microbuild.core.0.3.1.nupkg","projectUrl":"https://aka.ms/microbuild.package","published":"2018-11-13T04:26:56.943+00:00","requireLicenseAcceptance":true,"summary":"","tags":["MicroBuild"],"title":"","version":"0.3.1"},"packageContent":"https://api.nuget.org/v3-flatcontainer/microbuild.core/0.3.1/microbuild.core.0.3.1.nupkg","registration":"https://api.nuget.org/v3/registration3-gz-semver2/microbuild.core/index.json"}],"parent":"https://api.nuget.org/v3/registration3-gz-semver2/microbuild.core/index.json","lower":"0.1.1","upper":"0.3.1"}],"@context":{"@vocab":"http://schema.nuget.org/schema#","catalog":"http://schema.nuget.org/catalog#","xsd":"http://www.w3.org/2001/XMLSchema#","items":{"@id":"catalog:item","@container":"@set"},"commitTimeStamp":{"@id":"catalog:commitTimeStamp","@type":"xsd:dateTime"},"commitId":{"@id":"catalog:commitId"},"count":{"@id":"catalog:count"},"parent":{"@id":"catalog:parent","@type":"@id"},"tags":{"@container":"@set","@id":"tag"},"packageTargetFrameworks":{"@container":"@set","@id":"packageTargetFramework"},"dependencyGroups":{"@container":"@set","@id":"dependencyGroup"},"dependencies":{"@container":"@set","@id":"dependency"},"packageContent":{"@type":"@id"},"published":{"@type":"xsd:dateTime"},"registration":{"@type":"@id"}}}</value>
   </data>

--- a/tests/NuGet.Protocol.Catalog.Tests/TestDataHttpMessageHandler.cs
+++ b/tests/NuGet.Protocol.Catalog.Tests/TestDataHttpMessageHandler.cs
@@ -24,6 +24,7 @@ namespace NuGet.Protocol.Catalog
             { TestData.RegistrationLeafListedUrl, () => TestData.RegistrationLeafListed },
             { TestData.RegistrationPageUrl, () => TestData.RegistrationPage },
             { TestData.CatalogLeafInvalidDependencyVersionRangeUrl, () => TestData.CatalogLeafInvalidDependencyVersionRange },
+            { TestData.PackageDetailsLeafWithRequireLicenseAcceptanceUrl, () => TestData.PackageDetailsLeafWithRequireLicenseAcceptance },
         };
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/tests/NuGet.Services.AzureSearch.Tests/HijackDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/HijackDocumentBuilderFacts.cs
@@ -380,7 +380,7 @@ namespace NuGet.Services.AzureSearch
             public void LeavesNullRequiresLicenseAcceptanceAsNull()
             {
                 var leaf = Data.Leaf;
-                leaf.RequireLicenseAgreement = null;
+                leaf.RequireLicenseAcceptance = null;
 
                 var document = _target.FullFromCatalog(Data.NormalizedVersion, Data.HijackDocumentChanges, leaf);
 

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
@@ -440,7 +440,7 @@ namespace NuGet.Services.AzureSearch
             public void LeavesNullRequiresLicenseAcceptanceAsNull()
             {
                 var leaf = Data.Leaf;
-                leaf.RequireLicenseAgreement = null;                
+                leaf.RequireLicenseAcceptance = null;
 
                 var document = _target.UpdateLatestFromCatalog(
                     Data.SearchFilters,

--- a/tests/NuGet.Services.AzureSearch.Tests/Support/Data.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Support/Data.cs
@@ -181,7 +181,7 @@ namespace NuGet.Services.AzureSearch.Support
             ProjectUrl = "https://github.com/Azure/azure-storage-net",
             Published = new DateTimeOffset(new DateTime(2017, 1, 3), TimeSpan.Zero),
             ReleaseNotes = "Release notes.",
-            RequireLicenseAgreement = true,
+            RequireLicenseAcceptance = true,
             Summary = "Summary.",
             Tags = new List<string> { "Microsoft", "Azure", "Storage", "Table", "Blob", "File", "Queue", "Scalable", "windowsazureofficial" },
             Title = "Windows Azure Storage",


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/7637

It was incorrectly set as `requireLicenseAgreement`. I will fix docs next.

To fully rectify this we will need an index rebuild. Not all packages are affected since Db2AzureSearch sets the right value.

Note that the search index and the gallery DB call it <code>Require<b><u>s</u></b>LicenseAcceptance</code> while the catalog, V2, and the .nuspec call it <code>requireLicenseAcceptance</code>. The `s` is unfortunately different. Ideally the Azure Search index would match the .nuspec and catalog since I would say that is more official (.nuspec is the boss) but it's not worth the trouble to fix at this point.

The impact is V2 always `RequireLicenseAcceptance` set to `false` for packages pushed after the last index rebuild (2019-09-03). This looks to be 15K packages out of the 303K total packages with this value set to `true`.

Compare the catalog leaf:
https://api.nuget.org/v3/catalog0/data/2019.09.03.21.05.22/gregsstack.vwoengage.net.api.0.1.11.json
... to the registration leaf item:
https://api.nuget.org/v3/registration3/gregsstack.vwoengage.net.api/index.json
... to the V2 response:
https://www.nuget.org/api/v2/Packages(Id='GregsStack.VwoEngage.Net.Api',Version='0.1.11')

🤦‍♂ 