### PR TITLE
Move common V3 test support to V3.Tests

### DIFF
--- a/tests/NuGet.Services.AzureSearch.Tests/Support/Data.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Support/Data.cs
@@ -2,34 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.Extensions.Options;
 using Moq;
-using NuGet.Protocol.Catalog;
 using NuGet.Services.AzureSearch.AuxiliaryFiles;
-using NuGet.Services.Entities;
-using NuGet.Versioning;
-using NuGetGallery;
 using Xunit.Abstractions;
-using PackageDependency = NuGet.Protocol.Catalog.PackageDependency;
 
 namespace NuGet.Services.AzureSearch.Support
 {
-    public static class Data
+    public class Data : V3Data
     {
-        public const string GalleryBaseUrl = "https://example/";
-        public const string FlatContainerBaseUrl = "https://example/flat-container/";
-        public const string FlatContainerContainerName = "v3-flatcontainer";
-        public const string PackageId = "WindowsAzure.Storage";
-        public const string FullVersion = "7.1.2-alpha+git";
-        public static readonly string NormalizedVersion = NuGetVersion.Parse(FullVersion).ToNormalizedString();
-        public static readonly string LowerPackageId = PackageId.ToLowerInvariant();
-        public static readonly string LowerNormalizedVersion = NormalizedVersion.ToLowerInvariant();
-        public static readonly string GalleryLicenseUrl = $"{GalleryBaseUrl}packages/{PackageId}/{NormalizedVersion}/license";
-        public static readonly string FlatContainerIconUrl = $"{FlatContainerBaseUrl}{FlatContainerContainerName}/{LowerPackageId}/{LowerNormalizedVersion}/icon";
         public static readonly DateTimeOffset DocumentLastUpdated = new DateTimeOffset(2018, 12, 14, 9, 30, 0, TimeSpan.Zero);
-        public static readonly DateTimeOffset CommitTimestamp = new DateTimeOffset(2018, 12, 13, 12, 30, 0, TimeSpan.Zero);
-        public static readonly string CommitId = "6b9b24dd-7aec-48ae-afc1-2a117e3d50d1";
 
         public static void SetDocumentLastUpdated(IUpdatedDocument document, ITestOutputHelper output)
         {
@@ -39,35 +21,6 @@ namespace NuGet.Services.AzureSearch.Support
                 $"{currentTimestamp:O}. Replacing this value with {DocumentLastUpdated:O}.");
             document.LastUpdatedDocument = DocumentLastUpdated;
         }
-
-        public static Package PackageEntity => new Package
-        {
-            FlattenedAuthors = "Microsoft",
-            Copyright = "© Microsoft Corporation. All rights reserved.",
-            Created = new DateTime(2017, 1, 1),
-            Description = "Description.",
-            FlattenedDependencies = "Microsoft.Data.OData:5.6.4:net40-client|Newtonsoft.Json:6.0.8:net40-client",
-            Hash = "oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33+Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ==",
-            HashAlgorithm = "SHA512",
-            IconUrl = "http://go.microsoft.com/fwlink/?LinkID=288890",
-            IsPrerelease = true,
-            Language = "en-US",
-            LastEdited = new DateTime(2017, 1, 2),
-            LicenseUrl = "http://go.microsoft.com/fwlink/?LinkId=331471",
-            Listed = true,
-            MinClientVersion = "2.12",
-            NormalizedVersion = "7.1.2-alpha",
-            PackageFileSize = 3039254,
-            ProjectUrl = "https://github.com/Azure/azure-storage-net",
-            Published = new DateTime(2017, 1, 3),
-            ReleaseNotes = "Release notes.",
-            RequiresLicenseAcceptance = true,
-            SemVerLevelKey = SemVerLevelKey.SemVer2,
-            Summary = "Summary.",
-            Tags = "Microsoft Azure Storage Table Blob File Queue Scalable windowsazureofficial",
-            Title = "Windows Azure Storage",
-            Version = "7.1.2.0-alpha+git",
-        };
 
         public static string[] Versions => new[]
         {
@@ -137,56 +90,6 @@ namespace NuGet.Services.AzureSearch.Support
             PackageId,
             HijackDocumentChanges,
             PackageEntity);
-
-        public static PackageDetailsCatalogLeaf Leaf => new PackageDetailsCatalogLeaf
-        {
-            Authors = "Microsoft",
-            CommitId = CommitId,
-            CommitTimestamp = CommitTimestamp,
-            Copyright = "© Microsoft Corporation. All rights reserved.",
-            Created = new DateTimeOffset(new DateTime(2017, 1, 1), TimeSpan.Zero),
-            Description = "Description.",
-            DependencyGroups = new List<PackageDependencyGroup>
-            {
-                new PackageDependencyGroup
-                {
-                    TargetFramework = ".NETFramework4.0-Client",
-                    Dependencies = new List<PackageDependency>
-                    {
-                        new PackageDependency
-                        {
-                            Id = "Microsoft.Data.OData",
-                            Range = "[5.6.4, )",
-                        },
-                        new PackageDependency
-                        {
-                            Id = "Newtonsoft.Json",
-                            Range = "[6.0.8, )",
-                        },
-                    },
-                },
-            },
-            IconUrl = "http://go.microsoft.com/fwlink/?LinkID=288890",
-            IsPrerelease = true,
-            Language = "en-US",
-            LastEdited = new DateTimeOffset(new DateTime(2017, 1, 2), TimeSpan.Zero),
-            LicenseUrl = "http://go.microsoft.com/fwlink/?LinkId=331471",
-            Listed = true,
-            MinClientVersion = "2.12",
-            PackageHash = "oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33+Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ==",
-            PackageHashAlgorithm = "SHA512",
-            PackageId = PackageId,
-            PackageSize = 3039254,
-            PackageVersion = FullVersion,
-            ProjectUrl = "https://github.com/Azure/azure-storage-net",
-            Published = new DateTimeOffset(new DateTime(2017, 1, 3), TimeSpan.Zero),
-            ReleaseNotes = "Release notes.",
-            RequireLicenseAcceptance = true,
-            Summary = "Summary.",
-            Tags = new List<string> { "Microsoft", "Azure", "Storage", "Table", "Blob", "File", "Queue", "Scalable", "windowsazureofficial" },
-            Title = "Windows Azure Storage",
-            VerbatimVersion = "7.1.2.0-alpha+git",
-        };
 
         public static AuxiliaryFileMetadata GetAuxiliaryFileMetadata(string etag) => new AuxiliaryFileMetadata(
             DateTimeOffset.MinValue,

--- a/tests/NuGet.Services.AzureSearch.Tests/VersionList/VersionListsFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/VersionList/VersionListsFacts.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using NuGet.Services.V3.Support;
 using NuGet.Versioning;
 using Xunit;
 using Xunit.Abstractions;
@@ -311,10 +312,10 @@ namespace NuGet.Services.AzureSearch
                 IReadOnlyCollection<string> fullVersion,
                 IReadOnlyList<VersionAction> actions)
             {
-                foreach (var versionSubsetSequence in SubsetsOf(fullVersion))
+                foreach (var versionSubsetSequence in IterTools.SubsetsOf(fullVersion))
                 {
                     var versionSubset = versionSubsetSequence.ToList();
-                    var combinations = CombinationsOfTwo(versionSubset, actions);
+                    var combinations = IterTools.CombinationsOfTwo(versionSubset, actions);
                     foreach (var combination in combinations)
                     {
                         yield return combination.Select(x => ToVersionListChange(x.Item1, x.Item2));
@@ -339,98 +340,6 @@ namespace NuGet.Services.AzureSearch
                     default:
                         throw new NotSupportedException($"The version action {action} is not supported.");
                 }
-            }
-
-            /// <summary>
-            /// Source: https://stackoverflow.com/a/3098381
-            /// </summary>
-            private static IEnumerable<IEnumerable<Tuple<T, int>>> CombinationsOfTwoByIndex<T>(
-                IEnumerable<T> sequenceA,
-                IEnumerable<int> sequenceBCounts)
-            {
-                // This takes as input a sequence of elements (A) and a sequence of element counts (related to another
-                // sequence B). The count at each position is how many elements from B to combine with that element of
-                // A. Suppose the input is:
-                //
-                //   A = [ x, y, z ]
-                //   B = [ 2, 2, 2 ]
-                //
-                // The output (in no particular order) would be:
-                //
-                //   [
-                //     [ x-1, y-1, z-1 ], [ x-1, y-1, z-2 ],
-                //     [ x-1, y-2, z-1 ], [ x-1, y-2, z-2 ],
-                //     [ x-2, y-1, z-1 ], [ x-2, y-1, z-2 ],
-                //     [ x-2, y-2, z-1 ], [ x-2, y-2, z-2 ],
-                //   ]
-                //
-                // This allows the caller to index into sequence B and produce the combinations of A and B.
-                return from cpLine in CartesianProduct(
-                       from count in sequenceBCounts select Enumerable.Range(1, count))
-                       select cpLine.Zip(sequenceA, (x1, x2) => Tuple.Create(x2, x1));
-
-            }
-
-            private static IEnumerable<IEnumerable<Tuple<T1, T2>>> CombinationsOfTwo<T1, T2>(
-                IReadOnlyCollection<T1> sequenceA,
-                IReadOnlyList<T2> sequenceB)
-            {
-                // This has the same behavior as CombinationsOfTwoByIndex but maps the sequence B indexes to actual
-                // values. Suppose the input is:
-                //
-                //   A = [ x, y, z ]
-                //   B = [ a, b ]
-                //
-                // The output (in no particular order) would be:
-                //
-                //   [
-                //     [ x-a, y-a, z-a ], [ x-a, y-a, z-b ],
-                //     [ x-a, y-b, z-a ], [ x-a, y-b, z-b ],
-                //     [ x-b, y-a, z-a ], [ x-b, y-a, z-b ],
-                //     [ x-b, y-b, z-a ], [ x-b, y-b, z-b ],
-                //   ]
-                //
-                // This allows the caller to create combinations of A and B where A is fixed but B is varied per
-                // returned combination.
-                var arr2 = Enumerable.Repeat(sequenceB.Count, sequenceA.Count);
-                var combinations = CombinationsOfTwoByIndex(sequenceA, arr2);
-                return combinations.Select(x => x.Select(t => Tuple.Create(t.Item1, sequenceB[t.Item2 - 1])));
-            }
-
-            /// <summary>
-            /// Source: https://stackoverflow.com/a/3098381
-            /// </summary>
-            private static IEnumerable<IEnumerable<T>> CartesianProduct<T>(IEnumerable<IEnumerable<T>> sequences)
-            {
-                IEnumerable<IEnumerable<T>> emptyProduct = new[] { Enumerable.Empty<T>() };
-                return sequences.Aggregate(
-                    emptyProduct,
-                    (accumulator, sequence) =>
-                        from accseq in accumulator
-                        from item in sequence
-                        select accseq.Concat(new[] { item })
-                    );
-            }
-
-            /// <summary>
-            /// Source: https://stackoverflow.com/a/999182
-            /// </summary>
-            private static IEnumerable<IEnumerable<T>> SubsetsOf<T>(IEnumerable<T> source)
-            {
-                // This produces all subsets of the input. This includes the input itself and the empty set. The term
-                // "set" is used to emphasize that order does not matter. The input is assumed to have unique items. If
-                // it has duplicates, some output sets will also have duplicates.
-                if (!source.Any())
-                {
-                    return Enumerable.Repeat(Enumerable.Empty<T>(), 1);
-                }
-
-                var element = source.Take(1);
-
-                var haveNots = SubsetsOf(source.Skip(1));
-                var haves = haveNots.Select(set => element.Concat(set));
-
-                return haves.Concat(haveNots);
             }
 
             private enum VersionAction

--- a/tests/NuGet.Services.V3.Tests/NuGet.Services.V3.Tests.csproj
+++ b/tests/NuGet.Services.V3.Tests/NuGet.Services.V3.Tests.csproj
@@ -40,7 +40,9 @@
     <Compile Include="Registration\RegistrationClientFacts.cs" />
     <Compile Include="Registration\RegistrationUrlBuilderFacts.cs" />
     <Compile Include="Support\Cursor.cs" />
+    <Compile Include="Support\V3Data.cs" />
     <Compile Include="Support\DbSetMockFactory.cs" />
+    <Compile Include="Support\IterTools.cs" />
     <Compile Include="Support\RecordingLogger.cs" />
     <Compile Include="Support\TestCursorStorage.cs" />
     <Compile Include="Support\TestDbAsyncQueryProvider.cs" />

--- a/tests/NuGet.Services.V3.Tests/Support/IterTools.cs
+++ b/tests/NuGet.Services.V3.Tests/Support/IterTools.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NuGet.Services.V3.Support
+{
+    public static class IterTools
+    {
+        /// <summary>
+        /// Source: https://stackoverflow.com/a/3098381
+        /// </summary>
+        public static IEnumerable<IEnumerable<Tuple<T, int>>> CombinationsOfTwoByIndex<T>(
+            IEnumerable<T> sequenceA,
+            IEnumerable<int> sequenceBCounts)
+        {
+            // This takes as input a sequence of elements (A) and a sequence of element counts (related to another
+            // sequence B). The count at each position is how many elements from B to combine with that element of
+            // A. Suppose the input is:
+            //
+            //   A = [ x, y, z ]
+            //   B = [ 2, 2, 2 ]
+            //
+            // The output (in no particular order) would be:
+            //
+            //   [
+            //     [ x-1, y-1, z-1 ], [ x-1, y-1, z-2 ],
+            //     [ x-1, y-2, z-1 ], [ x-1, y-2, z-2 ],
+            //     [ x-2, y-1, z-1 ], [ x-2, y-1, z-2 ],
+            //     [ x-2, y-2, z-1 ], [ x-2, y-2, z-2 ],
+            //   ]
+            //
+            // This allows the caller to index into sequence B and produce the combinations of A and B.
+            return from cpLine in CartesianProduct(
+                   from count in sequenceBCounts select Enumerable.Range(1, count))
+                   select cpLine.Zip(sequenceA, (x1, x2) => Tuple.Create(x2, x1));
+
+        }
+
+        public static IEnumerable<IEnumerable<Tuple<T1, T2>>> CombinationsOfTwo<T1, T2>(
+            IReadOnlyCollection<T1> sequenceA,
+            IReadOnlyList<T2> sequenceB)
+        {
+            // This has the same behavior as CombinationsOfTwoByIndex but maps the sequence B indexes to actual
+            // values. Suppose the input is:
+            //
+            //   A = [ x, y, z ]
+            //   B = [ a, b ]
+            //
+            // The output (in no particular order) would be:
+            //
+            //   [
+            //     [ x-a, y-a, z-a ], [ x-a, y-a, z-b ],
+            //     [ x-a, y-b, z-a ], [ x-a, y-b, z-b ],
+            //     [ x-b, y-a, z-a ], [ x-b, y-a, z-b ],
+            //     [ x-b, y-b, z-a ], [ x-b, y-b, z-b ],
+            //   ]
+            //
+            // This allows the caller to create combinations of A and B where A is fixed but B is varied per
+            // returned combination.
+            var arr2 = Enumerable.Repeat(sequenceB.Count, sequenceA.Count);
+            var combinations = CombinationsOfTwoByIndex(sequenceA, arr2);
+            return combinations.Select(x => x.Select(t => Tuple.Create(t.Item1, sequenceB[t.Item2 - 1])));
+        }
+
+        /// <summary>
+        /// Source: https://stackoverflow.com/a/3098381
+        /// </summary>
+        public static IEnumerable<IEnumerable<T>> CartesianProduct<T>(IEnumerable<IEnumerable<T>> sequences)
+        {
+            IEnumerable<IEnumerable<T>> emptyProduct = new[] { Enumerable.Empty<T>() };
+            return sequences.Aggregate(
+                emptyProduct,
+                (accumulator, sequence) =>
+                    from accseq in accumulator
+                    from item in sequence
+                    select accseq.Concat(new[] { item })
+                );
+        }
+
+        /// <summary>
+        /// Source: https://stackoverflow.com/a/999182
+        /// </summary>
+        public static IEnumerable<IEnumerable<T>> SubsetsOf<T>(IEnumerable<T> source)
+        {
+            // This produces all subsets of the input. This includes the input itself and the empty set. The term
+            // "set" is used to emphasize that order does not matter. The input is assumed to have unique items. If
+            // it has duplicates, some output sets will also have duplicates.
+            if (!source.Any())
+            {
+                return Enumerable.Repeat(Enumerable.Empty<T>(), 1);
+            }
+
+            var element = source.Take(1);
+
+            var haveNots = SubsetsOf(source.Skip(1));
+            var haves = haveNots.Select(set => element.Concat(set));
+
+            return haves.Concat(haveNots);
+        }
+    }
+}

--- a/tests/NuGet.Services.V3.Tests/Support/V3Data.cs
+++ b/tests/NuGet.Services.V3.Tests/Support/V3Data.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Protocol.Catalog;
+using NuGet.Services.Entities;
+using NuGet.Versioning;
+using NuGetGallery;
+using PackageDependency = NuGet.Protocol.Catalog.PackageDependency;
+
+namespace NuGet.Services
+{
+    public class V3Data
+    {
+        public const string GalleryBaseUrl = "https://example/";
+        public const string FlatContainerBaseUrl = "https://example/flat-container/";
+        public const string FlatContainerContainerName = "v3-flatcontainer";
+        public const string PackageId = "WindowsAzure.Storage";
+        public const string FullVersion = "7.1.2-alpha+git";
+        public static readonly string NormalizedVersion = NuGetVersion.Parse(FullVersion).ToNormalizedString();
+        public static readonly string LowerPackageId = PackageId.ToLowerInvariant();
+        public static readonly string LowerNormalizedVersion = NormalizedVersion.ToLowerInvariant();
+        public static readonly string GalleryLicenseUrl = $"{GalleryBaseUrl}packages/{PackageId}/{NormalizedVersion}/license";
+        public static readonly string FlatContainerIconUrl = $"{FlatContainerBaseUrl}{FlatContainerContainerName}/{LowerPackageId}/{LowerNormalizedVersion}/icon";
+        public static readonly DateTimeOffset CommitTimestamp = new DateTimeOffset(2018, 12, 13, 12, 30, 0, TimeSpan.Zero);
+        public static readonly string CommitId = "6b9b24dd-7aec-48ae-afc1-2a117e3d50d1";
+
+        public static Package PackageEntity => new Package
+        {
+            FlattenedAuthors = "Microsoft",
+            Copyright = "© Microsoft Corporation. All rights reserved.",
+            Created = new DateTime(2017, 1, 1),
+            Description = "Description.",
+            FlattenedDependencies = "Microsoft.Data.OData:5.6.4:net40-client|Newtonsoft.Json:6.0.8:net40-client",
+            Hash = "oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33+Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ==",
+            HashAlgorithm = "SHA512",
+            IconUrl = "http://go.microsoft.com/fwlink/?LinkID=288890",
+            IsPrerelease = true,
+            Language = "en-US",
+            LastEdited = new DateTime(2017, 1, 2),
+            LicenseUrl = "http://go.microsoft.com/fwlink/?LinkId=331471",
+            Listed = true,
+            MinClientVersion = "2.12",
+            NormalizedVersion = "7.1.2-alpha",
+            PackageFileSize = 3039254,
+            ProjectUrl = "https://github.com/Azure/azure-storage-net",
+            Published = new DateTime(2017, 1, 3),
+            ReleaseNotes = "Release notes.",
+            RequiresLicenseAcceptance = true,
+            SemVerLevelKey = SemVerLevelKey.SemVer2,
+            Summary = "Summary.",
+            Tags = "Microsoft Azure Storage Table Blob File Queue Scalable windowsazureofficial",
+            Title = "Windows Azure Storage",
+            Version = "7.1.2.0-alpha+git",
+        };
+
+        public static PackageDetailsCatalogLeaf Leaf => new PackageDetailsCatalogLeaf
+        {
+            Authors = "Microsoft",
+            CommitId = CommitId,
+            CommitTimestamp = CommitTimestamp,
+            Copyright = "© Microsoft Corporation. All rights reserved.",
+            Created = new DateTimeOffset(new DateTime(2017, 1, 1), TimeSpan.Zero),
+            Description = "Description.",
+            DependencyGroups = new List<PackageDependencyGroup>
+            {
+                new PackageDependencyGroup
+                {
+                    TargetFramework = ".NETFramework4.0-Client",
+                    Dependencies = new List<PackageDependency>
+                    {
+                        new PackageDependency
+                        {
+                            Id = "Microsoft.Data.OData",
+                            Range = "[5.6.4, )",
+                        },
+                        new PackageDependency
+                        {
+                            Id = "Newtonsoft.Json",
+                            Range = "[6.0.8, )",
+                        },
+                    },
+                },
+            },
+            IconUrl = "http://go.microsoft.com/fwlink/?LinkID=288890",
+            IsPrerelease = true,
+            Language = "en-US",
+            LastEdited = new DateTimeOffset(new DateTime(2017, 1, 2), TimeSpan.Zero),
+            LicenseUrl = "http://go.microsoft.com/fwlink/?LinkId=331471",
+            Listed = true,
+            MinClientVersion = "2.12",
+            PackageHash = "oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33+Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ==",
+            PackageHashAlgorithm = "SHA512",
+            PackageId = PackageId,
+            PackageSize = 3039254,
+            PackageVersion = FullVersion,
+            ProjectUrl = "https://github.com/Azure/azure-storage-net",
+            Published = new DateTimeOffset(new DateTime(2017, 1, 3), TimeSpan.Zero),
+            ReleaseNotes = "Release notes.",
+            RequireLicenseAcceptance = true,
+            Summary = "Summary.",
+            Tags = new List<string> { "Microsoft", "Azure", "Storage", "Table", "Blob", "File", "Queue", "Scalable", "windowsazureofficial" },
+            Title = "Windows Azure Storage",
+            VerbatimVersion = "7.1.2.0-alpha+git",
+        };
+    }
+}


### PR DESCRIPTION
This stuff is generally useful for testing V3 jobs and can be used for future V3 jobs. In particular, this will help a Catalog2Registration rewrite.

`IterTools` is great for doing exhaustive unit tests of call combinations of some input data set. For example, Catalog2AzureSearch tests use this to generate all combinations of some catalog actions and verifying the resulting Azure Search index update operations are produced.