### PR TITLE
Allow storage different from CDN to be tested by RegistrationComparer

### DIFF
--- a/src/NuGet.Jobs.RegistrationComparer/CursorUtility.cs
+++ b/src/NuGet.Jobs.RegistrationComparer/CursorUtility.cs
@@ -19,7 +19,7 @@ namespace NuGet.Jobs.RegistrationComparer
             var hiveCursors = new Dictionary<string, ReadCursor>();
             foreach (var hives in options.Value.Registrations)
             {
-                var cursorUrl = new Uri(hives.LegacyBaseUrl.TrimEnd('/') + "/cursor.json");
+                var cursorUrl = new Uri(hives.Legacy.StorageBaseUrl.TrimEnd('/') + "/cursor.json");
                 hiveCursors.Add(cursorUrl.AbsoluteUri, new HttpReadCursor(cursorUrl, DateTime.MinValue, handlerFunc));
             }
 

--- a/src/NuGet.Jobs.RegistrationComparer/HiveConfiguration.cs
+++ b/src/NuGet.Jobs.RegistrationComparer/HiveConfiguration.cs
@@ -3,10 +3,9 @@
 
 namespace NuGet.Jobs.RegistrationComparer
 {
-    public class HivesConfiguration
+    public class HiveConfiguration
     {
-        public HiveConfiguration Legacy { get; set; }
-        public HiveConfiguration Gzipped { get; set; }
-        public HiveConfiguration SemVer2 { get; set; }
+        public string StorageBaseUrl { get; set; }
+        public string BaseUrl { get; set; }
     }
 }

--- a/src/NuGet.Jobs.RegistrationComparer/NuGet.Jobs.RegistrationComparer.csproj
+++ b/src/NuGet.Jobs.RegistrationComparer/NuGet.Jobs.RegistrationComparer.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <Compile Include="ComparisonContext.cs" />
     <Compile Include="CursorUtility.cs" />
+    <Compile Include="HiveConfiguration.cs" />
     <Compile Include="Normalizers.cs" />
     <Compile Include="RegistrationComparerCollectorLogic.cs" />
     <Compile Include="HiveComparer.cs" />


### PR DESCRIPTION
Improved logging around HTTP requests.
Removed duplicate HTTP request (OMG).
Moved response body fetching into HttpClient.GetAsync so HttpClient.Timeout acts on it.

Right now, this job can only test China storage if it's running from China. This change enables hitting storage that doesn't sit behind the client's resolution of api.nuget.org.

Related to https://github.com/nuget/nugetgallery/issues/7741.