### PR TITLE
Make Lightning case insensitive for package ID

### DIFF
--- a/src/Ng/Jobs/LightningJob.cs
+++ b/src/Ng/Jobs/LightningJob.cs
@@ -257,9 +257,9 @@ namespace Ng.Jobs
 
                 foreach (var packageRegistrationGroup in catalogIndexEntries
                     .OrderBy(x => x.CommitTimeStamp)
-                    .ThenBy(x => x.Id)
+                    .ThenBy(x => x.Id, StringComparer.OrdinalIgnoreCase)
                     .ThenBy(x => x.Version)
-                    .GroupBy(x => x.Id))
+                    .GroupBy(x => x.Id, StringComparer.OrdinalIgnoreCase))
                 {
                     streamWriter.WriteLine("Element@{0}. {1}", numberOfEntries++, packageRegistrationGroup.Key);
 


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/7680

Verified by running `prepare` against PROD and looking at the `nspec` package ID. The latest 11 versions are "NSpec". The older ones are "nspec". They should all be in one batch, not two.