### PR TITLE
[Hotfix] Add missing reference in functional test solution

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -100,6 +100,12 @@ Invoke-BuildStep 'Building solution' {
     } `
     -ev +BuildErrors
 
+Invoke-BuildStep 'Building functional test solution' { 
+        $SolutionPath = Join-Path $PSScriptRoot "tests\NuGetServicesMetadata.FunctionalTests.sln"
+        Build-Solution $Configuration $BuildNumber -MSBuildVersion "15" $SolutionPath -SkipRestore:$SkipRestore `
+    } `
+    -ev +BuildErrors
+
 Invoke-BuildStep 'Signing the binaries' {
         Sign-Binaries -Configuration $Configuration -BuildNumber $BuildNumber -MSBuildVersion "15" `
     } `

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/NuGet.Services.AzureSearch.FunctionalTests.csproj
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/NuGet.Services.AzureSearch.FunctionalTests.csproj
@@ -77,6 +77,9 @@
     <PackageReference Include="NuGet.Services.Configuration">
       <Version>2.43.0</Version>
     </PackageReference>
+    <PackageReference Include="NuGet.Versioning">
+      <Version>5.0.0-preview1.5707</Version>
+    </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>
     </PackageReference>


### PR DESCRIPTION
This project is not built during the CI so I missed it.

The break occurred here:
https://github.com/NuGet/NuGet.Services.Metadata/commit/b061be9a8ed9ffe0fadf6fbe005b7d6aa22129a2#diff-cb948c5b0d471668e46787a0fdfed3c8L68-L70