### PR TITLE
Align NuGet client packages to 5.0.0-preview1.5707

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
     <add key="nugetbuild" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
   </packageSources>

--- a/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
+++ b/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
@@ -294,12 +294,6 @@
     <PackageReference Include="NuGet.Services.Sql">
       <Version>2.58.0</Version>
     </PackageReference>
-    <PackageReference Include="NuGet.Protocol">
-      <Version>5.0.0-preview1.5665</Version>
-    </PackageReference>
-    <PackageReference Include="NuGet.Packaging">
-      <Version>5.0.0-preview1.5665</Version>
-    </PackageReference>
     <PackageReference Include="NuGet.StrongName.json-ld.net">
       <Version>1.0.6</Version>
     </PackageReference>
@@ -313,9 +307,6 @@
       <Version>4.8.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="NuGet.Packaging.Core">
-      <Version>5.0.0-preview1.5665</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
       <Version>2.58.0</Version>

--- a/src/Ng/Ng.csproj
+++ b/src/Ng/Ng.csproj
@@ -171,9 +171,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NuGet.Protocol">
-      <Version>5.0.0-preview1.5665</Version>
-    </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
       <Version>2.58.0</Version>
     </PackageReference>

--- a/src/NuGet.Indexing/Extraction/CatalogPackageReader.cs
+++ b/src/NuGet.Indexing/Extraction/CatalogPackageReader.cs
@@ -90,15 +90,10 @@ namespace NuGet.Indexing
 
         public override bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings)
         {
-            return false;
-        }
-
-        public override string GetContentHashForSignedPackage(CancellationToken token)
-        {
             throw new NotImplementedException();
         }
 
-        public override string GetContentHash(CancellationToken token)
+        public override string GetContentHash(CancellationToken token, Func<string> GetUnsignedPackageHash = null)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGet.Indexing/NuGet.Indexing.csproj
+++ b/src/NuGet.Indexing/NuGet.Indexing.csproj
@@ -181,9 +181,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NuGet.Packaging">
-      <Version>5.0.0-preview1.5665</Version>
-    </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
       <Version>2.58.0</Version>
     </PackageReference>

--- a/src/NuGet.Protocol.Catalog/NuGet.Protocol.Catalog.csproj
+++ b/src/NuGet.Protocol.Catalog/NuGet.Protocol.Catalog.csproj
@@ -64,7 +64,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Protocol">
-      <Version>4.8.0</Version>
+      <Version>5.0.0-preview1.5707</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/CatalogMetadataTests/CatalogMetadataTests.csproj
+++ b/tests/CatalogMetadataTests/CatalogMetadataTests.csproj
@@ -65,9 +65,6 @@
     <PackageReference Include="Moq">
       <Version>4.10.1</Version>
     </PackageReference>
-    <PackageReference Include="NuGet.Common">
-      <Version>5.0.0-preview1.5665</Version>
-    </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>
     </PackageReference>

--- a/tests/NgTests/NgTests.csproj
+++ b/tests/NgTests/NgTests.csproj
@@ -201,9 +201,6 @@
     <PackageReference Include="Moq">
       <Version>4.10.1</Version>
     </PackageReference>
-    <PackageReference Include="NuGet.Protocol">
-      <Version>5.0.0-preview1.5665</Version>
-    </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
       <Version>2.58.0</Version>
     </PackageReference>

--- a/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
+++ b/tests/NuGet.IndexingTests/NuGet.IndexingTests.csproj
@@ -97,9 +97,6 @@
     <PackageReference Include="NuGet.Services.Configuration">
       <Version>2.58.0</Version>
     </PackageReference>
-    <PackageReference Include="NuGet.Versioning">
-      <Version>5.0.0-preview1.5665</Version>
-    </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>
     </PackageReference>

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/NuGet.Services.AzureSearch.FunctionalTests.csproj
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/NuGet.Services.AzureSearch.FunctionalTests.csproj
@@ -77,9 +77,6 @@
     <PackageReference Include="NuGet.Services.Configuration">
       <Version>2.43.0</Version>
     </PackageReference>
-    <PackageReference Include="NuGet.Versioning">
-      <Version>5.0.0-preview1.5665</Version>
-    </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>
     </PackageReference>


### PR DESCRIPTION
This version is already coming into the Azure Search jobs via its NuGet.Jobs dependency.
https://github.com/NuGet/NuGet.Jobs/blob/49d771844b56b3c2243d0dc78dcbc61321607b3c/src/Validation.Common.Job/Validation.Common.Job.csproj#L112

This aligns the versions and fixes one API change.