### PR TITLE
Enable CORS on all origins for Azure Search

### DIFF
--- a/src/NuGet.Services.SearchService/App_Start/WebApiConfig.cs
+++ b/src/NuGet.Services.SearchService/App_Start/WebApiConfig.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Hosting;
 using System.Web.Http;
+using System.Web.Http.Cors;
 using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using Autofac.Integration.WebApi;
@@ -43,6 +44,15 @@ namespace NuGet.Services.SearchService
 
             var dependencyResolver = GetDependencyResolver(config);
             config.DependencyResolver = dependencyResolver;
+
+            config.EnableCors(new EnableCorsAttribute(
+                origins: "*",
+                headers: "Content-Type,If-Match,If-Modified-Since,If-None-Match,If-Unmodified-Since,Accept-Encoding",
+                methods: "GET,HEAD,OPTIONS",
+                exposedHeaders: "Content-Type,Content-Length,Last-Modified,Transfer-Encoding,ETag,Date,Vary,Server,X-Hit,X-CorrelationId")
+            {
+                PreflightMaxAge = 3600
+            });
 
             config.MapHttpAttributeRoutes();
 

--- a/src/NuGet.Services.SearchService/NuGet.Services.SearchService.csproj
+++ b/src/NuGet.Services.SearchService/NuGet.Services.SearchService.csproj
@@ -93,6 +93,9 @@
     <PackageReference Include="Microsoft.AspNet.WebApi">
       <Version>5.2.7</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNet.WebApi.Cors">
+      <Version>5.2.7</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuGet.Indexing\NuGet.Indexing.csproj">


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/7628.

The rule is copied from legacy search:
https://github.com/NuGet/NuGet.Services.Metadata/blob/bc7b6b5f3f84728946785d2021487876b130eb24/src/NuGet.Services.BasicSearch/Startup.cs#L157-L165