### PR TITLE
[C2R 2] Add registration comparer to compare two registration hives

### DIFF
--- a/src/NuGet.Jobs.RegistrationComparer/ComparisonContext.cs
+++ b/src/NuGet.Jobs.RegistrationComparer/ComparisonContext.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Jobs.RegistrationComparer
+{
+    public class ComparisonContext
+    {
+        public ComparisonContext(
+            string packageId,
+            string leftBaseUrl,
+            string rightBaseUrl,
+            string leftUrl,
+            string rightUrl,
+            Normalizers normalizers)
+        {
+            PackageId = packageId;
+            LeftBaseUrl = leftBaseUrl;
+            RightBaseUrl = rightBaseUrl;
+            LeftUrl = leftUrl;
+            RightUrl = rightUrl;
+            Normalizers = normalizers;
+        }
+
+        public string PackageId { get; }
+        public string LeftBaseUrl { get; }
+        public string RightBaseUrl { get; }
+        public string LeftUrl { get; }
+        public string RightUrl { get; }
+        public Normalizers Normalizers { get; }
+    }
+}

--- a/src/NuGet.Jobs.RegistrationComparer/CursorUtility.cs
+++ b/src/NuGet.Jobs.RegistrationComparer/CursorUtility.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Microsoft.Extensions.Options;
+using NuGet.Services.Metadata.Catalog;
+using NuGet.Services.Metadata.Catalog.Persistence;
+
+namespace NuGet.Jobs.RegistrationComparer
+{
+    public static class CursorUtility
+    {
+        public static Dictionary<string, ReadCursor> GetRegistrationCursors(
+            Func<HttpMessageHandler> handlerFunc,
+            IOptionsSnapshot<RegistrationComparerConfiguration> options)
+        {
+            var hiveCursors = new Dictionary<string, ReadCursor>();
+            foreach (var hives in options.Value.Registrations)
+            {
+                var cursorUrl = new Uri(hives.LegacyBaseUrl.TrimEnd('/') + "/cursor.json");
+                hiveCursors.Add(cursorUrl.AbsoluteUri, new HttpReadCursor(cursorUrl, DateTime.MinValue, handlerFunc));
+            }
+
+            return hiveCursors;
+        }
+
+        public static KeyValuePair<string, DurableCursor> GetComparerCursor(IStorageFactory storageFactory)
+        {
+            return GetDurableCursor(storageFactory, "comparer-cursor.json");
+        }
+
+        private static KeyValuePair<string, DurableCursor> GetDurableCursor(IStorageFactory storageFactory, string name)
+        {
+            var cursorStorage = storageFactory.Create();
+            var cursorUri = cursorStorage.ResolveUri(name);
+            return new KeyValuePair<string, DurableCursor>(
+                cursorUri.AbsoluteUri,
+                new DurableCursor(cursorUri, cursorStorage, DateTime.MinValue));
+        }
+    }
+}

--- a/src/NuGet.Jobs.RegistrationComparer/HiveComparer.cs
+++ b/src/NuGet.Jobs.RegistrationComparer/HiveComparer.cs
@@ -1,0 +1,244 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NuGet.Protocol.Catalog;
+using NuGet.Protocol.Registration;
+using NuGet.Services.Metadata.Catalog.Helpers;
+
+namespace NuGet.Jobs.RegistrationComparer
+{
+    public class HiveComparer
+    {
+        private readonly HttpClient _httpClient;
+        private readonly JsonComparer _comparer;
+        private readonly ILogger<HiveComparer> _logger;
+
+        public HiveComparer(
+            HttpClient httpClient,
+            JsonComparer comparer,
+            ILogger<HiveComparer> logger)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task CompareAsync(
+            IReadOnlyList<string> baseUrls,
+            string id,
+            IReadOnlyList<string> versions)
+        {
+            if (baseUrls.Count <= 1)
+            {
+                throw new ArgumentException("At least two base URLs must be provided.", nameof(baseUrls));
+            }
+
+            // Compare the indexes.
+            var rawIndexes = await Task.WhenAll(baseUrls.Select(x => GetIndexAsync(x, id)));
+            var areBothMissing = false;
+            for (var i = 1; i < baseUrls.Count; i++)
+            {
+                if (AreBothMissing(
+                   rawIndexes[i - 1].Url,
+                   rawIndexes[i].Url,
+                   rawIndexes[i - 1].Data,
+                   rawIndexes[i].Data))
+                {
+                    areBothMissing = true;
+                    continue;
+                }
+
+                var comparisonContext = new ComparisonContext(
+                    id,
+                    baseUrls[i - 1],
+                    baseUrls[i],
+                    rawIndexes[i - 1].Url,
+                    rawIndexes[i].Url,
+                    Normalizers.Index);
+
+                _comparer.Compare(
+                   rawIndexes[i - 1].Data,
+                   rawIndexes[i].Data,
+                   comparisonContext);
+            }
+
+            if (areBothMissing)
+            {
+                return;
+            }
+
+            // Deserialize the indexes so we can get the page URLs.
+            var indexes = new List<DownloadedData<RegistrationIndex>>();
+            foreach (var rawIndex in rawIndexes)
+            {
+                indexes.Add(new DownloadedData<RegistrationIndex>(
+                    rawIndex.Url,
+                    rawIndex.Data.ToObject<RegistrationIndex>(NuGetJsonSerialization.Serializer)));
+            }
+
+            // Download the pages (if any) and leaves.
+            var pageUrlGroups = indexes
+                .Select((x, i) => x
+                    .Data
+                    .Items
+                    .Where(p => p.Items == null)
+                    .Select(p => p.Url)
+                    .ToList())
+                .ToList();
+            var leafUrlGroups = baseUrls
+                .Select(x => versions.Select(v => $"{x}{id}/{v}.json").ToList())
+                .ToList();
+
+            var urls = new ConcurrentBag<string>(pageUrlGroups
+                .SelectMany(x => x)
+                .Concat(leafUrlGroups.SelectMany(x => x)));
+            var urlToJson = new ConcurrentDictionary<string, JObject>();
+            await ParallelAsync.Repeat(
+                async () =>
+                {
+                    await Task.Yield();
+                    while (urls.TryTake(out var pageUrl))
+                    {
+                        var json = await GetJObjectOrNullAsync(pageUrl);
+                        urlToJson.TryAdd(pageUrl, json.Data);
+                    }
+                });
+
+            // Compare the pages.
+            for (var i = 1; i < baseUrls.Count; i++)
+            {
+                for (var pageIndex = 0; pageIndex < pageUrlGroups[i].Count; pageIndex++)
+                {
+                    var leftUrl = pageUrlGroups[i - 1][pageIndex];
+                    var rightUrl = pageUrlGroups[i][pageIndex];
+
+                    var comparisonContext = new ComparisonContext(
+                        id,
+                        baseUrls[i - 1],
+                        baseUrls[i],
+                        leftUrl,
+                        rightUrl,
+                        Normalizers.Page);
+
+                    _comparer.Compare(
+                       urlToJson[leftUrl],
+                       urlToJson[rightUrl],
+                       comparisonContext);
+                }
+            }
+
+            // Compare the affected leaves.
+            for (var i = 1; i < baseUrls.Count; i++)
+            {
+                for (var leafIndex = 0; leafIndex < leafUrlGroups[i].Count; leafIndex++)
+                {
+                    var leftUrl = leafUrlGroups[i - 1][leafIndex];
+                    var rightUrl = leafUrlGroups[i][leafIndex];
+
+                    try
+                    {
+                        if (AreBothMissing(
+                            leftUrl,
+                            rightUrl,
+                            urlToJson[leftUrl],
+                            urlToJson[rightUrl]))
+                        {
+                            continue;
+                        }
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        ResultWriter.WriteWarning(ex.Message);
+                        continue;
+                    }
+
+                    var comparisonContext = new ComparisonContext(
+                        id,
+                        baseUrls[i - 1],
+                        baseUrls[i],
+                        leftUrl,
+                        rightUrl,
+                        Normalizers.Leaf);
+
+                    _comparer.Compare(
+                       urlToJson[leftUrl],
+                       urlToJson[rightUrl],
+                       comparisonContext);
+                }
+            }
+        }
+
+        private bool AreBothMissing(string leftUrl, string rightUrl, JObject left, JObject right)
+        {
+            if ((left == null) != (right == null))
+            {
+                throw new InvalidOperationException(Environment.NewLine +
+                   $"One of the URLs exists, the other does not." + Environment.NewLine +
+                   $"|  Left URL:     {leftUrl}" + Environment.NewLine +
+                   $"|  Right URL:    {rightUrl}" + Environment.NewLine +
+                   $"|  Left is 404:  {left == null}" + Environment.NewLine +
+                   $"|  Right is 404: {right == null}" + Environment.NewLine);
+            }
+
+            return left == null;
+        }
+
+        private async Task<DownloadedData<JObject>> GetIndexAsync(string baseUrl, string id)
+        {
+            var url = $"{baseUrl}{id}/index.json";
+            return await GetJObjectOrNullAsync(url);
+        }
+
+        private async Task<DownloadedData<JObject>> GetJObjectOrNullAsync(string url)
+        {
+            using (var response = await _httpClient.GetAsync(url))
+            {
+                _logger.LogInformation(
+                    "Fetched {Url}: {StatusCode} {ReasonPhrase}",
+                    url,
+                    (int)response.StatusCode,
+                    response.ReasonPhrase);
+
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    return new DownloadedData<JObject>(url, null);
+                }
+
+                response.EnsureSuccessStatusCode();
+
+                using (var stream = await _httpClient.GetStreamAsync(url))
+                using (var streamReader = new StreamReader(stream))
+                using (var jsonTextReader = new JsonTextReader(streamReader))
+                {
+                    jsonTextReader.DateParseHandling = DateParseHandling.None;
+
+                    var data = JObject.Load(jsonTextReader);
+                    return new DownloadedData<JObject>(url, data);
+                }
+            }
+        }
+
+        private class DownloadedData<T>
+        {
+            public DownloadedData(string url, T data)
+            {
+                Url = url;
+                Data = data;
+            }
+
+            public string Url { get; }
+            public T Data { get; }
+        }
+    }
+}

--- a/src/NuGet.Jobs.RegistrationComparer/HivesConfiguration.cs
+++ b/src/NuGet.Jobs.RegistrationComparer/HivesConfiguration.cs
@@ -3,12 +3,10 @@
 
 namespace NuGet.Jobs.RegistrationComparer
 {
-    class Program
+    public class HivesConfiguration
     {
-        static int Main(string[] args)
-        {
-            var job = new Job();
-            return JobRunner.Run(job, args).GetAwaiter().GetResult();
-        }
+        public string LegacyBaseUrl { get; set; }
+        public string GzippedBaseUrl { get; set; }
+        public string SemVer2BaseUrl { get; set; }
     }
 }

--- a/src/NuGet.Jobs.RegistrationComparer/Job.cs
+++ b/src/NuGet.Jobs.RegistrationComparer/Job.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Design;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Autofac;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.WindowsAzure.Storage;
+using NuGet.Protocol;
+using NuGet.Services.Configuration;
+using NuGet.Services.Metadata.Catalog.Persistence;
+using NuGet.Services.V3;
+
+namespace NuGet.Jobs.RegistrationComparer
+{
+    public class Job : JsonConfigurationJob
+    {
+        private const string ConfigurationSectionName = "RegistrationComparer";
+        private const string RegistrationComparerMode = "compare";
+        private string _mode;
+
+        public override void Init(IServiceContainer serviceContainer, IDictionary<string, string> jobArgsDictionary)
+        {
+            _mode = jobArgsDictionary.GetOrThrow<string>("mode");
+            base.Init(serviceContainer, jobArgsDictionary);
+        }
+
+        public override async Task Run()
+        {
+            ServicePointManager.DefaultConnectionLimit = 64;
+            ServicePointManager.MaxServicePointIdleTime = 10000;
+
+            switch (_mode)
+            {
+                case RegistrationComparerMode:
+                    await _serviceProvider
+                        .GetRequiredService<RegistrationComparerCommand>()
+                        .ExecuteAsync(CancellationToken.None);
+                    break;
+                default:
+                    throw new InvalidOperationException("Unknown mode.");
+            }
+        }
+
+        protected override void ConfigureAutofacServices(ContainerBuilder containerBuilder)
+        {
+            containerBuilder
+                   .Register(c =>
+                   {
+                       var options = c.Resolve<IOptionsSnapshot<RegistrationComparerConfiguration>>();
+                       return CloudStorageAccount.Parse(options.Value.StorageConnectionString);
+                   })
+                   .AsSelf();
+
+            containerBuilder
+                .Register<IStorageFactory>(c =>
+                {
+                    var options = c.Resolve<IOptionsSnapshot<RegistrationComparerConfiguration>>();
+                    return new AzureStorageFactory(
+                        c.Resolve<CloudStorageAccount>(),
+                        options.Value.StorageContainer,
+                        maxExecutionTime: AzureStorage.DefaultMaxExecutionTime,
+                        serverTimeout: AzureStorage.DefaultServerTimeout,
+                        path: string.Empty,
+                        baseAddress: null,
+                        useServerSideCopy: true,
+                        compressContent: false,
+                        verbose: true,
+                        initializeContainer: false,
+                        throttle: NullThrottle.Instance);
+                })
+                .As<IStorageFactory>();
+        }
+
+        protected override void ConfigureJobServices(IServiceCollection services, IConfigurationRoot configurationRoot)
+        {
+            services.AddV3();
+
+            switch (_mode)
+            {
+                case RegistrationComparerMode:
+                    services.AddTransient<ICommitCollectorLogic, RegistrationComparerCollectorLogic>();
+                    break;
+            }
+
+            services.AddTransient<RegistrationComparerCommand>();
+            services.AddTransient<HiveComparer>();
+            services.AddTransient<JsonComparer>();
+
+            services.Configure<RegistrationComparerConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));
+            services.Configure<CommitCollectorConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));
+        }
+    }
+}

--- a/src/NuGet.Jobs.RegistrationComparer/JsonComparer.cs
+++ b/src/NuGet.Jobs.RegistrationComparer/JsonComparer.cs
@@ -1,0 +1,176 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace NuGet.Jobs.RegistrationComparer
+{
+    public class JsonComparer
+    {
+        public void Compare(JToken left, JToken right, ComparisonContext context)
+        {
+            var normalized = false;
+            if (left.Type != right.Type)
+            {
+                Type leftType = null;
+                Type rightType = null;
+                try
+                {
+                    foreach (var pair in context.Normalizers.ScalarNormalizers)
+                    {
+                        if (pair.Key(left.Path))
+                        {
+                            leftType = pair.Value(left, true, context)?.GetType();
+                            rightType = pair.Value(right, false, context)?.GetType();
+                            normalized = true;
+                            break;
+                        }
+                    }
+                }
+                catch
+                {
+                    // Swallow exceptions encountered during normalization. The comparison will just consider the tokens
+                    // as different, which is correct.
+                }
+
+                if (!normalized || leftType != rightType)
+                {
+                    throw new InvalidOperationException(Environment.NewLine +
+                        $"The type of the JSON value is different." + Environment.NewLine +
+                        $"|  Left URL:   {context.LeftUrl}" + Environment.NewLine +
+                        $"|  Right URL:  {context.RightUrl}" + Environment.NewLine +
+                        $"|  Left path:  {left.Path}" + Environment.NewLine +
+                        $"|  Right path: {right.Path}" + Environment.NewLine +
+                        $"|  Left type:  {left.Type}" + Environment.NewLine +
+                        $"|  Right type: {right.Type}" + Environment.NewLine);
+                }
+            }
+
+            if (!normalized && left.Type == JTokenType.Object)
+            {
+                Compare((JObject)left, (JObject)right, context);
+            }
+            else if (!normalized && left.Type == JTokenType.Array)
+            {
+                Compare((JArray)left, (JArray)right, context);
+            }
+            else
+            {
+                var leftJson = left.ToString();
+                var rightJson = right.ToString();
+                if (leftJson != rightJson)
+                {
+                    var leftString = leftJson;
+                    var rightString = rightJson;
+                    foreach (var pair in context.Normalizers.ScalarNormalizers)
+                    {
+                        if (pair.Key(left.Path))
+                        {
+                            leftString = pair.Value(left, true, context) ?? leftJson;
+                            rightString = pair.Value(right, false, context) ?? rightJson;
+                            break;
+                        }
+                    }
+
+                    if (leftString != rightString)
+                    {
+                        throw new InvalidOperationException(Environment.NewLine +
+                           $"The value of the JSON scalar is different." + Environment.NewLine +
+                           $"|  Left URL:    {context.LeftUrl}" + Environment.NewLine +
+                           $"|  Right URL:   {context.RightUrl}" + Environment.NewLine +
+                           $"|  Left path:   {left.Path}" + Environment.NewLine +
+                           $"|  Right path:  {right.Path}" + Environment.NewLine +
+                           $"|  Left value:  {leftJson}" + Environment.NewLine +
+                           $"|  Right value: {rightJson}" + Environment.NewLine);
+                    }
+                }
+            }
+        }
+
+        private void Compare(JArray left, JArray right, ComparisonContext context)
+        {
+            if (left.Count != right.Count)
+            {
+                throw new InvalidOperationException(Environment.NewLine +
+                    $"The JSON array item count is different." + Environment.NewLine +
+                    $"|  Left URL:    {context.LeftUrl}" + Environment.NewLine +
+                    $"|  Right URL:   {context.RightUrl}" + Environment.NewLine +
+                    $"|  Left path:   {left.Path}" + Environment.NewLine +
+                    $"|  Right path:  {right.Path}" + Environment.NewLine +
+                    $"|  Left count:  {left.Count}" + Environment.NewLine +
+                    $"|  Right count: {right.Count}" + Environment.NewLine);
+            }
+
+            var leftItems = left.ToList();
+            var rightItems = right.ToList();
+            if (leftItems.Count > 1)
+            {
+                foreach (var pair in context.Normalizers.UnsortedArrays)
+                {
+                    if (pair.Key(left))
+                    {
+                        leftItems.Sort(pair.Value);
+                        rightItems.Sort(pair.Value);
+                        break;
+                    }
+                }
+            }
+
+            for (var i = 0; i < leftItems.Count; i++)
+            {
+                Compare(leftItems[i], rightItems[i], context);
+            }
+        }
+
+        private void Compare(JObject left, JObject right, ComparisonContext context)
+        {
+            var leftPropertyNames = left.Properties().Select(x => x.Name);
+            var rightPropertyNames = right.Properties().Select(x => x.Name);
+
+            var onlyLeft = leftPropertyNames.Except(rightPropertyNames);
+            var onlyRight = rightPropertyNames.Except(leftPropertyNames);
+            if (onlyLeft.Any() || onlyRight.Any())
+            {
+                throw new InvalidOperationException(Environment.NewLine +
+                    $"The JSON object property names are disjoint." + Environment.NewLine +
+                    $"|  Left URL:   {context.LeftUrl}" + Environment.NewLine +
+                    $"|  Right URL:  {context.RightUrl}" + Environment.NewLine +
+                    $"|  Left path:  {left.Path}" + Environment.NewLine +
+                    $"|  Right path: {right.Path}" + Environment.NewLine +
+                    $"|  Only left:  {string.Join(", ", onlyLeft)}" + Environment.NewLine +
+                    $"|  Only right: {string.Join(", ", onlyRight)}" + Environment.NewLine);
+            }
+
+            var leftProperties = left.Properties();
+            var rightProperties = right.Properties();
+
+            if (!leftPropertyNames.SequenceEqual(rightPropertyNames))
+            {
+                if (context.Normalizers.UnsortedObjects.Any(x => x(left.Path)))
+                {
+                    leftProperties = leftProperties.OrderBy(x => x.Name);
+                    rightProperties = rightProperties.OrderBy(x => x.Name);
+                }
+                else
+                {
+                    throw new InvalidOperationException(Environment.NewLine +
+                        $"The JSON object property names are in a different order." + Environment.NewLine +
+                        $"|  Left URL:    {context.LeftUrl}" + Environment.NewLine +
+                        $"|  Right URL:   {context.RightUrl}" + Environment.NewLine +
+                        $"|  Left path:   {left.Path}" + Environment.NewLine +
+                        $"|  Right path:  {right.Path}" + Environment.NewLine +
+                        $"|  Left order:  {string.Join(", ", leftPropertyNames)}" + Environment.NewLine +
+                        $"|  Right order: {string.Join(", ", rightPropertyNames)}" + Environment.NewLine);
+                }
+            }
+
+            var pairs = leftProperties.Zip(rightProperties, (l, r) => new { Left = l.Value, Right = r.Value });
+            foreach (var pair in pairs)
+            {
+                Compare(pair.Left, pair.Right, context);
+            }
+        }
+    }
+}

--- a/src/NuGet.Jobs.RegistrationComparer/Normalizers.cs
+++ b/src/NuGet.Jobs.RegistrationComparer/Normalizers.cs
@@ -1,0 +1,268 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json.Linq;
+using NuGet.Versioning;
+using ValueNormalizer = System.Collections.Generic.KeyValuePair<NuGet.Jobs.RegistrationComparer.ShouldNormalizeByPath, NuGet.Jobs.RegistrationComparer.NormalizeToken>;
+using ArrayNormalizer = System.Collections.Generic.KeyValuePair<NuGet.Jobs.RegistrationComparer.ShouldNormalizeByArray, System.Comparison<Newtonsoft.Json.Linq.JToken>>;
+
+namespace NuGet.Jobs.RegistrationComparer
+{
+    public delegate bool ShouldNormalizeByPath(string jsonPath);
+    public delegate bool ShouldNormalizeByArray(JArray array);
+    public delegate string NormalizeToken(JToken value, bool isLeft, ComparisonContext context);
+
+    public class Normalizers
+    {
+        private readonly static HashSet<string> PackageIdsWithDotDotDependencies = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "angularjs.TypeScript.DefinitelyTyped",
+            "devextreme.TypeScript.DefinitelyTyped",
+        };
+
+        private static readonly IReadOnlyList<ValueNormalizer> DefaultScalarNormalizers = new List<ValueNormalizer>
+        {
+            new ValueNormalizer(
+                path => IsPropertyName(path, "@id") || IsPropertyName(path, "registration") || IsPropertyName(path, "parent"),
+                (value, isLeft, context) =>
+                {
+                    var url = (string)value;
+                    var baseUrl = isLeft ? context.LeftBaseUrl : context.RightBaseUrl;
+
+                    // Ignore a quirky dependency package IDs:
+                    //   - "../jquery.TypeScript.DefinitelyTyped"
+                    //     https://api.nuget.org/v3/catalog0/data/2018.10.18.22.40.48/angularjs.typescript.definitelytyped.0.6.6.json
+                    //   - "../jquery.TypeScript.DefinitelyTyped"
+                    //     https://api.nuget.org/v3/catalog0/data/2018.12.15.06.50.14/devextreme.typescript.definitelytyped.0.0.4.json
+                    if (PackageIdsWithDotDotDependencies.Contains(context.PackageId)
+                        && IsPropertyName(value.Path, "registration")
+                        && url.Contains("../"))
+                    {
+                        var otherBaseUrl = isLeft ? context.RightBaseUrl : context.LeftBaseUrl;
+                        url = TrySetBaseUrl(url, baseUrl, otherBaseUrl);
+                        url = new Uri(url).AbsoluteUri;
+                    }
+
+                    url = TrySetBaseUrl(url, baseUrl, "{base URL}/");
+
+                    return url;
+                }),
+        };
+
+        private static string TrySetBaseUrl(string url, string currentBaseUrl, string newBaseUrl)
+        {
+            if (url.StartsWith(currentBaseUrl))
+            {
+                url = newBaseUrl + url.Substring(currentBaseUrl.Length);
+            }
+
+            return url;
+        }
+
+        private static readonly IReadOnlyList<ValueNormalizer> IndexAndPageScalarNormalizers = new List<ValueNormalizer>(DefaultScalarNormalizers)
+        {
+            new ValueNormalizer(
+                path => IsPropertyName(path, "commitId"),
+                (value, isLeft, context) =>
+                {
+                    // Each iteration, the writer will come up with a different commit ID.
+                    var commitId = (string)value;
+                    if (commitId != null
+                        && Regex.IsMatch(commitId, "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"))
+                    {
+                        return Guid.Empty.ToString();
+                    }
+
+                    return commitId;
+                }),
+            new ValueNormalizer(
+                path => IsPropertyName(path, "commitTimeStamp"),
+                (value, isLeft, context) =>
+                {
+                    // Each iteration, the writer will come up with a different commit timestamp.
+                    var commitTimestamp = (string)value;
+                    if (commitTimestamp != null
+                        && Regex.IsMatch(commitTimestamp, @"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{1,}(Z|\+00:00)"))
+                    {
+                        return DateTimeOffset.MinValue.ToString("o");
+                    }
+
+                    return commitTimestamp;
+                }), 
+            new ValueNormalizer(
+                path => IsPropertyName(path, "summary"),
+                (value, isLeft, context) =>
+                {
+                    // The NuGet.Protocol.Catalog library deserializes properties in a case-insensitive way.
+                    // This is due to the following Newtonsoft.Json issue:
+                    // https://github.com/JamesNK/Newtonsoft.Json/issues/815
+
+                    // This package has "Summary" instead of "summary"
+                    // https://api.nuget.org/v3/catalog0/data/2019.10.02.07.14.49/staticproxy.fody.1.0.146-genericmethods.json
+                    if (context.PackageId.Equals("StaticProxy.Fody", StringComparison.OrdinalIgnoreCase)
+                        && (string)value.Parent.Parent["version"] == "1.0.146-GenericMethods")
+                    {
+                        return "";
+                    }
+                    
+                    return (string)value;
+                }),
+            new ValueNormalizer(
+                path => IsPropertyName(path, "licenseUrl"),
+                (value, isLeft, context) =>
+                {
+                    // This package has "licenseurl" instead of "licenseUrl"
+                    // https://api.nuget.org/v3/catalog0/data/2019.01.02.03.56.37/boolli.1.0.0.json
+                    if (context.PackageId.Equals("Boolli", StringComparison.OrdinalIgnoreCase)
+                        && (string)value.Parent.Parent["version"] == "1.0.0")
+                    {
+                        return "";
+                    }
+
+                    return (string)value;
+                }),
+            new ValueNormalizer(
+                path => IsPropertyName(path, "projectUrl"),
+                (value, isLeft, context) =>
+                {
+                    // This package has "ProjectUrl" instead of "projectUrl"
+                    // https://api.nuget.org/v3/catalog0/data/2019.01.02.13.49.28/blogml.core.1.0.0.json
+                    if (context.PackageId.Equals("BlogML.Core", StringComparison.OrdinalIgnoreCase)
+                        && (string)value.Parent.Parent["version"] == "1.0.0")
+                    {
+                        return "";
+                    }
+
+                    return (string)value;
+                }),
+            new ValueNormalizer(
+                path => IsPropertyName(path, "iconUrl"),
+                (value, isLeft, context) =>
+                {
+                    // This package has "iconURL" instead of "iconUrl"
+                    // https://api.nuget.org/v3/catalog0/data/2019.04.18.10.29.30/confuser.msbuild.2.0.0-alpha-0191.json
+                    if (context.PackageId.Equals("Confuser.MSBuild", StringComparison.OrdinalIgnoreCase)
+                        && (string)value.Parent.Parent["version"] == "2.0.0-alpha-0191")
+                    {
+                        return "";
+                    }
+
+                    return (string)value;
+                }),
+            new ValueNormalizer(
+                path => IsPropertyName(path, "language"),
+                (value, isLeft, context) =>
+                {
+                    // This package has "Language" instead of "language"
+                    // https://api.nuget.org/v3/catalog0/data/2018.12.19.07.07.41/smartseeder.0.0.1.json
+                    // https://api.nuget.org/v3/catalog0/data/2018.12.19.07.07.41/smartseeder.1.0.0-rc1-beta.json
+                    // https://api.nuget.org/v3/catalog0/data/2018.12.19.07.07.31/smartseeder.1.0.0-rc1-preview.json
+                    if (context.PackageId.Equals("SmartSeeder", StringComparison.OrdinalIgnoreCase)
+                        && new[] { "0.0.1", "1.0.0-rc1-beta", "1.0.0-rc1-preview" }.Contains((string)value.Parent.Parent["version"]))
+                    {
+                        return "";
+                    }
+
+                    return (string)value;
+                }),
+            new ValueNormalizer(
+                path => IsPropertyName(path, "range"),
+                (value, isLeft, context) =>
+                {
+                    // This package has duplicate dependencies, meaning the dependency range is an array instead of string.
+                    // https://api.nuget.org/v3/catalog0/data/2019.11.26.10.59.56/paket.core.5.237.1.json
+                    // https://api.nuget.org/v3/catalog0/data/2019.11.26.11.13.24/paket.core.5.237.2.json
+                    if (context.PackageId.Equals("Paket.Core", StringComparison.OrdinalIgnoreCase)
+                        && new[] { "5.237.1", "5.237.2" }.Contains((string)value.Parent.Parent.Parent.Parent.Parent.Parent.Parent.Parent["version"])
+                        && value.Type == JTokenType.Array)
+                    {
+                        return (string)value.OrderBy(x => x).First();
+                    }
+
+                    // This package has duplicate dependencies, meaning the dependency range is an array instead of string.
+                    // https://api.nuget.org/v3/catalog0/data/2016.02.21.10.24.50/dingu.generic.repo.ef7.1.0.0.json
+                    // https://api.nuget.org/v3/catalog0/data/2016.02.21.11.06.01/dingu.generic.repo.ef7.1.0.0-beta2.json
+                    if (context.PackageId.Equals("Dingu.Generic.Repo.EF7", StringComparison.OrdinalIgnoreCase)
+                        && new[] { "1.0.0", "1.0.0-beta2" }.Contains((string)value.Parent.Parent.Parent.Parent.Parent.Parent.Parent.Parent["version"])
+                        && value.Type == JTokenType.Array)
+                    {
+                        return (string)value.OrderBy(x => x).First();
+                    }
+
+                    return (string)value;
+                }),
+        };
+
+        private static readonly IReadOnlyList<ShouldNormalizeByPath> DefaultUnsortedObjects = new List<ShouldNormalizeByPath>
+        {
+            path => path.StartsWith("@context."),
+        };
+
+        private static readonly IReadOnlyList<ShouldNormalizeByPath> PageUnsortedObjects = new List<ShouldNormalizeByPath>(DefaultUnsortedObjects)
+        {
+            path => path == string.Empty,
+        };
+
+        private static readonly IReadOnlyList<ArrayNormalizer> DefaultUnsortedArrays = new List<ArrayNormalizer>();
+
+        private static readonly IReadOnlyList<ArrayNormalizer> IndexAndPageUnsortedArrays = new List<ArrayNormalizer>(DefaultUnsortedArrays)
+        {
+            new ArrayNormalizer(
+                a => IsPropertyName(a.Path, "dependencies"),
+                (a, b) => StringComparer.OrdinalIgnoreCase.Compare((string)a["id"], (string)b["id"])),
+            new ArrayNormalizer(
+                a => IsPropertyName(a.Path, "tags"),
+                (a, b) => StringComparer.Ordinal.Compare((string)a, (string)b)),
+            new ArrayNormalizer(
+                a => IsPropertyName(a.Path, "reasons"),
+                (a, b) => StringComparer.Ordinal.Compare((string)a, (string)b)),
+            new ArrayNormalizer(
+                a => IsPropertyName(a.Path, "dependencyGroups"),
+                (a, b) => StringComparer.Ordinal.Compare((string)a["targetFramework"], (string)b["targetFramework"])),
+            new ArrayNormalizer(
+                a => IsPropertyName(a.Path, "items")
+                  && a.Parent?.Parent != null
+                  && a.Parent.Parent["@type"]?.Type == JTokenType.String
+                  && (string)a.Parent.Parent["@type"] == "catalog:CatalogPage",
+                (a, b) => NuGetVersion.Parse((string)a["catalogEntry"]["version"]).CompareTo(NuGetVersion.Parse((string)b["catalogEntry"]["version"])))
+        };
+
+        private static bool IsPropertyName(string path, string name)
+        {
+            return path == name || path.EndsWith("." + name);
+        }
+
+        private Normalizers(
+            IReadOnlyList<ValueNormalizer> scalarNormalizers,
+            IReadOnlyList<ShouldNormalizeByPath> unsortedObjects,
+            IReadOnlyList<ArrayNormalizer> unsortedArrays)
+        {
+            ScalarNormalizers = scalarNormalizers;
+            UnsortedObjects = unsortedObjects;
+            UnsortedArrays = unsortedArrays;
+        }
+
+        public static readonly Normalizers Index = new Normalizers(
+            IndexAndPageScalarNormalizers,
+            DefaultUnsortedObjects,
+            IndexAndPageUnsortedArrays);
+
+        public static readonly Normalizers Page = new Normalizers(
+            IndexAndPageScalarNormalizers,
+            PageUnsortedObjects,
+            IndexAndPageUnsortedArrays);
+
+        public static readonly Normalizers Leaf = new Normalizers(
+            DefaultScalarNormalizers,
+            DefaultUnsortedObjects,
+            DefaultUnsortedArrays);
+
+        public IReadOnlyList<ValueNormalizer> ScalarNormalizers { get; }
+        public IReadOnlyList<ShouldNormalizeByPath> UnsortedObjects { get; }
+        public IReadOnlyList<ArrayNormalizer> UnsortedArrays { get; }
+    }
+}

--- a/src/NuGet.Jobs.RegistrationComparer/NuGet.Jobs.RegistrationComparer.csproj
+++ b/src/NuGet.Jobs.RegistrationComparer/NuGet.Jobs.RegistrationComparer.csproj
@@ -41,9 +41,20 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ComparisonContext.cs" />
+    <Compile Include="CursorUtility.cs" />
+    <Compile Include="Normalizers.cs" />
+    <Compile Include="RegistrationComparerCollectorLogic.cs" />
+    <Compile Include="HiveComparer.cs" />
+    <Compile Include="HivesConfiguration.cs" />
+    <Compile Include="Job.cs" />
+    <Compile Include="JsonComparer.cs" />
+    <Compile Include="RegistrationComparerConfiguration.cs" />
+    <Compile Include="RegistrationComparerCommand.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />
+    <Compile Include="ResultWriter.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/src/NuGet.Jobs.RegistrationComparer/RegistrationComparerCollectorLogic.cs
+++ b/src/NuGet.Jobs.RegistrationComparer/RegistrationComparerCollectorLogic.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NuGet.Services.Metadata.Catalog;
+using NuGet.Services.Metadata.Catalog.Helpers;
+using NuGet.Services.V3;
+
+namespace NuGet.Jobs.RegistrationComparer
+{
+    public class RegistrationComparerCollectorLogic : ICommitCollectorLogic
+    {
+        private readonly CommitCollectorUtility _utility;
+        private readonly HiveComparer _comparer;
+        private readonly IOptionsSnapshot<RegistrationComparerConfiguration> _options;
+        private readonly ILogger<RegistrationComparerCollectorLogic> _logger;
+
+        public RegistrationComparerCollectorLogic(
+            CommitCollectorUtility utility,
+            HiveComparer comparer,
+            IOptionsSnapshot<RegistrationComparerConfiguration> options,
+            ILogger<RegistrationComparerCollectorLogic> logger)
+        {
+            _utility = utility ?? throw new ArgumentNullException(nameof(utility));
+            _comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public Task<IEnumerable<CatalogCommitItemBatch>> CreateBatchesAsync(IEnumerable<CatalogCommitItem> catalogItems)
+        {
+            return Task.FromResult(_utility.CreateSingleBatch(catalogItems));
+        }
+
+        public async Task OnProcessBatchAsync(IEnumerable<CatalogCommitItem> items)
+        {
+            var packageIdGroups = items
+                .GroupBy(x => x.PackageIdentity.Id, StringComparer.OrdinalIgnoreCase)
+                .Select(g => new
+                {
+                    Id = g.Key.ToLowerInvariant(),
+                    Versions = g
+                        .Select(x => x.PackageIdentity.Version)
+                        .Distinct()
+                        .OrderBy(x => x)
+                        .Select(x => x.ToNormalizedString().ToLowerInvariant())
+                        .ToList(),
+                })
+                .ToList();
+
+            _logger.LogInformation("Comparing {Count} package IDs.", packageIdGroups.Count);
+
+            var hiveGroups = _options
+                .Value
+                .Registrations
+                .SelectMany(x => new[]
+                {
+                    new { Hive = nameof(x.LegacyBaseUrl), Url = x.LegacyBaseUrl.TrimEnd('/') + '/' },
+                    new { Hive = nameof(x.GzippedBaseUrl), Url = x.GzippedBaseUrl.TrimEnd('/') + '/' },
+                    new { Hive = nameof(x.SemVer2BaseUrl), Url = x.SemVer2BaseUrl.TrimEnd('/') + '/' },
+                })
+                .GroupBy(x => x.Hive, x => x.Url);
+
+            var allWork = new ConcurrentBag<Func<Task>>();
+            var failures = 0;
+            foreach (var group in packageIdGroups)
+            {
+                foreach (var hiveGroup in hiveGroups)
+                {
+                    var baseUrls = hiveGroup.ToList();
+                    var hive = hiveGroup.Key;
+                    var id = group.Id;
+                    var versions = group.Versions;
+                    allWork.Add(async () =>
+                    {
+                        _logger.LogInformation("Verifying hive {Hive} for {PackageId}.", hive, id);
+                        try
+                        {
+                            await _comparer.CompareAsync(baseUrls, id, versions);
+                        }
+                        catch (Exception ex)
+                        {
+                            Interlocked.Increment(ref failures);
+                            ResultWriter.WriteError(ex.Message.ToString());
+                            _logger.LogError(ex, "The comparison failed.");
+                        }
+                    });
+                }
+            }
+
+            await ParallelAsync
+                .Repeat(async () =>
+                {
+                    await Task.Yield();
+                    while (allWork.TryTake(out var work))
+                    {
+                        await work();
+                    }
+                },
+                degreeOfParallelism: 32);
+
+            if (failures > 0)
+            {
+                throw new InvalidOperationException($"{failures} hives failed the comparison.");
+            }
+        }
+    }
+}

--- a/src/NuGet.Jobs.RegistrationComparer/RegistrationComparerCommand.cs
+++ b/src/NuGet.Jobs.RegistrationComparer/RegistrationComparerCommand.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.WindowsAzure.Storage;
+using NuGet.Services.Metadata.Catalog;
+using NuGet.Services.Metadata.Catalog.Persistence;
+using NuGet.Services.V3;
+
+namespace NuGet.Jobs.RegistrationComparer
+{
+    public class RegistrationComparerCommand
+    {
+        private readonly ICollector _collector;
+        private readonly CloudStorageAccount _storageAccount;
+        private readonly IStorageFactory _storageFactory;
+        private readonly Func<HttpMessageHandler> _handlerFunc;
+        private readonly IOptionsSnapshot<RegistrationComparerConfiguration> _options;
+        private readonly ILogger<RegistrationComparerCommand> _logger;
+
+        public RegistrationComparerCommand(
+            ICollector collector,
+            CloudStorageAccount storageAccount,
+            IStorageFactory storageFactory,
+            Func<HttpMessageHandler> handlerFunc,
+            IOptionsSnapshot<RegistrationComparerConfiguration> options,
+            ILogger<RegistrationComparerCommand> logger)
+        {
+            _collector = collector ?? throw new ArgumentNullException(nameof(collector));
+            _storageAccount = storageAccount ?? throw new ArgumentNullException(nameof(storageAccount));
+            _storageFactory = storageFactory ?? throw new ArgumentNullException(nameof(storageFactory));
+            _handlerFunc = handlerFunc ?? throw new ArgumentNullException(nameof(handlerFunc));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task ExecuteAsync(CancellationToken token)
+        {
+            var registrationCursors = CursorUtility.GetRegistrationCursors(_handlerFunc, _options);
+            var backCursor = new AggregateCursor(registrationCursors.Values);
+
+            var frontCursorPair = CursorUtility.GetComparerCursor(_storageFactory);
+            _logger.LogInformation("Using cursor: {CursurUrl}", frontCursorPair.Key);
+            var frontCursor = frontCursorPair.Value;
+
+            await _storageAccount
+                .CreateCloudBlobClient()
+                .GetContainerReference(_options.Value.StorageContainer)
+                .CreateIfNotExistsAsync();
+
+            await frontCursor.LoadAsync(token);
+            await backCursor.LoadAsync(token);
+            _logger.LogInformation(
+                "The cursors have been loaded. Front: {FrontCursor}. Back: {BackCursor}.",
+                frontCursor.Value,
+                backCursor.Value);
+
+            // Run the collector.
+            await _collector.RunAsync(
+                frontCursor,
+                backCursor,
+                token);
+        } 
+    }
+}

--- a/src/NuGet.Jobs.RegistrationComparer/RegistrationComparerConfiguration.cs
+++ b/src/NuGet.Jobs.RegistrationComparer/RegistrationComparerConfiguration.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Services.V3;
+
+namespace NuGet.Jobs.RegistrationComparer
+{
+    public class RegistrationComparerConfiguration : ICommitCollectorConfiguration
+    {
+        public string StorageConnectionString { get; set; }
+        public string StorageContainer { get; set; }
+        public List<HivesConfiguration> Registrations { get; set; }
+        public string Source { get; set; }
+        public int MaxConcurrentCatalogLeafDownloads { get; set; } = 64;
+        public TimeSpan HttpClientTimeout { get; set; } = TimeSpan.FromMinutes(10);
+    }
+}

--- a/src/NuGet.Jobs.RegistrationComparer/ResultWriter.cs
+++ b/src/NuGet.Jobs.RegistrationComparer/ResultWriter.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+
+namespace NuGet.Jobs.RegistrationComparer
+{
+    public static class ResultWriter
+    {
+        private static readonly object _warningsLock = new object();
+        private static readonly object _errorsLock = new object();
+
+        public static void WriteWarning(string message)
+        {
+            lock (_warningsLock)
+            {
+                File.AppendAllLines("warnings.txt", new[] { message.Trim(), Environment.NewLine });
+            }
+        }
+
+        public static void WriteError(string message)
+        {
+            lock (_errorsLock)
+            {
+                File.AppendAllLines("errors.txt", new[] { message.Trim(), Environment.NewLine });
+            }
+        }
+    }
+}


### PR DESCRIPTION
This basically is a generic JSON document comparer with some normalization logic to handle known differences. These known differences are either by design or quirks.

My goal was NOT to make super re-usable or high performance code. Instead, the goal is to find differences in the two implementations. The `JsonComparer` class code found all of the problems mentioned in `Normalizers.cs`, so I am confident in the results.

Progress on https://github.com/nuget/nugetgallery/issues/7741.
Depends on https://github.com/NuGet/NuGet.Services.Metadata/pull/728.