### PR TITLE
Update NuGet.Jobs dependency to latest and align NuGetGallery version

### DIFF
--- a/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
+++ b/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
@@ -289,7 +289,7 @@
       <Version>1.0.8.3533</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Entities">
-      <Version>4.4.5-dev-2939401</Version>
+      <Version>4.4.5-dev-3213233</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
       <Version>2.58.0</Version>

--- a/src/Ng/Jobs/Catalog2LuceneJob.cs
+++ b/src/Ng/Jobs/Catalog2LuceneJob.cs
@@ -11,7 +11,6 @@ using Lucene.Net.Index;
 using Microsoft.Extensions.Logging;
 using NuGet.Indexing;
 using NuGet.Services.Configuration;
-using NuGet.Services.Entities;
 using NuGet.Services.Metadata.Catalog;
 
 namespace Ng.Jobs

--- a/src/NuGet.Indexing/NuGet.Indexing.csproj
+++ b/src/NuGet.Indexing/NuGet.Indexing.csproj
@@ -188,7 +188,7 @@
       <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Entities">
-      <Version>4.4.5-dev-2939401</Version>
+      <Version>4.4.5-dev-3213233</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>

--- a/src/NuGet.Services.V3/NuGet.Services.V3.csproj
+++ b/src/NuGet.Services.V3/NuGet.Services.V3.csproj
@@ -67,7 +67,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Common.Job">
-      <Version>4.3.0-dev-3159955</Version>
+      <Version>4.3.0-dev-3214091</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/CatalogTests/CatalogTests.csproj
+++ b/tests/CatalogTests/CatalogTests.csproj
@@ -275,9 +275,6 @@
     <PackageReference Include="Moq">
       <Version>4.10.1</Version>
     </PackageReference>
-    <PackageReference Include="NuGet.Packaging">
-      <Version>5.0.0-preview1.5665</Version>
-    </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
       <Version>2.58.0</Version>
     </PackageReference>

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryCloudBlob.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryCloudBlob.cs
@@ -26,6 +26,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
         public Uri Uri => throw new NotImplementedException();
         public string Name => throw new NotImplementedException();
         public DateTime LastModifiedUtc => throw new NotImplementedException();
+        public bool IsSnapshot => throw new NotImplementedException();
 
         public string ETag
         {
@@ -130,6 +131,11 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
         }
 
         public Task SetPropertiesAsync(AccessCondition accessCondition)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task SnapshotAsync(CancellationToken token)
         {
             throw new NotImplementedException();
         }

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryCloudBlobContainer.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/InMemoryCloudBlobContainer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
@@ -49,6 +50,11 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
 
                 return blob;
             }
+        }
+
+        public Task<ISimpleBlobResultSegment> ListBlobsSegmentedAsync(string prefix, bool useFlatBlobListing, BlobListingDetails blobListingDetails, int? maxResults, BlobContinuationToken blobContinuationToken, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
         }
 
         public Task SetPermissionsAsync(BlobContainerPermissions permissions)

--- a/tests/NuGet.Services.AzureSearch.Tests/DatabaseOwnerFetcherFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/DatabaseOwnerFetcherFacts.cs
@@ -128,6 +128,8 @@ namespace NuGet.Services.AzureSearch
             public DbSet<SymbolPackage> SymbolPackages { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
             public DbSet<Package> Packages { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
             public DbSet<PackageDeprecation> Deprecations { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public DbSet<PackageVulnerability> Vulnerabilities { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public DbSet<VulnerablePackageVersionRange> VulnerableRanges { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
             public bool Disposed { get; private set; }
 


### PR DESCRIPTION
This brings the new storage abstractions in NuGetGallery.Core flowing from https://github.com/NuGet/NuGetGallery/pull/7670 and https://github.com/NuGet/NuGet.Jobs/pull/835.