### PR TITLE
Add unit tests for HiveMerger

### DIFF
--- a/tests/NuGet.Jobs.Catalog2Registration.Tests/App.config
+++ b/tests/NuGet.Jobs.Catalog2Registration.Tests/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+  </startup>
+</configuration>

--- a/tests/NuGet.Jobs.Catalog2Registration.Tests/Hives/HiveMergerFacts.FullEnumeration.cs
+++ b/tests/NuGet.Jobs.Catalog2Registration.Tests/Hives/HiveMergerFacts.FullEnumeration.cs
@@ -1,0 +1,317 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NuGet.Services.Metadata.Catalog.Helpers;
+using NuGet.Services.V3.Support;
+using NuGet.Versioning;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Jobs.Catalog2Registration
+{
+    public partial class HiveMergerFacts
+    {
+        public class FullEnumeration
+        {
+            private readonly ITestOutputHelper _output;
+
+            public FullEnumeration(ITestOutputHelper output)
+            {
+                _output = output;
+            }
+
+            [Theory]
+            [InlineData(1, 2, 4, 1, 7)] // Use page size 1 to try some extreme prepending cases.
+            [InlineData(2, 2, 6, 1, 7)] // Use page size 2 so we can easily have up to 3 pages.
+            [InlineData(3, 2, 5, 1, 6)] // Use page size 3 to allow insertions without bounds changes.
+            public async Task Execute(int maxLeavesPerPage, int minExisting, int maxExisting, int minUpdated, int maxUpdated)
+            {
+                var config = new Catalog2RegistrationConfiguration();
+                var options = new SimpleOptions<Catalog2RegistrationConfiguration>(config);
+                var logger = new NullLogger<HiveMerger>();
+                var target = new HiveMerger(options, logger);
+
+                config.MaxLeavesPerPage = maxLeavesPerPage;
+
+                var allExisting = Enumerable.Range(minExisting, (maxExisting - minExisting) + 1).Select(m => new NuGetVersion(m, 0, 0)).ToList();
+                var allUpdated = Enumerable.Range(minUpdated, (maxUpdated - minUpdated) + 1).Select(m => new NuGetVersion(m, 0, 0)).ToList();
+                var versionToNormalized = allExisting.Concat(allUpdated).Distinct().ToDictionary(v => v, v => v.ToNormalizedString());
+
+                // Enumerate all of the updated version sets, which is up to 9 versions and for each set every
+                // combination of either PackageDelete or PackageDetails for each version.
+                var deleteOrNotDelete = new[] { true, false };
+                var updatedCases = IterTools
+                    .SubsetsOf(allUpdated)
+                    .SelectMany(vs => IterTools.CombinationsOfTwo(vs.ToList(), deleteOrNotDelete))
+                    .Select(ts => ts.Select(t => new VersionAction(t.Item1, t.Item2)).OrderBy(v => v.Version).ToList())
+                    .ToList();
+
+                // Enumerate all of the updated version sets, which is up to 7 versions.
+                var existingCases = IterTools
+                    .SubsetsOf(allExisting)
+                    .Select(vs => vs.OrderBy(v => v).ToList())
+                    .ToList();
+
+                // Build all of the test cases which is every pairing of updated and existing cases.
+                var testCases = new ConcurrentBag<TestCase>();
+                foreach (var existing in existingCases)
+                {
+                    foreach (var updated in updatedCases)
+                    {
+                        testCases.Add(new TestCase(existing, updated));
+                    }
+                }
+
+                var completed = 0;
+                var total = testCases.Count;
+                var outputLock = new object();
+                await ParallelAsync
+                    .Repeat(async () =>
+                    {
+                        await Task.Yield();
+                        while (testCases.TryTake(out var testCase))
+                        {
+                            try
+                            {
+                                await ExecuteTestCaseAsync(config, target, versionToNormalized, testCase);
+
+                                var thisCompleted = Interlocked.Increment(ref completed);
+                                if (thisCompleted % 20000 == 0)
+                                {
+                                    lock (outputLock)
+                                    {
+                                        _output.WriteLine($"Progress: {1.0 * thisCompleted / total:P}");
+                                    }
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                lock (outputLock)
+                                {
+                                    _output.WriteLine(string.Empty);
+                                    _output.WriteLine("Test Case Failure");
+                                    _output.WriteLine(new string('=', 50));
+                                    _output.WriteLine(ex.Message);
+                                    _output.WriteLine(string.Empty);
+                                    _output.WriteLine("Existing: " + string.Join(", ", testCase.Existing));
+                                    _output.WriteLine("Changes:  " + string.Join(", ", testCase.Updated.Select(t => $"{(t.IsDelete ? '-' : '+')}{t.Version}")));
+                                    _output.WriteLine(new string('=', 50));
+                                    _output.WriteLine(string.Empty);
+                                    return;
+                                }
+                            }
+                        }
+                    },
+                    degreeOfParallelism: 8);
+
+                _output.WriteLine($"Progress: {1.0 * completed / total:P}");
+                _output.WriteLine($"Total test cases: {total}");
+                _output.WriteLine($"Completed test cases: {completed}");
+                Assert.Equal(total, completed);
+            }
+
+            private async Task ExecuteTestCaseAsync(
+                Catalog2RegistrationConfiguration config,
+                HiveMerger target,
+                Dictionary<NuGetVersion, string> versionToNormalized,
+                TestCase testCase)
+            {
+                // ARRANGE
+                var existing = testCase.Existing;
+                var allUpdated = testCase.Updated;
+
+                // Determine the sets of expected modified versions, deleted versions, and resulting versions.
+                var updatedGrouped = allUpdated.ToLookup(x => x.IsDelete);
+                var possibleDeletes = updatedGrouped[true].Select(x => x.Version);
+                var modified = updatedGrouped[false].Select(x => x.Version).OrderBy(v => v).ToList();
+                var deleted = existing.Intersect(possibleDeletes).OrderBy(v => v).ToList();
+                var unchanged = existing.Except(allUpdated.Select(x => x.Version)).OrderBy(v => v).ToList();
+                var expectedRemaining = modified.Concat(unchanged).OrderBy(v => v).ToList();
+
+                // Build the input data structures.
+                var sortedCatalog = MakeSortedCatalog(allUpdated);
+                var indexInfo = MakeIndexInfo(existing, config.MaxLeavesPerPage, versionToNormalized);
+
+                // Determine which pages will definitely not be affected.
+                var unaffectedPages = new List<PageInfo>();
+                if (existing.Any())
+                {
+                    var minVersion = allUpdated.Min(x => x.Version);
+                    unaffectedPages = indexInfo
+                        .Items
+                        .Take(indexInfo.Items.Count - 1)
+                        .Where(x => x.Upper < minVersion)
+                        .ToList();
+                }
+
+                // ACT
+                var result = await target.MergeAsync(indexInfo, sortedCatalog);
+
+                // ASSERT
+
+                // Verify the definitely unaffected pages are in still in the index and not loaded.
+                foreach (var page in unaffectedPages)
+                {
+                    Assert.Contains(page, indexInfo.Items);
+                    Assert.False(page.IsPageFetched, "A page before the lowest version input version must not be fetched.");
+                }
+
+                // Verify the modified version set.
+                Assert.Equal(modified, result.ModifiedLeaves.Select(x => x.Version).OrderBy(v => v).ToList());
+
+                // Verify the deleted version set.
+                Assert.Equal(deleted, result.DeletedLeaves.Select(x => x.Version).OrderBy(v => v).ToList());
+
+                // Verify the resulting set of versions.
+                var actualRemaining = await GetVersionsAsync(indexInfo);
+                Assert.Equal(expectedRemaining, actualRemaining);
+
+                // Verify all but the last page are full.
+                foreach (var pageInfo in indexInfo.Items.AsEnumerable().Reverse().Skip(1))
+                {
+                    Assert.True(
+                        pageInfo.Count == config.MaxLeavesPerPage,
+                        "All but the last page must have the maximum number of leaf items per page.");
+                }
+
+                // Verify the last page is not too full.
+                if (indexInfo.Items.Count > 0)
+                {
+                    Assert.True(
+                        indexInfo.Items.Last().Count <= config.MaxLeavesPerPage,
+                        "The last page must have less than or equal to the maximum number of leaf items per page.");
+                }
+
+                // Verify the page bounds are in ascending order.
+                var bounds = indexInfo.Items.SelectMany(GetUniqueBounds).ToList();
+                for (var i = 1; i < bounds.Count; i++)
+                {
+                    Assert.True(bounds[i - 1] < bounds[i], "Each page bound must be less than the next.");
+                }
+
+                // Verify the modified pages are in the index.
+                foreach (var pageInfo in result.ModifiedPages)
+                {
+                    Assert.True(indexInfo.Items.Contains(pageInfo), "A modified page must be in the index.");
+                }
+
+                // Verify the leaf item infos match the leaf items.
+                Assert.True(
+                    indexInfo.Items.Count == indexInfo.Index.Items.Count,
+                    "The number of page infos must match the number of page items.");
+                for (var pageIndex = 0; pageIndex < indexInfo.Items.Count; pageIndex++)
+                {
+                    var pageInfo = indexInfo.Items[pageIndex];
+                    var leafInfos = await pageInfo.GetLeafInfosAsync();
+                    var page = await pageInfo.GetPageAsync();
+                    Assert.True(
+                        page.Items.Count == leafInfos.Count,
+                        "The number of leaf items must match the number of leaf item infos.");
+
+                    for (var leafIndex = 0; leafIndex < page.Items.Count; leafIndex++)
+                    {
+                        var leafInfoVersion = leafInfos[leafIndex].Version;
+                        var leafItemVersion = NuGetVersion.Parse(page.Items[leafIndex].CatalogEntry.Version);
+                        Assert.True(
+                            leafInfoVersion == leafItemVersion,
+                            "The list of leaf info versions must match the leaf item versions.");
+                    }
+                }
+
+                // Verify the modified leaves and deleted leafs are disjoint sets.
+                var modifiedVersions = new HashSet<NuGetVersion>(result.ModifiedLeaves.Select(x => x.Version));
+                var deletedVersions = new HashSet<NuGetVersion>(result.DeletedLeaves.Select(x => x.Version));
+                Assert.True(
+                    !modifiedVersions.Overlaps(deletedVersions),
+                    "The deleted leaves and modified leaves must be disjoint sets.");
+
+                // Verify the modified leaves are visible in an inlined page or a downloaded page.
+                foreach (var leafInfo in result.ModifiedLeaves)
+                {
+                    foreach (var pageInfo in indexInfo.Items)
+                    {
+                        if (leafInfo.Version < pageInfo.Lower || leafInfo.Version > pageInfo.Upper)
+                        {
+                            continue;
+                        }
+
+                        Assert.True(
+                            pageInfo.IsInlined || pageInfo.IsPageFetched,
+                            "A page bounding a modified leaf must either be inlined or the page must be fetched.");
+
+                        var pageLeafInfos = await pageInfo.GetLeafInfosAsync();
+
+                        Assert.True(
+                            pageLeafInfos.Any(x => x.Version == leafInfo.Version),
+                            "A modified leaf must be in the page bounding its version.");
+                    }
+                }
+
+                // Verify the deleted leaves are not visible in any of the inlined or downloaded pages.
+                foreach (var leafInfo in result.DeletedLeaves)
+                {
+                    foreach (var pageInfo in indexInfo.Items)
+                    {
+                        var pageLeafInfos = await pageInfo.GetLeafInfosAsync();
+
+                        Assert.True(
+                            !pageLeafInfos.Any(x => x.Version == leafInfo.Version),
+                            "A deleted leaf must not be in any page.");
+                    }
+                }
+            }
+
+            private static IEnumerable<NuGetVersion> GetUniqueBounds(PageInfo x)
+            {
+                yield return x.Lower;
+
+                if (x.Lower != x.Upper)
+                {
+                    yield return x.Upper;
+                }
+                else
+                {
+                    Assert.True(
+                        x.Count == 1,
+                        "If the upper bound and the lower bound are the same, the leaf item count must be one.");
+                }
+            }
+
+            private class SimpleOptions<T> : IOptionsSnapshot<T> where T : class, new()
+            {
+                public SimpleOptions(T value)
+                {
+                    Value = value;
+                }
+
+                public T Value { get; }
+                public T Get(string name) => throw new NotImplementedException();
+            }
+
+            private class NullLogger<T> : ILogger<T>
+            {
+                public IDisposable BeginScope<TState>(TState state)
+                {
+                    return null;
+                }
+
+                public bool IsEnabled(LogLevel logLevel)
+                {
+                    return false;
+                }
+
+                public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+                {
+                }
+            }
+        }
+    }
+}

--- a/tests/NuGet.Jobs.Catalog2Registration.Tests/Hives/HiveMergerFacts.MergeAsync.cs
+++ b/tests/NuGet.Jobs.Catalog2Registration.Tests/Hives/HiveMergerFacts.MergeAsync.cs
@@ -1,0 +1,455 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Versioning;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Jobs.Catalog2Registration
+{
+    public partial class HiveMergerFacts
+    {
+        public class TheMergeAsyncMethod : Facts
+        {
+            public TheMergeAsyncMethod(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Theory]
+            [MemberData(nameof(Versions))]
+            public async Task AddSingleFirstVersion(string version)
+            {
+                var indexInfo = IndexInfo.New();
+                var sortedCatalog = MakeSortedCatalog(Details(version));
+
+                var result = await Target.MergeAsync(indexInfo, sortedCatalog);
+
+                Assert.True(indexInfo.Items[0].IsPageFetched);
+
+                var pageInfo = Assert.Single(indexInfo.Items);
+                var page = await pageInfo.GetPageAsync();
+                var leafInfo = Assert.Single(await pageInfo.GetLeafInfosAsync());
+                var leafItem = Assert.Single(page.Items);
+                Assert.Same(leafItem, leafInfo.LeafItem);
+                Assert.Equal(version, leafItem.CatalogEntry.Version);
+
+                Assert.Same(pageInfo, Assert.Single(result.ModifiedPages));
+                Assert.Same(leafInfo, Assert.Single(result.ModifiedLeaves));
+                Assert.Empty(result.DeletedLeaves);
+            }
+
+            [Theory]
+            [MemberData(nameof(Versions))]
+            public async Task UpdateSingleVersion(string version)
+            {
+                var indexInfo = MakeIndexInfo("1.0.0", "2.0.0", version, "4.0.0", "5.0.0");
+                var sortedCatalog = MakeSortedCatalog(Details(version));
+
+                var result = await Target.MergeAsync(indexInfo, sortedCatalog);
+
+                Assert.True(indexInfo.Items[0].IsPageFetched);
+                Assert.False(indexInfo.Items[1].IsPageFetched);
+
+                Assert.Equal(2, indexInfo.Items.Count);
+                var pageA = await indexInfo.Items[0].GetPageAsync();
+                var pageB = await indexInfo.Items[1].GetPageAsync();
+                Assert.Equal(3, pageA.Items.Count);
+                Assert.Equal("1.0.0", pageA.Items[0].CatalogEntry.Version);
+                Assert.Equal("2.0.0", pageA.Items[1].CatalogEntry.Version);
+                Assert.Equal(version, pageA.Items[2].CatalogEntry.Version);
+                Assert.Equal(2, pageB.Items.Count);
+                Assert.Equal("4.0.0", pageB.Items[0].CatalogEntry.Version);
+                Assert.Equal("5.0.0", pageB.Items[1].CatalogEntry.Version);
+
+                var pageInfo = Assert.Single(result.ModifiedPages);
+                Assert.Same(indexInfo.Items[0], pageInfo);
+                var leafInfo = (await pageInfo.GetLeafInfosAsync())[2];
+                Assert.Same(leafInfo, Assert.Single(result.ModifiedLeaves));
+                Assert.Empty(result.DeletedLeaves);
+            }
+
+            [Theory]
+            [MemberData(nameof(Versions))]
+            public async Task RemoveSingleExisting(string version)
+            {
+                var indexInfo = MakeIndexInfo("1.0.0", "2.0.0", version, "4.0.0", "5.0.0");
+                var sortedCatalog = MakeSortedCatalog(Delete(version));
+
+                var result = await Target.MergeAsync(indexInfo, sortedCatalog);
+
+                Assert.True(indexInfo.Items[0].IsPageFetched);
+                Assert.True(indexInfo.Items[1].IsPageFetched);
+
+                Assert.Equal(2, indexInfo.Items.Count);
+                var pageA = await indexInfo.Items[0].GetPageAsync();
+                var pageB = await indexInfo.Items[1].GetPageAsync();
+                Assert.Equal(3, pageA.Items.Count);
+                Assert.Equal("1.0.0", pageA.Items[0].CatalogEntry.Version);
+                Assert.Equal("2.0.0", pageA.Items[1].CatalogEntry.Version);
+                Assert.Equal("4.0.0", pageA.Items[2].CatalogEntry.Version);
+                Assert.Equal("5.0.0", Assert.Single(pageB.Items).CatalogEntry.Version);
+
+                Assert.Contains(indexInfo.Items[0], result.ModifiedPages);
+                Assert.Contains(indexInfo.Items[1], result.ModifiedPages);
+                Assert.Empty(result.ModifiedLeaves);
+                Assert.Equal(version, Assert.Single(result.DeletedLeaves).LeafItem.CatalogEntry.Version);
+            }
+
+            [Fact]
+            public async Task DeleteAgainstEmpty()
+            {
+                var indexInfo = IndexInfo.New();
+                var sortedCatalog = MakeSortedCatalog(Delete("1.0.0"));
+
+                var result = await Target.MergeAsync(indexInfo, sortedCatalog);
+
+                Assert.Empty(indexInfo.Items);
+
+                Assert.Empty(result.ModifiedPages);
+                Assert.Empty(result.ModifiedLeaves);
+                Assert.Empty(result.DeletedLeaves);
+            }
+
+            [Fact]
+            public async Task DeleteLast()
+            {
+                var indexInfo = MakeIndexInfo("1.0.0");
+                var leafInfo = (await indexInfo.Items.First().GetLeafInfosAsync()).First();
+                var sortedCatalog = MakeSortedCatalog(Delete("1.0.0"));
+
+                var result = await Target.MergeAsync(indexInfo, sortedCatalog);
+
+                Assert.Empty(indexInfo.Items);
+
+                Assert.Empty(result.ModifiedPages);
+                Assert.Empty(result.ModifiedLeaves);
+                Assert.Same(leafInfo, Assert.Single(result.DeletedLeaves));
+            }
+
+            [Fact]
+            public async Task DeleteLastThenAddOne()
+            {
+                var indexInfo = MakeIndexInfo("1.0.0");
+                var leafInfoA = (await indexInfo.Items.First().GetLeafInfosAsync()).First();
+                var sortedCatalog = MakeSortedCatalog(Delete("1.0.0"), Details("2.0.0"));
+
+                var result = await Target.MergeAsync(indexInfo, sortedCatalog);
+
+                Assert.True(indexInfo.Items[0].IsPageFetched);
+
+                var pageInfo = Assert.Single(indexInfo.Items);
+                var page = await pageInfo.GetPageAsync();
+                var leafInfoB = Assert.Single(await pageInfo.GetLeafInfosAsync());
+                var leafItem = Assert.Single(page.Items);
+                Assert.Same(leafItem, leafInfoB.LeafItem);
+                Assert.NotSame(leafInfoA, leafInfoB);
+                Assert.Equal("2.0.0", leafItem.CatalogEntry.Version);
+
+                Assert.Same(pageInfo, Assert.Single(result.ModifiedPages));
+                Assert.Same(leafInfoB, Assert.Single(result.ModifiedLeaves));
+                Assert.Same(leafInfoA, Assert.Single(result.DeletedLeaves));
+            }
+
+            [Fact]
+            public async Task DeleteNonExistentThenAddOne()
+            {
+                var indexInfo = MakeIndexInfo("1.0.0");
+                var sortedCatalog = MakeSortedCatalog(Delete("2.0.0"), Details("3.0.0"));
+
+                var result = await Target.MergeAsync(indexInfo, sortedCatalog);
+
+                Assert.True(indexInfo.Items[0].IsPageFetched);
+
+                var pageInfo = Assert.Single(indexInfo.Items);
+                var leafInfos = await pageInfo.GetLeafInfosAsync();
+                Assert.Equal(2, leafInfos.Count);
+                Assert.Equal("1.0.0", leafInfos[0].LeafItem.CatalogEntry.Version);
+                Assert.Equal("3.0.0", leafInfos[1].LeafItem.CatalogEntry.Version);
+
+                Assert.Same(pageInfo, Assert.Single(result.ModifiedPages));
+                Assert.Same(leafInfos[1], Assert.Single(result.ModifiedLeaves));
+                Assert.Empty(result.DeletedLeaves);
+            }
+
+            [Fact]
+            public async Task RemoveLastVersionFromPage()
+            {
+                var indexInfo = MakeIndexInfo("1.0.0", "2.0.0", "3.0.0", "4.0.0");
+                var sortedCatalog = MakeSortedCatalog(Delete("4.0.0"));
+
+                var result = await Target.MergeAsync(indexInfo, sortedCatalog);
+
+                Assert.False(indexInfo.Items[0].IsPageFetched);
+
+                var pageInfo = Assert.Single(indexInfo.Items);
+                var page = await pageInfo.GetPageAsync();
+                Assert.Equal(3, page.Items.Count);
+                Assert.Equal("1.0.0", page.Items[0].CatalogEntry.Version);
+                Assert.Equal("2.0.0", page.Items[1].CatalogEntry.Version);
+                Assert.Equal("3.0.0", page.Items[2].CatalogEntry.Version);
+
+                Assert.Empty(result.ModifiedPages);
+                Assert.Empty(result.ModifiedLeaves);
+                Assert.Equal("4.0.0", Assert.Single(result.DeletedLeaves).LeafItem.CatalogEntry.Version);
+            }
+
+            [Fact]
+            public async Task RemoveVersionFromPageCausingLastPageToBeRemoved()
+            {
+                var indexInfo = MakeIndexInfo("1.0.0", "2.0.0", "3.0.0", "4.0.0");
+                var sortedCatalog = MakeSortedCatalog(Delete("3.0.0"));
+
+                var result = await Target.MergeAsync(indexInfo, sortedCatalog);
+
+                Assert.True(indexInfo.Items[0].IsPageFetched);
+
+                var pageInfo = Assert.Single(indexInfo.Items);
+                Assert.Equal(new[] { "1.0.0", "2.0.0", "4.0.0" }, await GetVersionArrayAsync(indexInfo));
+
+                Assert.Same(pageInfo, Assert.Single(result.ModifiedPages));
+                Assert.Empty(result.ModifiedLeaves);
+                Assert.Equal("3.0.0", Assert.Single(result.DeletedLeaves).LeafItem.CatalogEntry.Version);
+            }
+
+            [Fact]
+            public async Task InsertInMiddlePage()
+            {
+                var indexInfo = MakeIndexInfo("1.0.0", "2.0.0", "3.0.0", "4.0.0", "6.0.0", "7.0.0", "8.0.0");
+                var sortedCatalog = MakeSortedCatalog(Details("5.0.0"));
+
+                var result = await Target.MergeAsync(indexInfo, sortedCatalog);
+
+                Assert.False(indexInfo.Items[0].IsPageFetched);
+                Assert.True(indexInfo.Items[1].IsPageFetched);
+                Assert.True(indexInfo.Items[2].IsPageFetched);
+
+                Assert.Equal(3, indexInfo.Items.Count);
+                Assert.Equal(
+                    new[] { "1.0.0", "2.0.0", "3.0.0", "4.0.0", "5.0.0", "6.0.0", "7.0.0", "8.0.0" },
+                    await GetVersionArrayAsync(indexInfo));
+
+                Assert.Equal(2, result.ModifiedPages.Count);
+                Assert.DoesNotContain(indexInfo.Items[0], result.ModifiedPages);
+                Assert.Contains(indexInfo.Items[1], result.ModifiedPages);
+                Assert.Contains(indexInfo.Items[2], result.ModifiedPages);
+                Assert.Equal("5.0.0", Assert.Single(result.ModifiedLeaves).LeafItem.CatalogEntry.Version);
+                Assert.Empty(result.DeletedLeaves);
+            }
+
+            [Fact]
+            public async Task InsertInLastPage()
+            {
+                var indexInfo = MakeIndexInfo("1.0.0", "2.0.0", "3.0.0", "4.0.0", "5.0.0", "6.0.0", "8.0.0");
+                var sortedCatalog = MakeSortedCatalog(Details("7.0.0"));
+
+                var result = await Target.MergeAsync(indexInfo, sortedCatalog);
+
+                Assert.False(indexInfo.Items[0].IsPageFetched);
+                Assert.False(indexInfo.Items[1].IsPageFetched);
+                Assert.True(indexInfo.Items[2].IsPageFetched);
+
+                Assert.Equal(3, indexInfo.Items.Count);
+                Assert.Equal(
+                    new[] { "1.0.0", "2.0.0", "3.0.0", "4.0.0", "5.0.0", "6.0.0", "7.0.0", "8.0.0" },
+                    await GetVersionArrayAsync(indexInfo));
+
+                Assert.Single(result.ModifiedPages);
+                Assert.Contains(indexInfo.Items[2], result.ModifiedPages);
+                Assert.Equal("7.0.0", Assert.Single(result.ModifiedLeaves).LeafItem.CatalogEntry.Version);
+                Assert.Empty(result.DeletedLeaves);
+            }
+
+            [Fact]
+            public async Task InsertLowestCreatingNewPage()
+            {
+                var indexInfo = MakeIndexInfo("2.0.0", "3.0.0", "4.0.0");
+                var sortedCatalog = MakeSortedCatalog(Details("1.0.0"));
+
+                var result = await Target.MergeAsync(indexInfo, sortedCatalog);
+
+                Assert.True(indexInfo.Items[0].IsPageFetched);
+                Assert.True(indexInfo.Items[1].IsPageFetched);
+
+                Assert.Equal(2, indexInfo.Items.Count);
+                Assert.Equal(new[] { "1.0.0", "2.0.0", "3.0.0", "4.0.0" }, await GetVersionArrayAsync(indexInfo));
+
+                Assert.Equal(2, result.ModifiedPages.Count);
+                Assert.Contains(indexInfo.Items[0], result.ModifiedPages);
+                Assert.Contains(indexInfo.Items[1], result.ModifiedPages);
+                Assert.Equal("1.0.0", Assert.Single(result.ModifiedLeaves).LeafItem.CatalogEntry.Version);
+                Assert.Empty(result.DeletedLeaves);
+            }
+
+            [Fact]
+            public async Task AppendLatestVersionCreatingNewPage()
+            {
+                var indexInfo = MakeIndexInfo("1.0.0", "2.0.0", "3.0.0");
+                var sortedCatalog = MakeSortedCatalog(Details("4.0.0"));
+
+                var result = await Target.MergeAsync(indexInfo, sortedCatalog);
+
+                Assert.False(indexInfo.Items[0].IsPageFetched);
+                Assert.True(indexInfo.Items[1].IsPageFetched);
+
+                Assert.Equal(2, indexInfo.Items.Count);
+                Assert.Equal(new[] { "1.0.0", "2.0.0", "3.0.0", "4.0.0" }, await GetVersionArrayAsync(indexInfo));
+
+                Assert.Equal(indexInfo.Items[1], Assert.Single(result.ModifiedPages));
+                Assert.Equal("4.0.0", Assert.Single(result.ModifiedLeaves).LeafItem.CatalogEntry.Version);
+                Assert.Empty(result.DeletedLeaves);
+            }
+
+            [Fact]
+            public async Task InterleaveVersions()
+            {
+                var indexInfo = MakeIndexInfo("2.0.0", "4.0.0", "6.0.0", "8.0.0", "10.0.0");
+                var sortedCatalog = MakeSortedCatalog(
+                    Details("1.0.0"),
+                    Details("3.0.0"),
+                    Details("5.0.0"),
+                    Details("7.0.0"),
+                    Details("9.0.0"));
+
+                var result = await Target.MergeAsync(indexInfo, sortedCatalog);
+
+                Assert.True(indexInfo.Items[0].IsPageFetched);
+                Assert.True(indexInfo.Items[1].IsPageFetched);
+                Assert.True(indexInfo.Items[2].IsPageFetched);
+                Assert.True(indexInfo.Items[3].IsPageFetched);
+
+                Assert.Equal(4, indexInfo.Items.Count);
+                Assert.Equal(
+                    new[] { "1.0.0", "2.0.0", "3.0.0", "4.0.0", "5.0.0", "6.0.0", "7.0.0", "8.0.0", "9.0.0", "10.0.0" },
+                    await GetVersionArrayAsync(indexInfo));
+
+                Assert.Equal(4, result.ModifiedPages.Count);
+                Assert.Equal(new[] { "1.0.0", "3.0.0", "5.0.0", "7.0.0", "9.0.0" }, GetVersionArray(result.ModifiedLeaves));
+                Assert.Empty(result.DeletedLeaves);
+            }
+
+            [Fact]
+            public async Task DeleteAllVersions()
+            {
+                var indexInfo = MakeIndexInfo("1.0.0", "2.0.0", "3.0.0", "4.0.0");
+                var sortedCatalog = MakeSortedCatalog(Delete("1.0.0"), Delete("2.0.0"), Delete("3.0.0"), Delete("4.0.0"));
+
+                var result = await Target.MergeAsync(indexInfo, sortedCatalog);
+
+                Assert.Empty(indexInfo.Items);
+                Assert.Empty(await GetVersionArrayAsync(indexInfo));
+
+                Assert.Empty(result.ModifiedPages);
+                Assert.Empty(result.ModifiedLeaves);
+                Assert.Equal(new[] { "1.0.0", "2.0.0", "3.0.0", "4.0.0" }, GetVersionArray(result.DeletedLeaves));
+            }
+
+            [Fact]
+            public async Task AddManyVersions()
+            {
+                var indexInfo = IndexInfo.New();
+                var sortedCatalog = MakeSortedCatalog(Details("1.0.0"), Details("2.0.0"), Details("3.0.0"), Details("4.0.0"));
+
+                var result = await Target.MergeAsync(indexInfo, sortedCatalog);
+
+                Assert.Equal(2, indexInfo.Items.Count);
+                Assert.Equal(new[] { "1.0.0", "2.0.0", "3.0.0", "4.0.0" }, await GetVersionArrayAsync(indexInfo));
+
+                Assert.Equal(2, result.ModifiedPages.Count);
+                Assert.Equal(new[] { "1.0.0", "2.0.0", "3.0.0", "4.0.0" }, GetVersionArray(result.ModifiedLeaves));
+                Assert.Empty(result.DeletedLeaves);
+            }
+
+            [Theory]
+            [InlineData("2.0.0", "1.0.0")]
+            [InlineData("4.0.0", "1.0.0")]
+            [InlineData("6.0.0", "1.0.0")]
+            [InlineData("2.0.0", "3.0.0")]
+            [InlineData("4.0.0", "3.0.0")]
+            [InlineData("6.0.0", "3.0.0")]
+            [InlineData("2.0.0", "5.0.0")]
+            [InlineData("4.0.0", "5.0.0")]
+            [InlineData("6.0.0", "5.0.0")]
+            [InlineData("2.0.0", "7.0.0")]
+            [InlineData("4.0.0", "7.0.0")]
+            [InlineData("6.0.0", "7.0.0")]
+            public async Task AddAndRemoveFromNonLastPage(string deleted, string added)
+            {
+                var existing = new[] { "2.0.0", "4.0.0", "6.0.0", "8.0.0" };
+                var expected = existing
+                    .Except(new[] { deleted })
+                    .Concat(new[] { added })
+                    .OrderBy(x => NuGetVersion.Parse(x))
+                    .ToArray();
+                var actions = new[] { Delete(deleted), Details(added) }
+                    .OrderBy(x => x.Version)
+                    .ToList();
+                var indexInfo = MakeIndexInfo(existing);
+                var sortedCatalog = MakeSortedCatalog(actions);
+
+                var result = await Target.MergeAsync(indexInfo, sortedCatalog);
+
+                Assert.True(indexInfo.Items[0].IsPageFetched);
+                Assert.False(indexInfo.Items[1].IsPageFetched);
+
+                Assert.Equal(2, indexInfo.Items.Count);
+                Assert.Equal(expected, await GetVersionArrayAsync(indexInfo));
+
+                Assert.Same(indexInfo.Items[0], Assert.Single(result.ModifiedPages));
+                Assert.Equal(new[] { added }, GetVersionArray(result.ModifiedLeaves));
+                Assert.Equal(new[] { deleted }, GetVersionArray(result.DeletedLeaves));
+            }
+
+            [Fact]
+            public async Task RemoveMiddlePage()
+            {
+                var indexInfo = MakeIndexInfo("1.0.0", "2.0.0", "3.0.0", "4.0.0", "5.0.0", "6.0.0", "7.0.0");
+                var sortedCatalog = MakeSortedCatalog(Delete("4.0.0"), Delete("5.0.0"), Delete("6.0.0"));
+
+                var result = await Target.MergeAsync(indexInfo, sortedCatalog);
+
+                Assert.False(indexInfo.Items[0].IsPageFetched);
+                Assert.False(indexInfo.Items[1].IsPageFetched);
+
+                Assert.Equal(2, indexInfo.Items.Count);
+                Assert.Equal(new[] { "1.0.0", "2.0.0", "3.0.0", "7.0.0" }, await GetVersionArrayAsync(indexInfo));
+
+                Assert.Empty(result.ModifiedPages);
+                Assert.Empty(result.ModifiedLeaves);
+                Assert.Equal(new[] { "4.0.0", "5.0.0", "6.0.0" }, GetVersionArray(result.DeletedLeaves));
+            }
+
+            [Fact]
+            public async Task LoadsPageToFindMiss()
+            {
+                var indexInfo = MakeIndexInfo("1.0.0", "2.0.0", "4.0.0", "5.0.0");
+                var sortedCatalog = MakeSortedCatalog(Delete("3.0.0"));
+
+                var result = await Target.MergeAsync(indexInfo, sortedCatalog);
+
+                Assert.True(indexInfo.Items[0].IsPageFetched);
+                Assert.False(indexInfo.Items[1].IsPageFetched);
+
+                Assert.Equal(2, indexInfo.Items.Count);
+                Assert.Equal(new[] { "1.0.0", "2.0.0", "4.0.0", "5.0.0" }, await GetVersionArrayAsync(indexInfo));
+
+                Assert.Empty(result.ModifiedPages);
+                Assert.Empty(result.ModifiedLeaves);
+                Assert.Empty(result.DeletedLeaves);
+            }
+
+            public static IEnumerable<object[]> Versions => new[]
+            {
+                new object[] { "3.0.0" },
+                new object[] { "3.1.0" },
+                new object[] { "3.0.1" },
+                new object[] { "3.0.0.1" },
+                new object[] { "3.0.0-beta" },
+                new object[] { "3.0.0-BETA" },
+                new object[] { "3.0.0-beta.1" },
+            };
+        }
+    }
+}

--- a/tests/NuGet.Jobs.Catalog2Registration.Tests/Hives/HiveMergerFacts.Support.cs
+++ b/tests/NuGet.Jobs.Catalog2Registration.Tests/Hives/HiveMergerFacts.Support.cs
@@ -1,0 +1,183 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Moq;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Registration;
+using NuGet.Services;
+using NuGet.Services.Metadata.Catalog;
+using NuGet.Versioning;
+using Xunit.Abstractions;
+
+namespace NuGet.Jobs.Catalog2Registration
+{
+    public partial class HiveMergerFacts
+    {
+        public abstract class Facts
+        {
+            public Facts(ITestOutputHelper output)
+            {
+                Options = new Mock<IOptionsSnapshot<Catalog2RegistrationConfiguration>>();
+                Logger = output.GetLogger<HiveMerger>();
+
+                Config = new Catalog2RegistrationConfiguration
+                {
+                    MaxLeavesPerPage = 3,
+                };
+                Options.Setup(x => x.Value).Returns(() => Config);
+
+                Target = new HiveMerger(
+                    Options.Object,
+                    Logger);
+            }
+
+            public Mock<IOptionsSnapshot<Catalog2RegistrationConfiguration>> Options { get; }
+            public RecordingLogger<HiveMerger> Logger { get; }
+            public Catalog2RegistrationConfiguration Config { get; }
+            public HiveMerger Target { get; }
+        }
+
+        private class VersionAction
+        {
+            public VersionAction(NuGetVersion version, bool isDelete)
+            {
+                Version = version;
+                IsDelete = isDelete;
+            }
+
+            public NuGetVersion Version { get; }
+            public bool IsDelete { get; }
+        }
+
+        private class TestCase
+        {
+            public TestCase(List<NuGetVersion> existing, List<VersionAction> updated)
+            {
+                Existing = existing;
+                Updated = updated;
+            }
+
+            public List<NuGetVersion> Existing { get; }
+            public List<VersionAction> Updated { get; }
+        }
+
+        private static VersionAction Details(string version)
+        {
+            return new VersionAction(NuGetVersion.Parse(version), isDelete: false);
+        }
+
+        private static VersionAction Delete(string version)
+        {
+            return new VersionAction(NuGetVersion.Parse(version), isDelete: true);
+        }
+
+        private static string[] GetVersionArray(HashSet<LeafInfo> leafInfos)
+        {
+            return leafInfos
+                .OrderBy(x => x.Version)
+                .Select(x => x.LeafItem.CatalogEntry.Version)
+                .ToArray();
+        }
+
+        private static async Task<string[]> GetVersionArrayAsync(IndexInfo indexInfo)
+        {
+            var versions = await GetVersionsAsync(indexInfo);
+            return versions.Select(x => x.ToNormalizedString()).ToArray();
+        }
+
+        private static async Task<List<NuGetVersion>> GetVersionsAsync(IndexInfo indexInfo)
+        {
+            var versions = new List<NuGetVersion>();
+            foreach (var pageInfo in indexInfo.Items)
+            {
+                var leafInfos = await pageInfo.GetLeafInfosAsync();
+                foreach (var leafInfo in leafInfos)
+                {
+                    versions.Add(leafInfo.Version);
+                }
+            }
+
+            return versions;
+        }
+
+        private static List<CatalogCommitItem> MakeSortedCatalog(params VersionAction[] versions)
+        {
+            return MakeSortedCatalog((ICollection<VersionAction>)versions);
+        }
+
+        private static List<CatalogCommitItem> MakeSortedCatalog(ICollection<VersionAction> sortedVersionActions)
+        {
+            var output = new List<CatalogCommitItem>();
+            foreach (var versionAction in sortedVersionActions)
+            {
+                var item = new CatalogCommitItem(
+                    uri: null,
+                    commitId: null,
+                    commitTimeStamp: DateTime.MinValue,
+                    types: null,
+                    typeUris: new[] { versionAction.IsDelete ? Schema.DataTypes.PackageDelete : Schema.DataTypes.PackageDetails },
+                    packageIdentity: new PackageIdentity("NuGet.Versioning", versionAction.Version));
+
+                output.Add(item);
+            }
+
+            return output;
+        }
+
+        private static IndexInfo MakeIndexInfo(params string[] versions)
+        {
+            var sortedVersions = versions.Select(x => NuGetVersion.Parse(x)).ToList();
+            var versionToNormalized = sortedVersions.ToDictionary(x => x, x => x.ToNormalizedString());
+
+            return MakeIndexInfo(sortedVersions, maxLeavesPerPage: 3, versionToNormalized: versionToNormalized);
+        }
+
+        private static IndexInfo MakeIndexInfo(
+            List<NuGetVersion> sortedVersions,
+            int maxLeavesPerPage,
+            Dictionary<NuGetVersion, string> versionToNormalized)
+        {
+            var index = new RegistrationIndex
+            {
+                Items = new List<RegistrationPage>(),
+            };
+
+            // Populate the pages.
+            RegistrationPage currentPage = null;
+            for (var i = 0; i < sortedVersions.Count; i++)
+            {
+                if (i % maxLeavesPerPage == 0)
+                {
+                    currentPage = new RegistrationPage
+                    {
+                        Items = new List<RegistrationLeafItem>(),
+                    };
+                    index.Items.Add(currentPage);
+                }
+
+                currentPage.Items.Add(new RegistrationLeafItem
+                {
+                    CatalogEntry = new RegistrationCatalogEntry
+                    {
+                        Version = versionToNormalized[sortedVersions[i]],
+                    },
+                });
+            }
+
+            // Update the bounds.
+            foreach (var page in index.Items)
+            {
+                page.Count = page.Items.Count;
+                page.Lower = page.Items.First().CatalogEntry.Version;
+                page.Upper = page.Items.Last().CatalogEntry.Version;
+            }
+
+            return IndexInfo.Existing(storage: null, hive: HiveType.SemVer2, index: index);
+        }
+    }
+}

--- a/tests/NuGet.Jobs.Catalog2Registration.Tests/NuGet.Jobs.Catalog2Registration.Tests.csproj
+++ b/tests/NuGet.Jobs.Catalog2Registration.Tests/NuGet.Jobs.Catalog2Registration.Tests.csproj
@@ -57,6 +57,9 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Hives\HiveMergerFacts.Support.cs" />
+    <Compile Include="Hives\HiveMergerFacts.FullEnumeration.cs" />
+    <Compile Include="Hives\HiveMergerFacts.MergeAsync.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -80,6 +83,9 @@
       <Project>{ccb4d5ef-ac84-449d-ac6e-0a0ad295483a}</Project>
       <Name>NuGet.Services.V3.Tests</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>


### PR DESCRIPTION
There are two approaches in this PR for unit testing the complex HiveMerger component (PR'd with https://github.com/NuGet/NuGet.Services.Metadata/pull/707).

1. Traditional unit tests covered happy path case and edge cases.
2. A "full enumeration" test that generates all possible subsets of a set of versions for both the existing versions in a registration index and the versions coming from the catalog.

The reason this full enumeration suite is valuable is because the naive implementation of HiveMerger is trivial and can be done in the assertion step of a unit test. The implementation we have for product code (not tests) is more complex because it needs to be more performance and avoid unnecessary HTTP requests.

Progress on https://github.com/NuGet/NuGetGallery/issues/7736