### PR TITLE
[PackageType]Remove Attribute from PackageType

### DIFF
--- a/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
@@ -44,7 +44,6 @@ namespace NuGet.Services.AzureSearch
             public string SearchFilters { get; set; }
 
             [IsFilterable]
-            [Analyzer(ExactMatchCustomAnalyzer.Name)]
             public string[] FilterablePackageTypes { get; set; }
 
             public string FullVersion { get; set; }


### PR DESCRIPTION
Whoops.
We accidentally added a custom analyser to a filterable field, which is not allowed.
Removing this.