### PR TITLE
Fix Azure Search functional test that broke from "json" results changing

### DIFF
--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/V2SearchProtocolTests.cs
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/V2SearchProtocolTests.cs
@@ -140,7 +140,7 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
         [Fact]
         public async Task ResultsHonorPreReleaseField()
         {
-            var searchTerm = "json";
+            var searchTerm = "basetestpackage";
 
             var resultsWithPrerelease = await V2SearchAsync(new V2SearchBuilder { Query = searchTerm, Prerelease = true }); ;
             Assert.NotNull(resultsWithPrerelease);

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/V3SearchProtocolTests.cs
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/V3SearchProtocolTests.cs
@@ -118,7 +118,7 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
         [Fact]
         public async Task ResultsHonorPreReleaseField()
         {
-            var searchTerm = "json";
+            var searchTerm = "basetestpackage";
 
             var resultsWithPrerelease = await V3SearchAsync(new V3SearchBuilder { Query = searchTerm, Prerelease = true }); ;
             Assert.NotNull(resultsWithPrerelease);
@@ -135,11 +135,13 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
 
             var hasPrereleaseVersions = resultsWithPrerelease
                 .Data
+                .SelectMany(x => x.Versions)
                 .Any(x => TestUtilities.IsPrerelease(x.Version));
             Assert.True(hasPrereleaseVersions, $"The search query did not return any results with the expected prerelease versions.");
 
             hasPrereleaseVersions = resultsWithoutPrerelease
                 .Data
+                .SelectMany(x => x.Versions)
                 .Any(x => TestUtilities.IsPrerelease(x.Version));
             Assert.False(hasPrereleaseVersions, $"The search query returned results with prerelease versions when queried for Prerelease = false");
         }


### PR DESCRIPTION
These tests are broken right now. I found this at deployment time.

I added a "BaseTestPackage.NoStable" package to all environments to ensure that this test assertions are always true. "json" worked for a while but it is prone to failure since people can push stable versions as their latest.