### PR TITLE
Query for verified packages directly in Auxiliary2AzureSearch

### DIFF
--- a/src/NuGet.Jobs.Auxiliary2AzureSearch/Job.cs
+++ b/src/NuGet.Jobs.Auxiliary2AzureSearch/Job.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using NuGet.Services.AzureSearch;
 using NuGet.Services.AzureSearch.Auxiliary2AzureSearch;
 using NuGet.Services.AzureSearch.AuxiliaryFiles;

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryDataStorageConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryDataStorageConfiguration.cs
@@ -10,6 +10,5 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
         public string AuxiliaryDataStorageDownloadsPath { get; set; }
         public string AuxiliaryDataStorageDownloadOverridesPath { get; set; }
         public string AuxiliaryDataStorageExcludedPackagesPath { get; set; }
-        public string AuxiliaryDataStorageVerifiedPackagesPath { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryFileClient.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryFileClient.cs
@@ -51,13 +51,6 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
                 });
         }
 
-        public async Task<HashSet<string>> LoadVerifiedPackagesAsync()
-        {
-            return await LoadAuxiliaryFileAsync(
-                _options.Value.AuxiliaryDataStorageVerifiedPackagesPath,
-                reader => JsonStringArrayFileParser.Load(reader, _logger));
-        }
-
         public async Task<HashSet<string>> LoadExcludedPackagesAsync()
         {
             return await LoadAuxiliaryFileAsync(

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryDataStorageConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryDataStorageConfiguration.cs
@@ -10,6 +10,5 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
         string AuxiliaryDataStorageDownloadsPath { get; }
         string AuxiliaryDataStorageDownloadOverridesPath { get; }
         string AuxiliaryDataStorageExcludedPackagesPath { get; }
-        string AuxiliaryDataStorageVerifiedPackagesPath { get; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryFileClient.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryFileClient.cs
@@ -10,7 +10,6 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
     {
         Task<DownloadData> LoadDownloadDataAsync();
         Task<IReadOnlyDictionary<string, long>> LoadDownloadOverridesAsync();
-        Task<HashSet<string>> LoadVerifiedPackagesAsync();
         Task<HashSet<string>> LoadExcludedPackagesAsync();
     }
 }

--- a/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
@@ -393,5 +393,16 @@ namespace NuGet.Services.AzureSearch
                     { "HitCount", hitCount.ToString() },
                 });
         }
+
+        public void TrackReadLatestVerifiedPackagesFromDatabase(int packageIdCount, TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "ReadLatestVerifiedPackagesFromDatabaseSeconds",
+                elapsed.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { "PackageIdCount", packageIdCount.ToString() },
+                });
+        }
     }
 }

--- a/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/CatalogIndexActionBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/CatalogIndexActionBuilder.cs
@@ -20,7 +20,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
         private readonly IVersionListDataClient _versionListDataClient;
         private readonly ICatalogLeafFetcher _leafFetcher;
-        private readonly IDatabaseOwnerFetcher _ownerFetcher;
+        private readonly IDatabaseAuxiliaryDataFetcher _ownerFetcher;
         private readonly ISearchDocumentBuilder _search;
         private readonly IHijackDocumentBuilder _hijack;
         private readonly ILogger<CatalogIndexActionBuilder> _logger;
@@ -28,7 +28,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
         public CatalogIndexActionBuilder(
             IVersionListDataClient versionListDataClient,
             ICatalogLeafFetcher leafFetcher,
-            IDatabaseOwnerFetcher ownerFetcher,
+            IDatabaseAuxiliaryDataFetcher ownerFetcher,
             ISearchDocumentBuilder search,
             IHijackDocumentBuilder hijack,
             ILogger<CatalogIndexActionBuilder> logger)

--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -240,7 +240,7 @@ namespace NuGet.Services.AzureSearch
             services.AddTransient<ICatalogIndexActionBuilder, CatalogIndexActionBuilder>();
             services.AddTransient<ICatalogLeafFetcher, CatalogLeafFetcher>();
             services.AddTransient<ICommitCollectorLogic, AzureSearchCollectorLogic>();
-            services.AddTransient<IDatabaseOwnerFetcher, DatabaseOwnerFetcher>();
+            services.AddTransient<IDatabaseAuxiliaryDataFetcher, DatabaseAuxiliaryDataFetcher>();
             services.AddTransient<IDownloadSetComparer, DownloadSetComparer>();
             services.AddTransient<IEntitiesContextFactory, EntitiesContextFactory>();
             services.AddTransient<IHijackDocumentBuilder, HijackDocumentBuilder>();

--- a/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
@@ -20,6 +20,7 @@ namespace NuGet.Services.AzureSearch
         void TrackOwnerSetComparison(int oldCount, int newCount, int changeCount, TimeSpan elapsed);
         void TrackReadLatestIndexedOwners(int packageIdCount, TimeSpan elapsed);
         void TrackReadLatestOwnersFromDatabase(int packageIdCount, TimeSpan elapsed);
+        void TrackReadLatestVerifiedPackagesFromDatabase(int packageIdCount, TimeSpan elapsed);
         IDisposable TrackReplaceLatestIndexedOwners(int packageIdCount);
         IDisposable TrackUploadOwnerChangeHistory(int packageIdCount);
         IDisposable TrackVersionListsUpdated(int versionListCount, int workerCount);

--- a/src/NuGet.Services.AzureSearch/IDatabaseAuxiliaryDataFetcher.cs
+++ b/src/NuGet.Services.AzureSearch/IDatabaseAuxiliaryDataFetcher.cs
@@ -7,9 +7,9 @@ using System.Threading.Tasks;
 namespace NuGet.Services.AzureSearch
 {
     /// <summary>
-    /// Fetches the current owner information from the database.
+    /// Fetches auxiliary data from the Gallery database.
     /// </summary>
-    public interface IDatabaseOwnerFetcher
+    public interface IDatabaseAuxiliaryDataFetcher
     {
         /// <summary>
         /// Fetch the owners for a specific package ID. If the package registration does not exist or if there are no
@@ -23,5 +23,10 @@ namespace NuGet.Services.AzureSearch
         /// gallery database.
         /// </summary>
         Task<SortedDictionary<string, SortedSet<string>>> GetPackageIdToOwnersAsync();
+
+        /// <summary>
+        /// Fetch the set of all verified package IDs.
+        /// </summary>
+        Task<HashSet<string>> GetVerifiedPackagesAsync();
     }
 }

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -70,12 +70,12 @@
     <Compile Include="AzureSearchJob.cs" />
     <Compile Include="AzureSearchScoringConfiguration.cs" />
     <Compile Include="BaseDocumentBuilder.cs" />
-    <Compile Include="DatabaseOwnerFetcher.cs" />
+    <Compile Include="DatabaseAuxiliaryDataFetcher.cs" />
     <Compile Include="Db2AzureSearch\InitialAuxiliaryData.cs" />
     <Compile Include="IAzureSearchTelemetryService.cs" />
     <Compile Include="IBaseDocumentBuilder.cs" />
     <Compile Include="IAzureSearchCommand.cs" />
-    <Compile Include="IDatabaseOwnerFetcher.cs" />
+    <Compile Include="IDatabaseAuxiliaryDataFetcher.cs" />
     <Compile Include="ISearchIndexActionBuilder.cs" />
     <Compile Include="JobOutcome.cs" />
     <Compile Include="Models\IUpdatedDocument.cs" />

--- a/src/NuGet.Services.AzureSearch/Owners2AzureSearch/Owners2AzureSearchCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Owners2AzureSearch/Owners2AzureSearchCommand.cs
@@ -15,7 +15,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
 {
     public class Owners2AzureSearchCommand : IAzureSearchCommand
     {
-        private readonly IDatabaseOwnerFetcher _databaseOwnerFetcher;
+        private readonly IDatabaseAuxiliaryDataFetcher _databaseFetcher;
         private readonly IOwnerDataClient _ownerDataClient;
         private readonly IOwnerSetComparer _ownerSetComparer;
         private readonly ISearchDocumentBuilder _searchDocumentBuilder;
@@ -26,7 +26,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
         private readonly ILogger<Owners2AzureSearchCommand> _logger;
 
         public Owners2AzureSearchCommand(
-            IDatabaseOwnerFetcher databaseOwnerFetcher,
+            IDatabaseAuxiliaryDataFetcher databaseFetcher,
             IOwnerDataClient ownerDataClient,
             IOwnerSetComparer ownerSetComparer,
             ISearchDocumentBuilder searchDocumentBuilder,
@@ -36,7 +36,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
             IAzureSearchTelemetryService telemetryService,
             ILogger<Owners2AzureSearchCommand> logger)
         {
-            _databaseOwnerFetcher = databaseOwnerFetcher ?? throw new ArgumentNullException(nameof(databaseOwnerFetcher));
+            _databaseFetcher = databaseFetcher ?? throw new ArgumentNullException(nameof(databaseFetcher));
             _ownerDataClient = ownerDataClient ?? throw new ArgumentNullException(nameof(ownerDataClient));
             _ownerSetComparer = ownerSetComparer ?? throw new ArgumentNullException(nameof(ownerSetComparer));
             _searchDocumentBuilder = searchDocumentBuilder ?? throw new ArgumentNullException(nameof(searchDocumentBuilder));
@@ -64,7 +64,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
                 var storageResult = await _ownerDataClient.ReadLatestIndexedAsync();
 
                 _logger.LogInformation("Fetching new owner data from the database.");
-                var databaseResult = await _databaseOwnerFetcher.GetPackageIdToOwnersAsync();
+                var databaseResult = await _databaseFetcher.GetPackageIdToOwnersAsync();
 
                 _logger.LogInformation("Detecting owner changes.");
                 var changes = _ownerSetComparer.Compare(storageResult.Result, databaseResult);

--- a/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommandFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Auxiliary2AzureSearchCommandFacts.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
 using Castle.Core.Logging;
@@ -371,6 +372,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
             public Facts(ITestOutputHelper output)
             {
                 AuxiliaryFileClient = new Mock<IAuxiliaryFileClient>();
+                DatabaseAuxiliaryDataFetcher = new Mock<IDatabaseAuxiliaryDataFetcher>();
                 DownloadDataClient = new Mock<IDownloadDataClient>();
                 VerifiedPackagesDataClient = new Mock<IVerifiedPackagesDataClient>();
                 DownloadSetComparer = new Mock<IDownloadSetComparer>();
@@ -409,7 +411,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
                     .Setup(x => x.ReadLatestAsync(It.IsAny<IAccessCondition>(), It.IsAny<StringCache>()))
                     .ReturnsAsync(() => OldVerifiedPackagesResult);
                 NewVerifiedPackagesData = new HashSet<string>();
-                AuxiliaryFileClient.Setup(x => x.LoadVerifiedPackagesAsync()).ReturnsAsync(() => NewVerifiedPackagesData);
+                DatabaseAuxiliaryDataFetcher.Setup(x => x.GetVerifiedPackagesAsync()).ReturnsAsync(() => NewVerifiedPackagesData);
 
                 Changes = new SortedDictionary<string, long>();
                 DownloadSetComparer
@@ -454,6 +456,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
 
                 Target = new Auxiliary2AzureSearchCommand(
                     AuxiliaryFileClient.Object,
+                    DatabaseAuxiliaryDataFetcher.Object,
                     DownloadDataClient.Object,
                     VerifiedPackagesDataClient.Object,
                     DownloadSetComparer.Object,
@@ -467,6 +470,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
             }
 
             public Mock<IAuxiliaryFileClient> AuxiliaryFileClient { get; }
+            public Mock<IDatabaseAuxiliaryDataFetcher> DatabaseAuxiliaryDataFetcher { get; }
             public Mock<IDownloadDataClient> DownloadDataClient { get; }
             public Mock<IVerifiedPackagesDataClient> VerifiedPackagesDataClient { get; }
             public Mock<IDownloadSetComparer> DownloadSetComparer { get; }

--- a/tests/NuGet.Services.AzureSearch.Tests/AuxiliaryFiles/AuxiliaryFileClientFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/AuxiliaryFiles/AuxiliaryFileClientFacts.cs
@@ -61,40 +61,6 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
             }
         }
 
-        public class LoadVerifiedPackagesAsync : BaseFacts
-        {
-            public LoadVerifiedPackagesAsync(ITestOutputHelper output) : base(output)
-            {
-            }
-
-            [Fact]
-            public async Task ReadsContent()
-            {
-                var json = @"
-[
-    ""NuGet.Frameworks"",
-    ""NuGet.Versioning""
-]
-";
-                _blob
-                    .Setup(x => x.OpenReadAsync(It.IsAny<AccessCondition>()))
-                    .ReturnsAsync(() => new MemoryStream(Encoding.UTF8.GetBytes(json)));
-
-                var actual = await _target.LoadVerifiedPackagesAsync();
-
-                Assert.NotNull(actual);
-                Assert.Contains("NuGet.Frameworks", actual);
-                Assert.Contains("nuget.versioning", actual);
-                Assert.DoesNotContain("something.else", actual);
-                _blobClient.Verify(x => x.GetContainerReference("my-container"), Times.Once);
-                _blobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
-                _container.Verify(x => x.GetBlobReference("my-verified-packages.json"), Times.Once);
-                _container.Verify(x => x.GetBlobReference(It.IsAny<string>()), Times.Once);
-                _blob.Verify(x => x.OpenReadAsync(It.Is<AccessCondition>(a => a.IfMatchETag == null && a.IfNoneMatchETag == null)), Times.Once);
-                _blob.Verify(x => x.OpenReadAsync(It.IsAny<AccessCondition>()), Times.Once);
-            }
-        }
-
         public class LoadExcludedPackagesAsync : BaseFacts
         {
             public LoadExcludedPackagesAsync(ITestOutputHelper output) : base(output)
@@ -217,7 +183,6 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
                 _configStorage.AuxiliaryDataStorageContainer = "my-container";
                 _configStorage.AuxiliaryDataStorageDownloadsPath = "my-downloads.json";
                 _configStorage.AuxiliaryDataStorageDownloadOverridesPath = "my-download-overrides.json";
-                _configStorage.AuxiliaryDataStorageVerifiedPackagesPath = "my-verified-packages.json";
                 _configStorage.AuxiliaryDataStorageExcludedPackagesPath = "my-excluded-packages.json";
                 _optionsStorage.Setup(x => x.Value).Returns(() => _configStorage);
 

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/CatalogIndexActionBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/CatalogIndexActionBuilderFacts.cs
@@ -666,7 +666,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
         {
             protected readonly Mock<IVersionListDataClient> _versionListDataClient;
             protected readonly Mock<ICatalogLeafFetcher> _leafFetcher;
-            protected readonly Mock<IDatabaseOwnerFetcher> _ownerFetcher;
+            protected readonly Mock<IDatabaseAuxiliaryDataFetcher> _ownerFetcher;
             protected readonly Mock<ISearchDocumentBuilder> _search;
             protected readonly Mock<IHijackDocumentBuilder> _hijack;
             protected readonly RecordingLogger<CatalogIndexActionBuilder> _logger;
@@ -685,7 +685,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
             {
                 _versionListDataClient = new Mock<IVersionListDataClient>();
                 _leafFetcher = new Mock<ICatalogLeafFetcher>();
-                _ownerFetcher = new Mock<IDatabaseOwnerFetcher>();
+                _ownerFetcher = new Mock<IDatabaseAuxiliaryDataFetcher>();
                 _search = new Mock<ISearchDocumentBuilder>();
                 _hijack = new Mock<IHijackDocumentBuilder>();
                 _logger = output.GetLogger<CatalogIndexActionBuilder>();

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/AzureSearchCollectorLogicIntegrationTests.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/AzureSearchCollectorLogicIntegrationTests.cs
@@ -37,7 +37,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
         private V3TelemetryService _v3TelemetryService;
         private Mock<IEntitiesContextFactory> _entitiesContextFactory;
         private Mock<IEntitiesContext> _entitiesContext;
-        private DatabaseOwnerFetcher _ownerFetcher;
+        private DatabaseAuxiliaryDataFetcher _ownerFetcher;
         private InMemoryRegistrationClient _registrationClient;
         private InMemoryCatalogClient _catalogClient;
         private CatalogLeafFetcher _leafFetcher;
@@ -89,11 +89,11 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
             _entitiesContext = new Mock<IEntitiesContext>();
             _entitiesContextFactory.Setup(x => x.CreateAsync(It.IsAny<bool>())).ReturnsAsync(() => _entitiesContext.Object);
             _entitiesContext.Setup(x => x.PackageRegistrations).Returns(DbSetMockFactory.Create<PackageRegistration>());
-            _ownerFetcher = new DatabaseOwnerFetcher(
+            _ownerFetcher = new DatabaseAuxiliaryDataFetcher(
                 new Mock<ISqlConnectionFactory<GalleryDbConfiguration>>().Object,
                 _entitiesContextFactory.Object,
                 _telemetryService,
-                output.GetLogger<DatabaseOwnerFetcher>());
+                output.GetLogger<DatabaseAuxiliaryDataFetcher>());
 
             _cloudBlobClient = new InMemoryCloudBlobClient();
             _versionListDataClient = new VersionListDataClient(

--- a/tests/NuGet.Services.AzureSearch.Tests/DatabaseAuxiliaryDataFetcherFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/DatabaseAuxiliaryDataFetcherFacts.cs
@@ -16,7 +16,7 @@ using Xunit.Abstractions;
 
 namespace NuGet.Services.AzureSearch
 {
-    public class DatabaseOwnerFetcherFacts
+    public class DatabaseAuxiliaryDataFetcherFacts
     {
         public class GetOwnersOrEmptyAsync : Facts
         {
@@ -88,7 +88,7 @@ namespace NuGet.Services.AzureSearch
                 EntitiesContextFactory = new Mock<IEntitiesContextFactory>();
                 EntitiesContext = new Mock<IEntitiesContext>();
                 TelemetryService = new Mock<IAzureSearchTelemetryService>();
-                Logger = output.GetLogger<DatabaseOwnerFetcher>();
+                Logger = output.GetLogger<DatabaseAuxiliaryDataFetcher>();
 
                 PackageRegistrations = DbSetMockFactory.Create<PackageRegistration>();
 
@@ -99,7 +99,7 @@ namespace NuGet.Services.AzureSearch
                     .Setup(x => x.PackageRegistrations)
                     .Returns(() => PackageRegistrations);
 
-                Target = new DatabaseOwnerFetcher(
+                Target = new DatabaseAuxiliaryDataFetcher(
                     SqlConnectionFactory.Object,
                     EntitiesContextFactory.Object,
                     TelemetryService.Object,
@@ -110,9 +110,9 @@ namespace NuGet.Services.AzureSearch
             public Mock<IEntitiesContextFactory> EntitiesContextFactory { get; }
             public Mock<IEntitiesContext> EntitiesContext { get; }
             public Mock<IAzureSearchTelemetryService> TelemetryService { get; }
-            public RecordingLogger<DatabaseOwnerFetcher> Logger { get; }
+            public RecordingLogger<DatabaseAuxiliaryDataFetcher> Logger { get; }
             public DbSet<PackageRegistration> PackageRegistrations { get; }
-            public DatabaseOwnerFetcher Target { get; }
+            public DatabaseAuxiliaryDataFetcher Target { get; }
         }
 
         private class DisposableEntitiesContext : IEntitiesContext, IDisposable

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -53,7 +53,7 @@
     <Compile Include="Catalog2AzureSearch\CatalogIndexActionBuilderFacts.cs" />
     <Compile Include="Catalog2AzureSearch\CatalogLeafFetcherFacts.cs" />
     <Compile Include="Catalog2AzureSearch\Integration\InMemoryDocumentsOperations.cs" />
-    <Compile Include="DatabaseOwnerFetcherFacts.cs" />
+    <Compile Include="DatabaseAuxiliaryDataFetcherFacts.cs" />
     <Compile Include="Db2AzureSearch\Db2AzureSearchCommandFacts.cs" />
     <Compile Include="Db2AzureSearch\EnumerableExtensionsFacts.cs" />
     <Compile Include="Db2AzureSearch\NewPackageRegistrationProducerFacts.cs" />

--- a/tests/NuGet.Services.AzureSearch.Tests/Owners2AzureSearch/Owners2AzureSearchCommandFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Owners2AzureSearch/Owners2AzureSearchCommandFacts.cs
@@ -167,7 +167,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
         {
             public Facts(ITestOutputHelper output)
             {
-                DatabaseOwnerFetcher = new Mock<IDatabaseOwnerFetcher>();
+                DatabaseOwnerFetcher = new Mock<IDatabaseAuxiliaryDataFetcher>();
                 OwnerDataClient = new Mock<IOwnerDataClient>();
                 OwnerSetComparer = new Mock<IOwnerSetComparer>();
                 SearchDocumentBuilder = new Mock<ISearchDocumentBuilder>();
@@ -223,7 +223,7 @@ namespace NuGet.Services.AzureSearch.Owners2AzureSearch
                     Logger);
             }
 
-            public Mock<IDatabaseOwnerFetcher> DatabaseOwnerFetcher { get; }
+            public Mock<IDatabaseAuxiliaryDataFetcher> DatabaseOwnerFetcher { get; }
             public Mock<IOwnerDataClient> OwnerDataClient { get; }
             public Mock<IOwnerSetComparer> OwnerSetComparer { get; }
             public Mock<ISearchDocumentBuilder> SearchDocumentBuilder { get; }


### PR DESCRIPTION
Progress on https://github.com/nuget/engineering/issues/2978

This will allow us to delete the Search.GenerateAuxiliaryData job. This job's only responsibility today is to build the verified packages data file to be consumed by Auxiliary2AzureSearch.

Next step is to consider merging Owners2AzureSearch into Auxiliary2AzureSearch.

Fewer jobs the better, amiright?