### PR TITLE
Normalize cases where the decimal seconds are 0 and therefore excluded

### DIFF
--- a/src/NuGet.Jobs.RegistrationComparer/Normalizers.cs
+++ b/src/NuGet.Jobs.RegistrationComparer/Normalizers.cs
@@ -86,7 +86,7 @@ namespace NuGet.Jobs.RegistrationComparer
                     // Each iteration, the writer will come up with a different commit timestamp.
                     var commitTimestamp = (string)value;
                     if (commitTimestamp != null
-                        && Regex.IsMatch(commitTimestamp, @"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{1,}(Z|\+00:00)"))
+                        && Regex.IsMatch(commitTimestamp, @"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,})?(Z|\+00:00)"))
                     {
                         return DateTimeOffset.MinValue.ToString("o");
                     }


### PR DESCRIPTION
The RegistrationComparer in PROD got stuck on this. There was a commit timestamp that fell exactly on the second and therefore was not normalized.

Progress on https://github.com/NuGet/NuGetGallery/issues/7741.