### PR TITLE
Add HiveMerger and supporting bookkeeping models

### DIFF
--- a/src/NuGet.Jobs.Catalog2Registration/Hives/Bookkeeping/IndexInfo.cs
+++ b/src/NuGet.Jobs.Catalog2Registration/Hives/Bookkeeping/IndexInfo.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Protocol.Registration;
+
+namespace NuGet.Jobs.Catalog2Registration
+{
+    /// <summary>
+    /// A class that handles the bookkeeping of modifying a registration index. It holds a reference to a
+    /// <see cref="RegistrationIndex"/> that can be later serialized into a blob. It also holds references to
+    /// bookkeeping objects for its contained pages.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class IndexInfo
+    {
+        private string DebuggerDisplay => $"Index ({Items.Count} page items)";
+
+        private readonly List<PageInfo> _items;
+
+        private IndexInfo(RegistrationIndex index, List<PageInfo> items)
+        {
+            Index = index ?? throw new ArgumentNullException(nameof(index));
+            _items = items ?? throw new ArgumentNullException(nameof(items));
+        }
+
+        public static IndexInfo Existing(IHiveStorage storage, HiveType hive, RegistrationIndex index)
+        {
+            // Ensure the index is sorted in ascending order by lower version bound.
+            var sorted = index.Items
+                .Select(pageItem => new
+                {
+                    PageItem = pageItem,
+                    PageInfo = PageInfo.Existing(pageItem, url => GetPageAsync(storage, hive, url)),
+                })
+                .OrderBy(x => x.PageInfo.Lower)
+                .ToList();
+
+            var items = sorted.Select(x => x.PageInfo).ToList();
+            index.Items.Clear();
+            index.Items.AddRange(sorted.Select(x => x.PageItem));
+
+            return new IndexInfo(index, items);
+        }
+
+        private static async Task<RegistrationPage> GetPageAsync(IHiveStorage storage, HiveType hive, string url)
+        {
+            return await storage.ReadPageAsync(hive, url);
+        }
+
+        public static IndexInfo New()
+        {
+            var index = new RegistrationIndex
+            {
+                Items = new List<RegistrationPage>(),
+            };
+
+            return new IndexInfo(index, new List<PageInfo>());
+        }
+
+        public RegistrationIndex Index { get; }
+        public IReadOnlyList<PageInfo> Items => _items;
+
+        public void RemoveAt(int index)
+        {
+            _items.RemoveAt(index);
+            Index.Items.RemoveAt(index);
+        }
+
+        public void Insert(int index, PageInfo pageInfo)
+        {
+            _items.Insert(index, pageInfo);
+            Index.Items.Insert(index, pageInfo.PageItem);
+        }
+    }
+}

--- a/src/NuGet.Jobs.Catalog2Registration/Hives/Bookkeeping/LeafInfo.cs
+++ b/src/NuGet.Jobs.Catalog2Registration/Hives/Bookkeeping/LeafInfo.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using NuGet.Protocol.Registration;
+using NuGet.Versioning;
+
+namespace NuGet.Jobs.Catalog2Registration
+{
+    /// <summary>
+    /// A class that handled the bookkeeping of a leaf item. The leaf item has minimal bookkeeping required except
+    /// maintaining a parsed version object for easy comparison.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class LeafInfo
+    {
+        private string DebuggerDisplay => $"Leaf {Version.ToNormalizedString()}";
+
+        private LeafInfo(NuGetVersion version, RegistrationLeafItem leafItem)
+        {
+            Version = version ?? throw new ArgumentNullException(nameof(version));
+            LeafItem = leafItem ?? throw new ArgumentNullException(nameof(leafItem));
+        }
+
+        public static LeafInfo New(NuGetVersion version)
+        {
+            return new LeafInfo(version, new RegistrationLeafItem
+            {
+                CatalogEntry = new RegistrationCatalogEntry
+                {
+                    Version = version.ToFullString(),
+                }
+            });
+        }
+
+        public static LeafInfo Existing(RegistrationLeafItem leafItem)
+        {
+            return new LeafInfo(
+                NuGetVersion.Parse(leafItem.CatalogEntry.Version),
+                leafItem);
+        }
+
+        public NuGetVersion Version { get; }
+        public RegistrationLeafItem LeafItem { get; }
+    }
+}

--- a/src/NuGet.Jobs.Catalog2Registration/Hives/Bookkeeping/PageInfo.cs
+++ b/src/NuGet.Jobs.Catalog2Registration/Hives/Bookkeeping/PageInfo.cs
@@ -1,0 +1,234 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Protocol.Registration;
+using NuGet.Services;
+using NuGet.Versioning;
+
+namespace NuGet.Jobs.Catalog2Registration
+{
+    /// <summary>
+    /// A class that handles the bookkeeping of a registration page. This contains the page item for easy access but
+    /// also has the logic to fetch the leaf items if they are not inlined.
+    /// 
+    /// The count and bounds properties are updated by the <see cref="InsertAsync(int, LeafInfo)"/> and
+    /// <see cref="RemoveAtAsync(int)"/> methods as items are moved around but note that the only property on the
+    /// <see cref="PageItem"/> (or external page) updated by this bookkeeping class is
+    /// <see cref="RegistrationPage.Items"/>. The other properties can be updated by the caller prior to serialization
+    /// as necessary.
+    /// 
+    /// The main benefit of a dedicated bookkeeping class is that it can hold parsed version instances and can keep
+    /// them up to date given relevant state-changing actions. For example, removing a leaf item changes the count and
+    /// can change the bounds.
+    /// 
+    /// In general pages are ephemeral things that don't hold any unique state than can't be inferred by the contained
+    /// leaf items.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class PageInfo
+    {
+        private string DebuggerDisplay =>
+            $"Page " +
+            $"[{Lower?.ToNormalizedString() ?? "null"}, {Upper?.ToNormalizedString() ?? "null"}] " +
+            $"({Count} leaf items)";
+
+        private readonly Lazy<Task> _lazyInitializeTask;
+        private RegistrationPage _page;
+        private List<LeafInfo> _leafInfos;
+
+        private PageInfo(
+            RegistrationPage pageItem,
+            Func<PageInfo, Task> initializeTaskFactory)
+        {
+            PageItem = pageItem ?? throw new ArgumentNullException(nameof(pageItem));
+
+            if (initializeTaskFactory == null)
+            {
+                throw new ArgumentNullException(nameof(initializeTaskFactory));
+            }
+
+            _lazyInitializeTask = new Lazy<Task>(() => initializeTaskFactory(this));
+        }
+
+        public static PageInfo New()
+        {
+            var pageItem = new RegistrationPage
+            {
+                Items = new List<RegistrationLeafItem>(),
+            };
+
+            var pageInfo = new PageInfo(pageItem, _ => Task.CompletedTask);
+            Initialize(pageInfo, pageItem);
+            return pageInfo;
+        }
+
+        public static PageInfo Existing(
+            RegistrationPage pageItem,
+            Func<string, Task<RegistrationPage>> getPageByUrlAsync)
+        {
+            if (pageItem.Items == null)
+            {
+                if (getPageByUrlAsync == null)
+                {
+                    throw new ArgumentNullException(nameof(getPageByUrlAsync));
+                }
+
+                return new PageInfo(
+                    pageItem,
+                    async pageInfo =>
+                    {
+                        var page = await getPageByUrlAsync(pageItem.Url);
+                        Initialize(pageInfo, page);
+                    })
+                {
+                    Count = pageItem.Count,
+                    Lower = NuGetVersion.Parse(pageItem.Lower),
+                    Upper = NuGetVersion.Parse(pageItem.Upper),
+                };
+            }
+            else
+            {
+                var pageInfo = new PageInfo(pageItem, _ => Task.CompletedTask);
+                Initialize(pageInfo, pageItem);
+                return pageInfo;
+            }
+        }
+
+        public bool IsInlined => PageItem.Items != null;
+        public int Count { get; private set; }
+        public NuGetVersion Lower { get; private set; }
+        public NuGetVersion Upper { get; private set; }
+        public RegistrationPage PageItem { get; set; }
+        public bool IsPageFetched => _lazyInitializeTask.IsValueCreated;
+
+        private static void Initialize(PageInfo pageInfo, RegistrationPage page)
+        {
+            // Ensure the page is sorted in ascending order by version.
+            var leafInfos = page
+                .Items
+                .Select(x => LeafInfo.Existing(x))
+                .OrderBy(x => x.Version)
+                .ToList();
+            page.Items.Clear();
+            page.Items.AddRange(leafInfos.Select(x => x.LeafItem));
+
+            // Update the bookkeeping with the latest information. The leaf items themselves are the "true" for the
+            // count, lower bound, and upper bound properties not whatever might be set on the page item.
+            pageInfo._page = page;
+            pageInfo._leafInfos = leafInfos;
+            pageInfo.Count = page.Items.Count;
+            pageInfo.Lower = leafInfos.FirstOrDefault()?.Version;
+            pageInfo.Upper = leafInfos.LastOrDefault()?.Version;
+        }
+
+        /// <summary>
+        /// Clone this page info into another instance but with the leaf items inlined. An inlined page is one that has
+        /// its leaf items in the page item, not in an external page.
+        /// </summary>
+        /// <returns>The new page info instance with leaf items inlined.</returns>
+        public async Task<PageInfo> CloneToInlinedAsync()
+        {
+            var page = await GetPageAsync();
+            return Existing(page, getPageByUrlAsync: null);
+        }
+
+        /// <summary>
+        /// Clone this page info into another instance but with the leaf items not inlined. A non-inlined page is one
+        /// that has a null item list in the page item. The leaf items are stored in an external page.
+        /// </summary>
+        /// <returns>The new page info instance with leaf items in a different page instance.</returns>
+        public async Task<PageInfo> CloneToNonInlinedAsync()
+        {
+            var page = await GetPageAsync();
+            var pageInfo = new PageInfo(new RegistrationPage(), _ => Task.CompletedTask);
+            Initialize(pageInfo, page);
+            return pageInfo;
+        }
+
+        public async Task<LeafInfo> RemoveAtAsync(int index)
+        {
+            var page = await GetPageAsync();
+            var leafInfos = await GetMutableLeafInfosAsync();
+
+            // Remove from the real page, for future serialization.
+            page.Items.RemoveAt(index);
+
+            // Remove from the leaf info list, for bookkeeping.
+            var leafInfo = leafInfos[index];
+            leafInfos.RemoveAt(index);
+
+            Count--;
+            UpdateBounds(page, leafInfos);
+
+            return leafInfo;
+        }
+
+        public async Task InsertAsync(int index, LeafInfo leafInfo)
+        {
+            var page = await GetPageAsync();
+            var leafInfos = await GetMutableLeafInfosAsync();
+
+            if (index > 0)
+            {
+                Guard.Assert(
+                    leafInfos[index - 1].Version < leafInfo.Version,
+                    "The version added to a page must have a higher version than the item before it.");
+            }
+
+            if (index < leafInfos.Count)
+            {
+                Guard.Assert(
+                    leafInfos[index].Version > leafInfo.Version,
+                    "The version added to a page must have a lower version than the item after it.");
+            }
+
+            // Add to the real page, for future serialization.
+            page.Items.Insert(index, leafInfo.LeafItem);
+
+            // Add to the leaf info list, for bookeeping.
+            leafInfos.Insert(index, leafInfo);
+
+            Count++;
+            UpdateBounds(page, leafInfos);
+        }
+
+        private void UpdateBounds(RegistrationPage page, List<LeafInfo> leafInfos)
+        {
+            Guard.Assert(Count == page.Items.Count, "The count property on the page info must match the number of leaf items.");
+            Guard.Assert(Count == leafInfos.Count, "The count property on the page info match the number of leaf infos.");
+
+            if (Count > 0)
+            {
+                Lower = leafInfos.First().Version;
+                Upper = leafInfos.Last().Version;
+            }
+            else
+            {
+                Lower = null;
+                Upper = null;
+            }
+        }
+
+        public async Task<RegistrationPage> GetPageAsync()
+        {
+            await _lazyInitializeTask.Value;
+            return _page;
+        }
+
+        public async Task<IReadOnlyList<LeafInfo>> GetLeafInfosAsync()
+        {
+            return await GetMutableLeafInfosAsync();
+        }
+
+        private async Task<List<LeafInfo>> GetMutableLeafInfosAsync()
+        {
+            await _lazyInitializeTask.Value;
+            return _leafInfos;
+        }
+    }
+}

--- a/src/NuGet.Jobs.Catalog2Registration/Hives/HiveMergeResult.cs
+++ b/src/NuGet.Jobs.Catalog2Registration/Hives/HiveMergeResult.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGet.Jobs.Catalog2Registration
+{
+    public class HiveMergeResult
+    {
+        public HiveMergeResult(HashSet<PageInfo> modifiedPages, HashSet<LeafInfo> modifiedLeaves, HashSet<LeafInfo> deletedLeaves)
+        {
+            ModifiedPages = modifiedPages;
+            ModifiedLeaves = modifiedLeaves;
+            DeletedLeaves = deletedLeaves;
+        }
+
+        public HashSet<PageInfo> ModifiedPages { get; }
+        public HashSet<LeafInfo> ModifiedLeaves { get; }
+        public HashSet<LeafInfo> DeletedLeaves { get; }
+    }
+}

--- a/src/NuGet.Jobs.Catalog2Registration/Hives/HiveMerger.cs
+++ b/src/NuGet.Jobs.Catalog2Registration/Hives/HiveMerger.cs
@@ -1,0 +1,312 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NuGet.Services;
+using NuGet.Services.Metadata.Catalog;
+
+namespace NuGet.Jobs.Catalog2Registration
+{
+    public class HiveMerger : IHiveMerger
+    {
+        private readonly IOptionsSnapshot<Catalog2RegistrationConfiguration> _options;
+        private readonly ILogger<HiveMerger> _logger;
+
+        public HiveMerger(
+            IOptionsSnapshot<Catalog2RegistrationConfiguration> options,
+            ILogger<HiveMerger> logger)
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        private int MaxLeavesPerPage => _options.Value.MaxLeavesPerPage;
+
+        public async Task<HiveMergeResult> MergeAsync(IndexInfo indexInfo, IReadOnlyList<CatalogCommitItem> sortedCatalog)
+        {
+            for (var i = 1; i < sortedCatalog.Count; i++)
+            {
+                Guard.Assert(
+                    sortedCatalog[i - 1].PackageIdentity.Version < sortedCatalog[i].PackageIdentity.Version,
+                    "The catalog commit items must be in ascending order by version.");
+            }
+
+            var context = new Context(indexInfo, sortedCatalog);
+
+            await MergeAsync(context);
+
+            return new HiveMergeResult(
+                context.ModifiedPages,
+                context.ModifiedLeaves,
+                context.DeletedLeaves);
+        }
+
+        private async Task MergeAsync(Context context)
+        {
+            // The general approach here is to use the merge algorithm to combine the incoming list of catalog commit
+            // items with the existing list of registration leaf items to end up with a new sorted list of registration
+            // leaf items. There are additional complexities in addition a textbook "merge" algorithm:
+            //
+            //   1. Items from the catalog of type PackageDelete can result in a removal from the result list.
+            //
+            //   2. Items from the catalog can be ignored if it is a PackageDelete on a version that does not exist in
+            //      the list of registration leaf items.
+            //
+            //   3. When both input sorted lists (catalog and registration) have the same version, the item from the
+            //      catalog replaces the item from the registration instead of having both versions next to each other.
+            //
+            //   4. There is additional bookkeeping requires to manage pages. We have a maximum number of leaves per
+            //      registration page so we need to handle cases when a full page needs to be filled up again after
+            //      a package delete or have items pushed to a later page if it is too full (from a package insert).
+            //
+            // These are just complexities though. The general approach of "merge" still works fine. The catalog leaves
+            // can be sorted by version in memory and the registration leaves are already sorted. We will iterate
+            // through the two lists in parallel by using queue data structures.
+            //
+            // The benefit of the merge algorithm is that we don't need to touch registration pages that don't bound
+            // any of the incoming catalog leaves.
+            //
+            // See the wonderful Wikipedia page: https://en.wikipedia.org/wiki/Merge_algorithm
+
+            var catalogIndex = 0;
+            var pageIndex = 0;
+
+            var sortedCatalog = context.SortedCatalog;
+            var pageInfos = context.IndexInfo.Items;
+
+            // Keep track of the position in the current page.
+            var itemIndex = 0;
+
+            // This is the main "merge" step where the two input lists are interleaved.
+            while (catalogIndex < sortedCatalog.Count && pageIndex < pageInfos.Count)
+            {
+                var catalog = sortedCatalog[catalogIndex];
+                var pageInfo = pageInfos[pageIndex];
+                var nextLower = pageIndex < pageInfos.Count - 1 ? pageInfos[pageIndex + 1].Lower : null;
+                var hasGap = pageInfo.Count < MaxLeavesPerPage && nextLower != null && catalog.PackageIdentity.Version < nextLower;
+
+                if (catalog.PackageIdentity.Version <= pageInfo.Upper || hasGap)
+                {
+                    itemIndex = await MergeEntryIntoPageAsync(context, catalog, pageIndex, itemIndex);
+                    catalogIndex++;
+                }
+                else
+                {
+                    // Before considering the current page "complete" ensure the page size is correct.
+                    await EnsureValidPageSizeAtAsync(context, pageIndex);
+
+                    if (catalog.PackageIdentity.Version > pageInfo.Upper)
+                    {
+                        // The current catalog entry is greater than the current page's upper bound. This means we're done
+                        // with the current page. Move to the next page and reset the item index.
+                        pageIndex++;
+                        itemIndex = 0;
+                    }
+                }
+            }
+
+            // Now that one of the two input lists is drained, handle the other (undrained) list. 
+
+            // Process the rest of the catalog leaves, if any.
+            if (catalogIndex < sortedCatalog.Count)
+            {
+                // Make sure there is at least one non-full page so that remaining catalog leaves can be pushed there.
+                if (pageInfos.Count == 0
+                    || pageInfos.Last().Count == MaxLeavesPerPage)
+                {
+                    context.IndexInfo.Insert(pageIndex, PageInfo.New());
+                }
+                else
+                {
+                    pageIndex = pageInfos.Count - 1;
+                }
+
+                // Push the remaining catalog leaves into the last page.
+                while (catalogIndex < sortedCatalog.Count)
+                {
+                    var catalog = sortedCatalog[catalogIndex];
+                    itemIndex = await MergeEntryIntoPageAsync(context, catalog, pageIndex, itemIndex);
+                    catalogIndex++;
+                }
+
+                RemovePageAtIfEmpty(context, pageIndex);
+            }
+
+            // Process the rest of the registration pages, if any, by ensuring the remaining pages are not too large.
+            while (pageIndex < pageInfos.Count)
+            {
+                await EnsureValidPageSizeAtAsync(context, pageIndex);
+                pageIndex++;
+            }
+        }
+
+        private async Task<int> MergeEntryIntoPageAsync(
+            Context context,
+            CatalogCommitItem entry,
+            int pageIndex,
+            int itemIndex)
+        {
+            var pageInfo = context.IndexInfo.Items[pageIndex];
+            var items = await pageInfo.GetLeafInfosAsync();
+
+            while (itemIndex < items.Count)
+            {
+                if (entry.PackageIdentity.Version > items[itemIndex].Version)
+                {
+                    // The current position in the item list is too low for the catalog version. Keep looking.
+                    itemIndex++;
+                }
+                else if (entry.PackageIdentity.Version == items[itemIndex].Version)
+                {
+                    if (entry.IsPackageDelete)
+                    {
+                        // Remove the registration leaf item. The current catalog commit item represents a
+                        // delete for this version.
+                        _logger.LogInformation(
+                            "Version {Version} will be deleted by commit {CommitId}.",
+                            entry.PackageIdentity.Version.ToNormalizedString(),
+                            entry.CommitId);
+                        context.DeletedLeaves.Add(await pageInfo.RemoveAtAsync(itemIndex));
+                        context.ModifiedPages.Add(pageInfo);
+
+                        RemovePageAtIfEmpty(context, pageIndex);
+                    }
+                    else
+                    {
+                        // Update the metadata of the existing registration leaf item.
+                        _logger.LogInformation(
+                            "Version {Version} will be updated by commit {CommitId}.",
+                            entry.PackageIdentity.Version.ToNormalizedString(),
+                            entry.CommitId);
+                        context.ModifiedLeaves.Add(items[itemIndex]);
+                        context.ModifiedPages.Add(pageInfo);
+                    }
+
+                    // The version has been matched with an existing version. Leave the item index as-is. The next item
+                    // is now at the current position. No more work is necessary. 
+                    return itemIndex;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            await InsertAsync(context, pageInfo, itemIndex, entry);
+
+            return itemIndex;
+        }
+
+        private async Task InsertAsync(
+            Context context,
+            PageInfo pageInfo,
+            int index,
+            CatalogCommitItem entry)
+        {
+            if (entry.IsPackageDelete)
+            {
+                // No matching version was found for this delete. No more work is necessary.
+                _logger.LogInformation(
+                    "Version {Version} does not exist. The delete from commit {CommitId} will have no affect.",
+                    entry.PackageIdentity.Version.ToNormalizedString(),
+                    entry.CommitId);
+            }
+            else
+            {
+                // Insert the new registration leaf item.
+                _logger.LogInformation(
+                    "Version {Version} will be added by commit {CommitId}.",
+                    entry.PackageIdentity.Version.ToNormalizedString(),
+                    entry.CommitId);
+                var leafInfo = LeafInfo.New(entry.PackageIdentity.Version);
+                await pageInfo.InsertAsync(index, leafInfo);
+                context.ModifiedLeaves.Add(leafInfo);
+                context.ModifiedPages.Add(pageInfo);
+            }
+        }
+
+        private async Task EnsureValidPageSizeAtAsync(Context context, int pageIndex)
+        {
+            var pageInfo = context.IndexInfo.Items[pageIndex];
+
+            // If we're not on the last page, pull items from the next page until the page is full or we've drained all
+            // of the subsequent pages and are now the last page.
+            while (pageInfo.Count < MaxLeavesPerPage && pageIndex < context.IndexInfo.Items.Count - 1)
+            {
+                var nextPageInfo = context.IndexInfo.Items[pageIndex + 1];
+                var leafInfo = await nextPageInfo.RemoveAtAsync(0);
+                _logger.LogInformation(
+                    "Page {PageNumber}/{PageCount} has too few items. Version {Version} will be moved from the next page.",
+                    pageIndex + 1,
+                    context.IndexInfo.Items.Count,
+                    leafInfo.Version);
+                await pageInfo.InsertAsync(pageInfo.Count, leafInfo);
+                context.ModifiedPages.Add(pageInfo);
+                context.ModifiedPages.Add(nextPageInfo);
+                RemovePageAtIfEmpty(context, pageIndex + 1);
+            }
+
+            // If the page is too large, push the extra items to the next page.
+            while (pageInfo.Count > MaxLeavesPerPage)
+            {
+                PageInfo nextPageInfo;
+                if (pageIndex == context.IndexInfo.Items.Count - 1)
+                {
+                    nextPageInfo = PageInfo.New();
+                    context.IndexInfo.Insert(context.IndexInfo.Items.Count, nextPageInfo);
+                }
+                else
+                {
+                    nextPageInfo = context.IndexInfo.Items[pageIndex + 1];
+                }
+
+                var leafInfo = await pageInfo.RemoveAtAsync(pageInfo.Count - 1);
+                _logger.LogInformation(
+                    "Page {PageNumber}/{PageCount} has too many items. Version {Version} will be moved to the next page.",
+                    pageIndex + 1,
+                    context.IndexInfo.Items.Count,
+                    leafInfo.Version);
+                await nextPageInfo.InsertAsync(0, leafInfo);
+                context.ModifiedPages.Add(pageInfo);
+                context.ModifiedPages.Add(nextPageInfo);
+            }
+        }
+
+        private void RemovePageAtIfEmpty(Context context, int pageIndex)
+        {
+            var pageInfo = context.IndexInfo.Items[pageIndex];
+            if (pageInfo.Count == 0)
+            {
+                _logger.LogInformation(
+                    "The last version on page {PageNumber}/{PageCount} has been removed. The page itself will be removed.",
+                    pageIndex + 1,
+                    context.IndexInfo.Items.Count);
+                context.IndexInfo.RemoveAt(pageIndex);
+                context.ModifiedPages.Remove(pageInfo);
+            }
+        }
+
+        private class Context
+        {
+            public Context(IndexInfo indexInfo, IReadOnlyList<CatalogCommitItem> sortedCatalog)
+            {
+                SortedCatalog = sortedCatalog;
+                IndexInfo = indexInfo;
+                ModifiedPages = new HashSet<PageInfo>();
+                ModifiedLeaves = new HashSet<LeafInfo>();
+                DeletedLeaves = new HashSet<LeafInfo>();
+            }
+
+            public IndexInfo IndexInfo { get; }
+            public IReadOnlyList<CatalogCommitItem> SortedCatalog { get; }
+            public HashSet<PageInfo> ModifiedPages { get; }
+            public HashSet<LeafInfo> ModifiedLeaves { get; }
+            public HashSet<LeafInfo> DeletedLeaves { get; }
+        }
+    }
+}

--- a/src/NuGet.Jobs.Catalog2Registration/Hives/IHiveMerger.cs
+++ b/src/NuGet.Jobs.Catalog2Registration/Hives/IHiveMerger.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NuGet.Services.Metadata.Catalog;
+
+namespace NuGet.Jobs.Catalog2Registration
+{
+    public interface IHiveMerger
+    {
+        /// <summary>
+        /// Merge the incoming list of catalog items into the registration index. This method will not go into the
+        /// details of updating the leaf item metadata. That responsiblity is left up to the caller who can inspect the
+        /// <see cref="HiveMergeResult.ModifiedLeaves"/>. This logic also does not handle the inlining or externalizing
+        /// of leaf items since this is more of a storage concern. The provided <see cref="IndexInfo"/> bookkeeping
+        /// object and its child object will be modified and the changes will be detailed in the returned
+        /// <see cref="HiveMergeResult"/>.
+        /// </summary>
+        Task<HiveMergeResult> MergeAsync(IndexInfo indexInfo, IReadOnlyList<CatalogCommitItem> sortedCatalog);
+    }
+}

--- a/src/NuGet.Jobs.Catalog2Registration/Hives/IHiveStorage.cs
+++ b/src/NuGet.Jobs.Catalog2Registration/Hives/IHiveStorage.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using NuGet.Protocol.Registration;
+
+namespace NuGet.Jobs.Catalog2Registration
+{
+    public interface IHiveStorage
+    {
+        Task<RegistrationPage> ReadPageAsync(HiveType hive, string url);
+    }
+}

--- a/src/NuGet.Jobs.Catalog2Registration/NuGet.Jobs.Catalog2Registration.csproj
+++ b/src/NuGet.Jobs.Catalog2Registration/NuGet.Jobs.Catalog2Registration.csproj
@@ -46,7 +46,14 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Catalog2RegistrationConfiguration.cs" />
+    <Compile Include="Hives\Bookkeeping\LeafInfo.cs" />
+    <Compile Include="Hives\Bookkeeping\IndexInfo.cs" />
+    <Compile Include="Hives\Bookkeeping\PageInfo.cs" />
+    <Compile Include="Hives\HiveMerger.cs" />
+    <Compile Include="Hives\HiveMergeResult.cs" />
     <Compile Include="Hives\HiveType.cs" />
+    <Compile Include="Hives\IHiveMerger.cs" />
+    <Compile Include="Hives\IHiveStorage.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />


### PR DESCRIPTION
Progress https://github.com/NuGet/NuGetGallery/issues/7736.
Depends on https://github.com/NuGet/NuGet.Services.Metadata/pull/706.

This introduces the core merging logic and associated bookkeeping classes. Consider the bookkeeping classes as implementation details of the `HiveMerger`. Their purpose is to make the logic of merging easier to read. They also are the things that "remember" which non-inlined pages have been download. The bookkeeping classes are:

- `IndexInfo` - holds a `RegistrationIndex` and allows adding and removing pages
- `PageInfo` - holds a `RegistrationPage` and allows adding and removing items and can transition a page from inlined to non-inlined and vice-versa
- `LeafInfo` - holds a `RegistrationLeafItem`

Unit tests will be added by a subsequent PR.

Note that this logic is relatively tricky (it took multiple iterations to get right) but I am confident in the correctness because of some exhaustive unit tests I added.

The `HiveMerger.MergeAsync` method can be considered the entry point.