### PR TITLE
[Db2AzureSearch] Support skipping packages by prefix

### DIFF
--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using NuGet.Services.AzureSearch.AuxiliaryFiles;
 
 namespace NuGet.Services.AzureSearch.Db2AzureSearch
@@ -16,5 +17,11 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
         public string AuxiliaryDataStorageDownloadOverridesPath { get; set; }
         public string AuxiliaryDataStorageExcludedPackagesPath { get; set; }
         public string AuxiliaryDataStorageVerifiedPackagesPath { get; set; }
+
+        /// <summary>
+        /// Db2AzureSearch skips packages whose ID start with these prefixes.
+        /// This is case insensitive.
+        /// </summary>
+        public IReadOnlyList<string> SkipPackagePrefixes { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationProducer.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationProducer.cs
@@ -43,6 +43,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
             var ranges = await GetPackageRegistrationRangesAsync();
 
             // Fetch exclude packages list from auxiliary files.
+            // These packages are excluded from the default search's results.
             var excludedPackages = await _auxiliaryFileClient.LoadExcludedPackagesAsync();
 
             Guard.Assert(
@@ -206,6 +207,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                 var packageRegistrations = await query.ToListAsync();
 
                 return packageRegistrations
+                    .Where(pr => !ShouldSkipPackageRegistration(pr))
                     .Select(pr => new PackageRegistrationInfo(
                         pr.Key,
                         pr.Id,
@@ -213,6 +215,25 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                         pr.IsVerified))
                     .ToList();
             }
+        }
+
+        private bool ShouldSkipPackageRegistration(PackageRegistration packageRegistration)
+        {
+            if (_options.Value.SkipPackagePrefixes == null)
+            {
+                return false;
+            }
+
+            foreach (var skippedPackagePrefix in _options.Value.SkipPackagePrefixes)
+            {
+                if (packageRegistration.Id.StartsWith(skippedPackagePrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogDebug("Skipping package {PackageId}", packageRegistration.Id);
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private async Task<IReadOnlyList<PackageRegistrationRange>> GetPackageRegistrationRangesAsync()

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationProducer.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationProducer.cs
@@ -228,7 +228,6 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
             {
                 if (packageRegistration.Id.StartsWith(skippedPackagePrefix, StringComparison.OrdinalIgnoreCase))
                 {
-                    _logger.LogDebug("Skipping package {PackageId}", packageRegistration.Id);
                     return true;
                 }
             }

--- a/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/NewPackageRegistrationProducerFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/NewPackageRegistrationProducerFacts.cs
@@ -320,6 +320,50 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
             }
 
             [Fact]
+            public async Task SkipsUnwantedPackages()
+            {
+                _config.SkipPackagePrefixes = new List<string> { "Foo" };
+
+                _packageRegistrations.Add(new PackageRegistration
+                {
+                    Key = 1,
+                    Id = "FOO.Bar",
+                    Owners = new User[0],
+                    Packages = new[]
+                     {
+                        new Package { Version = "1.0.0" },
+                    },
+                });
+                _packageRegistrations.Add(new PackageRegistration
+                {
+                    Key = 2,
+                    Id = "foo.Buzz",
+                    Owners = new User[0],
+                    Packages = new[]
+                    {
+                        new Package { Version = "2.0.0" },
+                    },
+                });
+                _packageRegistrations.Add(new PackageRegistration
+                {
+                    Key = 3,
+                    Id = "Hello.World",
+                    Owners = new User[0],
+                    Packages = new[]
+                    {
+                        new Package { Version = "3.0.0" },
+                    },
+                });
+
+                InitializePackagesFromPackageRegistrations();
+
+                await _target.ProduceWorkAsync(_work, _token);
+
+                var newRegistration = Assert.Single(_work);
+                Assert.Equal("Hello.World", newRegistration.PackageId);
+            }
+
+            [Fact]
             public async Task ReturnsInitialAuxiliaryData()
             {
                 _packageRegistrations.Add(new PackageRegistration


### PR DESCRIPTION
The DEV environment has many tests packages, which makes the `Db2AzureSearch` tool quite slow on DEV. This change lets us skip these test packages by adding their prefixes to the config file:

```json
{
  "Db2AzureSearch": {
    "SkipPackagePrefixes": [
      "TestPackage",
      "E2E.",
      "Nuggets4NuGet.IngestionTime.",
    ],
  },
}
```

<details>
<summary>Full skip list for DEV</summary>
```json
    "SkipPackagePrefixes": [
      "Test",
      "E2E.",
      "NuGetFunctionalTest_",
      "VerifyPackageKey",
      "ScopedApiKeys",
      "DuplicatePushesAreRejected",
      "PackagePush_",
      "Nuggets4NuGet.IngestionTime.",
      "GetUpdates",
      "UploadPackageTo",
      "UploadAndUnlistPackages",
      "VerifyKeyReturns",
    ],
```
</details>