### PR TITLE
Improve error message when an argument is not provided

### DIFF
--- a/src/Ng/Program.cs
+++ b/src/Ng/Program.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
@@ -95,6 +96,12 @@ namespace Ng
             catch (ArgumentException ae)
             {
                 _logger?.LogError("A required argument was not found or was malformed/invalid: {Exception}", ae);
+
+                Console.WriteLine(job != null ? job.GetUsage() : NgJob.GetUsageBase());
+            }
+            catch (KeyNotFoundException knfe)
+            {
+                _logger?.LogError("An expected key was not found. One possible cause of this is required argument has not been provided: {Exception}", knfe);
 
                 Console.WriteLine(job != null ? job.GetUsage() : NgJob.GetUsageBase());
             }


### PR DESCRIPTION
`KeyNotFoundException` can be thrown because this method is used a lot:
https://github.com/NuGet/ServerCommon/blob/01f97075c87121e48abd428771cb4f758861d572/src/NuGet.Services.Configuration/DictionaryExtensions.cs#L38

It's better to show the error message here and helps local/ops execution of `ng.exe`.