### PR TITLE
Add fix up code when Azure Search documents go missing

### DIFF
--- a/src/NuGet.Protocol.Catalog/CatalogClient.cs
+++ b/src/NuGet.Protocol.Catalog/CatalogClient.cs
@@ -4,13 +4,11 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 
 namespace NuGet.Protocol.Catalog
 {
     public class CatalogClient : ICatalogClient
     {
-        private static readonly JsonSerializer JsonSerializer = NuGetJsonSerialization.Serializer;
         private readonly ISimpleHttpClient _jsonClient;
         private readonly ILogger<CatalogClient> _logger;
 

--- a/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/DocumentFixUp.cs
+++ b/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/DocumentFixUp.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Services.Metadata.Catalog;
+
+namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
+{
+    public class DocumentFixUp
+    {
+        private DocumentFixUp(bool applicable, List<CatalogCommitItem> itemList)
+        {
+            Applicable = applicable;
+            ItemList = itemList;
+        }
+
+        public static DocumentFixUp IsNotApplicable()
+        {
+            return new DocumentFixUp(applicable: false, itemList: null);
+        }
+
+        public static DocumentFixUp IsApplicable(List<CatalogCommitItem> itemList)
+        {
+            if (itemList == null)
+            {
+                throw new ArgumentNullException(nameof(itemList));
+            }
+
+            return new DocumentFixUp(applicable: true, itemList: itemList);
+        }
+
+        public bool Applicable { get; } 
+        public List<CatalogCommitItem> ItemList { get; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/DocumentFixUpEvaluator.cs
+++ b/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/DocumentFixUpEvaluator.cs
@@ -1,0 +1,164 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Azure.Search;
+using Microsoft.Azure.Search.Models;
+using Microsoft.Extensions.Logging;
+using NuGet.Packaging.Core;
+using NuGet.Services.Metadata.Catalog;
+using NuGet.Versioning;
+
+namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
+{
+    public class DocumentFixUpEvaluator : IDocumentFixUpEvaluator
+    {
+        private readonly IVersionListDataClient _versionListClient;
+        private readonly ICatalogLeafFetcher _leafFetcher;
+        private readonly ILogger<DocumentFixUpEvaluator> _logger;
+
+        public DocumentFixUpEvaluator(
+            IVersionListDataClient versionListClient,
+            ICatalogLeafFetcher leafFetcher,
+            ILogger<DocumentFixUpEvaluator> logger)
+        {
+            _versionListClient = versionListClient ?? throw new ArgumentNullException(nameof(versionListClient));
+            _leafFetcher = leafFetcher ?? throw new ArgumentNullException(nameof(leafFetcher));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<DocumentFixUp> TryFixUpAsync(
+            IReadOnlyList<CatalogCommitItem> itemList,
+            ConcurrentBag<IdAndValue<IndexActions>> allIndexActions,
+            InvalidOperationException exception)
+        {
+            var innerEx = exception.InnerException as IndexBatchException;
+            if (innerEx == null || innerEx.IndexingResults == null)
+            {
+                return DocumentFixUp.IsNotApplicable();
+            }
+
+            // There may have been a Case of the Missing Document! We have confirmed with the Azure Search team that
+            // this is a bug on the Azure Search side. To mitigate the issue, we replace any Merge operation that
+            // failed with 404 with a MergeOrUpload with the full metadata so that we can replace that missing document.
+            //
+            // 1. The first step is to find all of the document keys that failed with a 404 Not Found error.
+            var notFoundKeys = new HashSet<string>(innerEx
+                .IndexingResults
+                .Where(x => x.StatusCode == (int)HttpStatusCode.NotFound)
+                .Select(x => x.Key));
+            if (!notFoundKeys.Any())
+            {
+                return DocumentFixUp.IsNotApplicable();
+            }
+
+            _logger.LogWarning("{Count} document action(s) failed with 404 Not Found.", notFoundKeys.Count);
+
+            // 2. Find all of the package IDs that were affected, only considering Merge operations against the Search
+            //    index. We ignore the the hijack index for now because we have only ever seen the problem in the Search
+            //    index.
+            var failedIds = new HashSet<string>();
+            foreach (var pair in allIndexActions.OrderBy(x => x.Id, StringComparer.OrdinalIgnoreCase))
+            {
+                var failedMerges = pair
+                    .Value
+                    .Search
+                    .Where(a => a.ActionType == IndexActionType.Merge)
+                    .Where(a => notFoundKeys.Contains(a.Document.Key));
+
+                if (failedMerges.Any() && failedIds.Add(pair.Id))
+                {
+                    _logger.LogWarning("Package {PackageId} had a Merge operation fail with 404 Not Found.", pair.Id);
+                }
+            }
+
+            if (!failedIds.Any())
+            {
+                _logger.LogInformation("No failed Merge operations against the Search index were found.");
+                return DocumentFixUp.IsNotApplicable();
+            }
+
+            // 3. For each affected package ID, get the version list to determine the latest version per search filter
+            //    so we can find the the catalog entry for the version.
+            var identityToItems = itemList.GroupBy(x => x.PackageIdentity).ToDictionary(x => x.Key, x => x.ToList());
+            foreach (var packageId in failedIds)
+            {
+                var accessConditionAndData = await _versionListClient.ReadAsync(packageId);
+                var versionLists = new VersionLists(accessConditionAndData.Result);
+
+                var latestVersions = DocumentUtilities
+                    .AllSearchFilters
+                    .Select(sf => versionLists.GetLatestVersionInfoOrNull(sf))
+                    .Where(lvi => lvi != null)
+                    .Select(lvi => (IReadOnlyList<NuGetVersion>)new List<NuGetVersion> { lvi.ParsedVersion })
+                    .ToList();
+
+                var leaves = await _leafFetcher.GetLatestLeavesAsync(packageId, latestVersions);
+
+                // We ignore unavailable (deleted) versions for now. We have never had a delete cause this problem. It's
+                // only ever been discovered when a new version is being added or updated.
+                //
+                // For each package details leaf found, create a catalog commit item and add it to the set of items we
+                // will process. This will force the metadata to be updated on each of the latest versions. Since this
+                // is the latest metadata, replace any older leaves that may be associated with that package version.
+                foreach (var pair in leaves.Available)
+                {
+                    var identity = new PackageIdentity(packageId, pair.Key);
+                    var leaf = pair.Value;
+
+                    if (identityToItems.TryGetValue(identity, out var existing))
+                    {
+                        if (existing.Count == 1 && existing[0].Uri.AbsoluteUri == leaf.Url)
+                        {
+                            _logger.LogInformation(
+                                "For {PackageId} {PackageVersion}, metadata will remain the same.",
+                                identity.Id,
+                                identity.Version.ToNormalizedString(),
+                                leaf.Url,
+                                existing.Count);
+                            continue;
+                        }
+                        else
+                        {
+                            _logger.LogInformation(
+                                "For {PackageId} {PackageVersion}, metadata from {Url} will be used instead of {Count} catalog commit items.",
+                                identity.Id,
+                                identity.Version.ToNormalizedString(),
+                                leaf.Url,
+                                existing.Count);
+                        }
+                    }
+                    else
+                    {
+                        _logger.LogInformation(
+                            "For {PackageId} {PackageVersion}, metadata from {Url} will be used.",
+                            identity.Id,
+                            identity.Version.ToNormalizedString(),
+                            leaf.Url);
+                    }
+
+                    identityToItems[identity] = new List<CatalogCommitItem>
+                    {
+                        new CatalogCommitItem(
+                            new Uri(leaf.Url),
+                            leaf.CommitId,
+                            leaf.CommitTimestamp.UtcDateTime,
+                            new string[0],
+                            new[] { Schema.DataTypes.PackageDetails },
+                            identity),
+                    };
+                }
+            }
+
+            _logger.LogInformation("The catalog commit item list has been modified to fix up the missing document(s).");
+
+            var newItemList = identityToItems.SelectMany(x => x.Value).ToList();
+            return DocumentFixUp.IsApplicable(newItemList);
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/IDocumentFixUpEvaluator.cs
+++ b/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/IDocumentFixUpEvaluator.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NuGet.Services.Metadata.Catalog;
+
+namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
+{
+    public interface IDocumentFixUpEvaluator
+    {
+        Task<DocumentFixUp> TryFixUpAsync(
+            IReadOnlyList<CatalogCommitItem> itemList,
+            ConcurrentBag<IdAndValue<IndexActions>> allIndexActions,
+            InvalidOperationException exception);
+    }
+}

--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -249,6 +249,7 @@ namespace NuGet.Services.AzureSearch
             services.AddTransient<ICatalogLeafFetcher, CatalogLeafFetcher>();
             services.AddTransient<ICommitCollectorLogic, AzureSearchCollectorLogic>();
             services.AddTransient<IDatabaseAuxiliaryDataFetcher, DatabaseAuxiliaryDataFetcher>();
+            services.AddTransient<IDocumentFixUpEvaluator, DocumentFixUpEvaluator>();
             services.AddTransient<IDownloadSetComparer, DownloadSetComparer>();
             services.AddTransient<IEntitiesContextFactory, EntitiesContextFactory>();
             services.AddTransient<IHijackDocumentBuilder, HijackDocumentBuilder>();

--- a/src/NuGet.Services.AzureSearch/DocumentUtilities.cs
+++ b/src/NuGet.Services.AzureSearch/DocumentUtilities.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Web;
@@ -10,6 +12,11 @@ namespace NuGet.Services.AzureSearch
 {
     public static class DocumentUtilities
     {
+        public static readonly IReadOnlyList<SearchFilters> AllSearchFilters = Enum
+            .GetValues(typeof(SearchFilters))
+            .Cast<SearchFilters>()
+            .ToList();
+
         public static string GetSearchFilterString(SearchFilters searchFilters)
         {
             return searchFilters.ToString();

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -73,6 +73,9 @@
     <Compile Include="AzureSearchJobDevelopmentConfiguration.cs" />
     <Compile Include="AzureSearchScoringConfiguration.cs" />
     <Compile Include="BaseDocumentBuilder.cs" />
+    <Compile Include="Catalog2AzureSearch\DocumentFixUp.cs" />
+    <Compile Include="Catalog2AzureSearch\DocumentFixUpEvaluator.cs" />
+    <Compile Include="Catalog2AzureSearch\IDocumentFixUpEvaluator.cs" />
     <Compile Include="DatabaseAuxiliaryDataFetcher.cs" />
     <Compile Include="Db2AzureSearch\Db2AzureSearchDevelopmentConfiguration.cs" />
     <Compile Include="Db2AzureSearch\InitialAuxiliaryData.cs" />

--- a/src/NuGet.Services.AzureSearch/SearchIndexActionBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchIndexActionBuilder.cs
@@ -12,11 +12,6 @@ namespace NuGet.Services.AzureSearch
 {
     public class SearchIndexActionBuilder : ISearchIndexActionBuilder
     {
-        private static readonly IReadOnlyList<SearchFilters> AllSearchFilters = Enum
-            .GetValues(typeof(SearchFilters))
-            .Cast<SearchFilters>()
-            .ToList();
-
         private readonly IVersionListDataClient _versionListDataClient;
         private readonly ILogger<SearchIndexActionBuilder> _logger;
 
@@ -55,7 +50,7 @@ namespace NuGet.Services.AzureSearch
             ///   documents is different.
             var search = new List<IndexAction<KeyedDocument>>();
             var searchFilters = new List<SearchFilters>();
-            foreach (var searchFilter in AllSearchFilters)
+            foreach (var searchFilter in DocumentUtilities.AllSearchFilters)
             {
                 // Determine if there is a document for this ID and search filter.
                 if (versionLists.GetLatestVersionInfoOrNull(searchFilter) == null)

--- a/src/NuGet.Services.AzureSearch/VersionList/MutableHijackDocumentChanges.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/MutableHijackDocumentChanges.cs
@@ -57,7 +57,7 @@ namespace NuGet.Services.AzureSearch
                         UpdateMetadata != true,
                         "The hijack document has already been set to update metadata.");
                     Delete = true;
-                    foreach (var eachSearchFilters in MutableIndexChanges.AllSearchFilters)
+                    foreach (var eachSearchFilters in DocumentUtilities.AllSearchFilters)
                     {
                         SetLatest(eachSearchFilters, latest: null);
                     }

--- a/src/NuGet.Services.AzureSearch/VersionList/MutableIndexChanges.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/MutableIndexChanges.cs
@@ -14,11 +14,6 @@ namespace NuGet.Services.AzureSearch
     /// </summary>
     internal class MutableIndexChanges
     {
-        internal static readonly IReadOnlyList<SearchFilters> AllSearchFilters = Enum
-            .GetValues(typeof(SearchFilters))
-            .Cast<SearchFilters>()
-            .ToList();
-
         /// <summary>
         /// This is a dictionary where the key is the state transition. The value of the dictionary is the resulting
         /// state from that transition. Remember that versions are processed in descending version order so some state
@@ -132,7 +127,7 @@ namespace NuGet.Services.AzureSearch
             }
 
             // Verify that there are not multiple latest versions per search filter.
-            foreach (var searchFilters in AllSearchFilters)
+            foreach (var searchFilters in DocumentUtilities.AllSearchFilters)
             {
                 var latest = HijackDocuments
                     .Where(x => x.Value.GetLatest(searchFilters).GetValueOrDefault(false))

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/DocumentFixUpEvaluatorFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/DocumentFixUpEvaluatorFacts.cs
@@ -1,0 +1,223 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Castle.Core.Resource;
+using Microsoft.Azure.Search;
+using Microsoft.Azure.Search.Models;
+using Microsoft.Data.OData;
+using Moq;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Catalog;
+using NuGet.Services.Metadata.Catalog;
+using NuGet.Versioning;
+using NuGetGallery;
+using Serilog.Core;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
+{
+    public class DocumentFixUpEvaluatorFacts
+    {
+        public class TheTryFixUpAsyncMethod : Facts
+        {
+            public TheTryFixUpAsyncMethod(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task NoInnerExceptionIsNotApplicable()
+            {
+                var ex = new InvalidOperationException();
+
+                var result = await Target.TryFixUpAsync(ItemList, AllIndexActions, ex);
+
+                Assert.False(result.Applicable);
+            }
+
+            [Fact]
+            public async Task WrongInnerExceptionTypeIsNotApplicable()
+            {
+                var ex = new InvalidOperationException("Not good!", new ArgumentException());
+
+                var result = await Target.TryFixUpAsync(ItemList, AllIndexActions, ex);
+
+                Assert.False(result.Applicable);
+            }
+
+            [Fact]
+            public async Task No404FailureIsNotApplicable()
+            {
+                IndexingResults.Add(new IndexingResult(statusCode: 503));
+
+                var result = await Target.TryFixUpAsync(ItemList, AllIndexActions, Exception);
+
+                Assert.False(result.Applicable);
+            }
+
+            [Fact]
+            public async Task Unmatched404FailureIsNotApplicable()
+            {
+                IndexingResults.Add(new IndexingResult(statusCode: 404));
+
+                var result = await Target.TryFixUpAsync(ItemList, AllIndexActions, Exception);
+
+                Assert.False(result.Applicable);
+            }
+
+            [Fact]
+            public async Task Hijack404FailureIsNotApplicable()
+            {
+                IndexingResults.Add(new IndexingResult(key: "hijack-doc", statusCode: 404));
+                AllIndexActions.Add(new IdAndValue<IndexActions>(
+                    "NuGet.Versioning",
+                    new IndexActions(
+                        search: new List<IndexAction<KeyedDocument>>(),
+                        hijack: new List<IndexAction<KeyedDocument>>
+                        {
+                            IndexAction.Merge(new KeyedDocument { Key = "hijack-doc" }),
+                        },
+                        versionListDataResult: new ResultAndAccessCondition<VersionListData>(
+                            new VersionListData(new Dictionary<string, VersionPropertiesData>()),
+                            Mock.Of<IAccessCondition>()))));
+
+                var result = await Target.TryFixUpAsync(ItemList, AllIndexActions, Exception);
+
+                Assert.False(result.Applicable);
+            }
+
+            [Fact]
+            public async Task Search404NonMergeFailureIsNotApplicable()
+            {
+                IndexingResults.Add(new IndexingResult(key: "search-doc", statusCode: 404));
+                AllIndexActions.Add(new IdAndValue<IndexActions>(
+                    "NuGet.Versioning",
+                    new IndexActions(
+                        search: new List<IndexAction<KeyedDocument>>
+                        {
+                            IndexAction.Delete(new KeyedDocument { Key = "search-doc" }),
+                        },
+                        hijack: new List<IndexAction<KeyedDocument>>(),
+                        versionListDataResult: new ResultAndAccessCondition<VersionListData>(
+                            new VersionListData(new Dictionary<string, VersionPropertiesData>()),
+                            Mock.Of<IAccessCondition>()))));
+
+                var result = await Target.TryFixUpAsync(ItemList, AllIndexActions, Exception);
+
+                Assert.False(result.Applicable);
+            }
+
+            [Fact]
+            public async Task Search404MergeFailureIsApplicable()
+            {
+                ItemList.Add(new CatalogCommitItem(
+                    new Uri("https://example/catalog/0.json"),
+                    "commit-id-a",
+                    new DateTime(2020, 3, 16, 12, 5, 0, DateTimeKind.Utc),
+                    new string[0],
+                    new[] { Schema.DataTypes.PackageDetails },
+                    new PackageIdentity("NuGet.Frameworks", NuGetVersion.Parse("1.0.0"))));
+                ItemList.Add(new CatalogCommitItem(
+                    new Uri("https://example/catalog/1.json"),
+                    "commit-id-a",
+                    new DateTime(2020, 3, 16, 12, 5, 0, DateTimeKind.Utc),
+                    new string[0],
+                    new[] { Schema.DataTypes.PackageDetails },
+                    new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("0.9.0-beta.1"))));
+
+                IndexingResults.Add(new IndexingResult(key: "search-doc", statusCode: 404));
+                AllIndexActions.Add(new IdAndValue<IndexActions>(
+                    "NuGet.Versioning",
+                    new IndexActions(
+                        search: new List<IndexAction<KeyedDocument>>
+                        {
+                            IndexAction.Merge(new KeyedDocument { Key = "search-doc" }),
+                        },
+                        hijack: new List<IndexAction<KeyedDocument>>(),
+                        versionListDataResult: new ResultAndAccessCondition<VersionListData>(
+                            new VersionListData(new Dictionary<string, VersionPropertiesData>()),
+                            Mock.Of<IAccessCondition>()))));
+                VersionListClient
+                    .Setup(x => x.ReadAsync(It.IsAny<string>()))
+                    .ReturnsAsync(() => new ResultAndAccessCondition<VersionListData>(
+                        new VersionListData(new Dictionary<string, VersionPropertiesData>
+                        {
+                            { "1.0.0", new VersionPropertiesData(listed: true, semVer2: false) },
+                        }),
+                        Mock.Of<IAccessCondition>()));
+                var leaf = new PackageDetailsCatalogLeaf
+                {
+                    Url = "https://example/catalog/2.json",
+                    CommitId = "commit-id",
+                    CommitTimestamp = new DateTimeOffset(2020, 3, 17, 12, 5, 0, TimeSpan.Zero),
+                    Type = CatalogLeafType.PackageDetails,
+                };
+                LeafFetcher
+                    .Setup(x => x.GetLatestLeavesAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<IReadOnlyList<IReadOnlyList<NuGetVersion>>>()))
+                    .ReturnsAsync(() => new LatestCatalogLeaves(
+                        new HashSet<NuGetVersion>(),
+                        new Dictionary<NuGetVersion, PackageDetailsCatalogLeaf>
+                        {
+                            { NuGetVersion.Parse("1.0.0"), leaf },
+                        }));
+
+                var result = await Target.TryFixUpAsync(ItemList, AllIndexActions, Exception);
+
+                Assert.True(result.Applicable, "The fix up should be applicable.");
+                Assert.Equal(3, result.ItemList.Count);
+                Assert.Empty(ItemList.Except(result.ItemList));
+
+                var addedItem = Assert.Single(result.ItemList.Except(ItemList));
+                Assert.Equal(leaf.Url, addedItem.Uri.AbsoluteUri);
+                Assert.Equal(leaf.CommitId, addedItem.CommitId);
+                Assert.Equal(leaf.CommitTimestamp, addedItem.CommitTimeStamp);
+                Assert.Empty(addedItem.Types);
+                Assert.Equal(Schema.DataTypes.PackageDetails, Assert.Single(addedItem.TypeUris));
+                Assert.Equal(new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("1.0.0")), addedItem.PackageIdentity);
+                Assert.True(addedItem.IsPackageDetails, "The generated item should be a package details item.");
+                Assert.False(addedItem.IsPackageDelete, "The generated item should not be a package delete item.");
+            }
+        }
+
+        public abstract class Facts
+        {
+            public Facts(ITestOutputHelper output)
+            {
+                VersionListClient = new Mock<IVersionListDataClient>();
+                LeafFetcher = new Mock<ICatalogLeafFetcher>();
+                Logger = output.GetLogger<DocumentFixUpEvaluator>();
+
+                ItemList = new List<CatalogCommitItem>();
+                AllIndexActions = new ConcurrentBag<IdAndValue<IndexActions>>();
+                IndexingResults = new List<IndexingResult>();
+                DocumentIndexResult = new DocumentIndexResult(IndexingResults);
+                InnerException = new IndexBatchException(DocumentIndexResult);
+                Exception = new InvalidOperationException("It broke.", InnerException);
+
+                Target = new DocumentFixUpEvaluator(
+                    VersionListClient.Object,
+                    LeafFetcher.Object,
+                    Logger);
+            }
+
+            public Mock<IVersionListDataClient> VersionListClient { get; }
+            public Mock<ICatalogLeafFetcher> LeafFetcher { get; }
+            public RecordingLogger<DocumentFixUpEvaluator> Logger { get; }
+            public List<CatalogCommitItem> ItemList { get; }
+            public ConcurrentBag<IdAndValue<IndexActions>> AllIndexActions { get; }
+            public List<IndexingResult> IndexingResults { get; }
+            public DocumentIndexResult DocumentIndexResult { get; }
+            public IndexBatchException InnerException { get; }
+            public InvalidOperationException Exception { get; }
+            public DocumentFixUpEvaluator Target { get; }
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/AzureSearchCollectorLogicIntegrationTests.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/Integration/AzureSearchCollectorLogicIntegrationTests.cs
@@ -53,6 +53,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
         private InMemoryDocumentsOperations _searchDocuments;
         private Mock<ISearchIndexClientWrapper> _hijackIndex;
         private InMemoryDocumentsOperations _hijackDocuments;
+        private DocumentFixUpEvaluator _fixUpEvaluator;
         private CommitCollectorUtility _commitCollectorUtility;
         private AzureSearchCollectorLogic _collector;
 
@@ -132,6 +133,11 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
             _hijackDocuments = new InMemoryDocumentsOperations();
             _hijackIndex.Setup(x => x.Documents).Returns(() => _hijackDocuments);
 
+            _fixUpEvaluator = new DocumentFixUpEvaluator(
+                _versionListDataClient,
+                _leafFetcher,
+                output.GetLogger<DocumentFixUpEvaluator>());
+
             _commitCollectorUtility = new CommitCollectorUtility(
                 _catalogClient,
                 _v3TelemetryService,
@@ -148,6 +154,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch.Integration
                     _developmentOptions.Object,
                     _telemetryService,
                     output.GetLogger<BatchPusher>()),
+                _fixUpEvaluator,
                 _commitCollectorUtility,
                 _options.Object,
                 _telemetryService,

--- a/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
+++ b/tests/NuGet.Services.AzureSearch.Tests/NuGet.Services.AzureSearch.Tests.csproj
@@ -49,6 +49,7 @@
     <Compile Include="BaseDocumentBuilderFacts.cs" />
     <Compile Include="BatchPusherFacts.cs" />
     <Compile Include="Catalog2AzureSearch\AzureSearchCollectorLogicFacts.cs" />
+    <Compile Include="Catalog2AzureSearch\DocumentFixUpEvaluatorFacts.cs" />
     <Compile Include="Catalog2AzureSearch\Integration\AzureSearchCollectorLogicIntegrationTests.cs" />
     <Compile Include="Catalog2AzureSearch\Catalog2AzureSearchCommandFacts.cs" />
     <Compile Include="Catalog2AzureSearch\CatalogIndexActionBuilderFacts.cs" />


### PR DESCRIPTION
Mitigate https://github.com/NuGet/NuGetGallery/issues/7871

The approach is as follows:

1. Catch the `InvalidOperationException` that occurs
1. If the exception does not contain details specific to this case, rethrow
1. Look up the latest versions of the affected  package IDs
1. Add the latest catalog commit items for these versions to the working set
1. Reprocess the batch

This is a sad workaround and so I tried to isolate it to its own type.

After manually deleting the a document from one of the DEV indexes, I ran a test. This is the output.

<details>
<pre>
[13:47:11 INF] Downloading catalog leaf for jver.semver2.package.dots 1.0.0-a.5: https://apidev.nugettest.org/v3/catalog0/data/2020.03.17.20.46.09/jver.semver2.package.dots.1.0.0-a.5.json
[13:47:11 DBG] Downloading https://apidev.nugettest.org/v3/catalog0/data/2020.03.17.20.46.09/jver.semver2.package.dots.1.0.0-a.5.json as a stream.
[13:47:12 INF] Reading the version list for package ID jver.semver2.package.dots.
[13:47:13 INF] Refreshed secret dev-gallerydb-reader, Expiring at: 3/7/2022 8:22:24 AM. Took 136.97ms.
[13:47:15 INF] Fetching owners for package registration with ID jver.semver2.package.dots.
[13:47:16 INF] The package registration with ID jver.semver2.package.dots has 1 owners.
[13:47:16 INF] Search index action prepared for jver.semver2.package.dots Default: Merge with a NuGet.Services.AzureSearch.SearchDocument+UpdateVersionListAndOwners document.
[13:47:16 INF] Search index action prepared for jver.semver2.package.dots IncludePrerelease: Merge with a NuGet.Services.AzureSearch.SearchDocument+UpdateVersionListAndOwners document.
[13:47:16 INF] Search index action prepared for jver.semver2.package.dots IncludeSemVer2: Merge with a NuGet.Services.AzureSearch.SearchDocument+UpdateVersionListAndOwners document.
[13:47:16 INF] Search index action prepared for jver.semver2.package.dots IncludePrereleaseAndSemVer2: MergeOrUpload with a NuGet.Services.AzureSearch.SearchDocument+UpdateLatest document.
[13:47:16 INF] Hijack index action prepared for jver.semver2.package.dots 1.0.0-a.5: MergeOrUpload with a NuGet.Services.AzureSearch.HijackDocument+Full document.
[13:47:16 INF] Hijack index action prepared for jver.semver2.package.dots 0.9.0: Merge with a NuGet.Services.AzureSearch.HijackDocument+Latest document.
[13:47:16 INF] There are 4 search index changes and 2 hijack index changes for jver.semver2.package.dots.
[13:47:22 INF] Pushing batch of 2 to index hijack-012.
[13:47:22 INF] ServiceClient invocation 1 sending request: POST https://nuget-dev-ea-012.search.windows.net/indexes('hijack-012')/docs/search.index?api-version=2017-11-11
[13:47:23 INF] ServiceClient invocation 1 received response: 200 OK
[13:47:23 INF] Pushing batch of 4 to index search-012.
[13:47:24 INF] ServiceClient invocation 2 sending request: POST https://nuget-dev-ea-012.search.windows.net/indexes('search-012')/docs/search.index?api-version=2017-11-11
[13:47:25 INF] ServiceClient invocation 2 received response: 207 Multi-Status
[13:47:25 ERR] An exception was thrown while sending documents to index search-012.
Microsoft.Azure.Search.IndexBatchException: 1 of 4 indexing actions in the batch failed. The remaining actions succeeded and modified the index. Check the IndexResponse property for the status of each index action.
   at Microsoft.Azure.Search.DocumentsOperations.<DoIndexWithHttpMessagesAsync>d__23.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.Azure.Search.DocumentsOperationsExtensions.<IndexAsync>d__13`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at NuGet.Services.AzureSearch.Wrappers.DocumentsOperationsWrapper.<IndexAsync>d__3`1.MoveNext() in D:\src\git\github.com\NuGet\NuGet.Services.Metadata\src\NuGet.Services.AzureSearch\Wrappers\DocumentsOperationsWrapper.cs:line 30
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at NuGet.Services.AzureSearch.BatchPusher.<IndexAsync>d__17.MoveNext() in D:\src\git\github.com\NuGet\NuGet.Services.Metadata\src\NuGet.Services.AzureSearch\BatchPusher.cs:line 181
[13:47:25 ERR] Indexing document with key jver_semver2_package_dots-anZlci5zZW12ZXIyLnBhY2thZ2UuZG90cw2-Default failed for index search-012. 404: Document not found.
[13:47:25 ERR] 1 errors were found when indexing a batch for index search-012. 1 were logged.
[13:47:41 WRN] 1 document action(s) failed with 404 Not Found.
[13:47:48 WRN] Package jver.semver2.package.dots had a Merge operation fail with 404 Not Found.
[13:47:52 INF] Reading the version list for package ID jver.semver2.package.dots.
[13:47:55 DBG] Downloading https://apidev.nugettest.org/v3/registration5-gz-semver2/jver.semver2.package.dots/index.json as a stream.
[13:47:56 INF] Looking for the catalog leaf for jver.semver2.package.dots 0.9.0.
[13:47:56 INF] Fetching the catalog leaf for jver.semver2.package.dots 0.9.0 from https://apidev.nugettest.org/v3/catalog0/data/2018.08.23.00.13.24/jver.semver2.package.dots.0.9.0.json
[13:47:56 DBG] Downloading https://apidev.nugettest.org/v3/catalog0/data/2018.08.23.00.13.24/jver.semver2.package.dots.0.9.0.json as a stream.
[13:47:56 INF] jver.semver2.package.dots 0.9.0 was found to be listed. Metadata from https://apidev.nugettest.org/v3/catalog0/data/2018.08.23.00.13.24/jver.semver2.package.dots.0.9.0.json will be used.
[13:47:56 DBG] For jver.semver2.package.dots, version 0.9.0 was already fetched.
[13:47:56 INF] jver.semver2.package.dots 0.9.0 was found to be listed. Metadata from https://apidev.nugettest.org/v3/catalog0/data/2018.08.23.00.13.24/jver.semver2.package.dots.0.9.0.json will be used.
[13:47:56 DBG] For jver.semver2.package.dots, version 0.9.0 was already fetched.
[13:47:56 INF] jver.semver2.package.dots 0.9.0 was found to be listed. Metadata from https://apidev.nugettest.org/v3/catalog0/data/2018.08.23.00.13.24/jver.semver2.package.dots.0.9.0.json will be used.
[13:47:56 INF] Looking for the catalog leaf for jver.semver2.package.dots 1.0.0-a.5.
[13:47:56 INF] Fetching the catalog leaf for jver.semver2.package.dots 1.0.0-a.5 from https://apidev.nugettest.org/v3/catalog0/data/2020.03.17.20.46.09/jver.semver2.package.dots.1.0.0-a.5.json
[13:47:56 DBG] Downloading https://apidev.nugettest.org/v3/catalog0/data/2020.03.17.20.46.09/jver.semver2.package.dots.1.0.0-a.5.json as a stream.
[13:47:57 INF] jver.semver2.package.dots 1.0.0-a.5 was found to be listed. Metadata from https://apidev.nugettest.org/v3/catalog0/data/2020.03.17.20.46.09/jver.semver2.package.dots.1.0.0-a.5.json will be used.
[13:48:16 INF] For jver.semver2.package.dots 0.9.0, metadata from https://apidev.nugettest.org/v3/catalog0/data/2018.08.23.00.13.24/jver.semver2.package.dots.0.9.0.json will be used.
[13:48:28 INF] For jver.semver2.package.dots 1.0.0-a.5, metadata will remain the same.
[13:48:31 INF] The catalog commit item list has been modified to fix up the missing document(s).
[13:48:58 INF] Downloading catalog leaf for jver.semver2.package.dots 1.0.0-a.5: https://apidev.nugettest.org/v3/catalog0/data/2020.03.17.20.46.09/jver.semver2.package.dots.1.0.0-a.5.json
[13:48:58 INF] Downloading catalog leaf for jver.semver2.package.dots 0.9.0: https://apidev.nugettest.org/v3/catalog0/data/2018.08.23.00.13.24/jver.semver2.package.dots.0.9.0.json
[13:48:58 DBG] Downloading https://apidev.nugettest.org/v3/catalog0/data/2018.08.23.00.13.24/jver.semver2.package.dots.0.9.0.json as a stream.
[13:48:58 DBG] Downloading https://apidev.nugettest.org/v3/catalog0/data/2020.03.17.20.46.09/jver.semver2.package.dots.1.0.0-a.5.json as a stream.
[13:48:59 INF] Reading the version list for package ID jver.semver2.package.dots.
[13:49:00 INF] Fetching owners for package registration with ID jver.semver2.package.dots.
[13:49:00 INF] The package registration with ID jver.semver2.package.dots has 1 owners.
[13:49:00 INF] Search index action prepared for jver.semver2.package.dots Default: MergeOrUpload with a NuGet.Services.AzureSearch.SearchDocument+UpdateLatest document.
[13:49:00 INF] Search index action prepared for jver.semver2.package.dots IncludePrerelease: MergeOrUpload with a NuGet.Services.AzureSearch.SearchDocument+UpdateLatest document.
[13:49:00 INF] Search index action prepared for jver.semver2.package.dots IncludeSemVer2: MergeOrUpload with a NuGet.Services.AzureSearch.SearchDocument+UpdateLatest document.
[13:49:00 INF] Search index action prepared for jver.semver2.package.dots IncludePrereleaseAndSemVer2: MergeOrUpload with a NuGet.Services.AzureSearch.SearchDocument+UpdateLatest document.
[13:49:00 INF] Hijack index action prepared for jver.semver2.package.dots 1.0.0-a.5: MergeOrUpload with a NuGet.Services.AzureSearch.HijackDocument+Full document.
[13:49:00 INF] Hijack index action prepared for jver.semver2.package.dots 0.9.0: MergeOrUpload with a NuGet.Services.AzureSearch.HijackDocument+Full document.
[13:49:00 INF] There are 4 search index changes and 2 hijack index changes for jver.semver2.package.dots.
[13:49:16 INF] Pushing batch of 2 to index hijack-012.
[13:49:16 INF] ServiceClient invocation 3 sending request: POST https://nuget-dev-ea-012.search.windows.net/indexes('hijack-012')/docs/search.index?api-version=2017-11-11
[13:49:17 INF] ServiceClient invocation 3 received response: 200 OK
[13:49:17 INF] Pushing batch of 4 to index search-012.
[13:49:17 INF] ServiceClient invocation 4 sending request: POST https://nuget-dev-ea-012.search.windows.net/indexes('search-012')/docs/search.index?api-version=2017-11-11
[13:49:18 INF] ServiceClient invocation 4 received response: 200 OK
[13:49:18 INF] Updating 1 version lists with 1 workers, including ["jver.semver2.package.dots"].
[13:49:18 INF] Replacing the version list for package ID jver.semver2.package.dots.
[13:49:19 INF] Done updating 1 version lists.
</pre>
</details>