### PR TITLE
Move to latest ServerCommon, NuGet.Jobs, and NuGetGallery dependencies

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -9,7 +9,7 @@ param (
     [string]$SemanticVersion = '1.0.0-zlocal',
     [string]$Branch,
     [string]$CommitSHA,
-    [string]$BuildBranch = 'd298565f387e93995a179ef8ae6838f1be37904f'
+    [string]$BuildBranch = '6d1fcf147a7af8b6b4db842494bc7beed3b1d0e9'
 )
 
 # For TeamCity - If any issue occurs, this script fails the build. - By default, TeamCity returns an exit code of 0 for all powershell scripts, even if they fail

--- a/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
+++ b/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
@@ -289,10 +289,10 @@
       <Version>1.0.8.3533</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Entities">
-      <Version>4.4.5-dev-3213233</Version>
+      <Version>4.4.5-dev-3612899</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.json-ld.net">
       <Version>1.0.6</Version>
@@ -309,7 +309,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>

--- a/src/Ng/Ng.csproj
+++ b/src/Ng/Ng.csproj
@@ -164,16 +164,16 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Sinks.File">
       <Version>4.0.0</Version>

--- a/src/NuGet.Services.Metadata.Catalog.Monitoring/NuGet.Services.Metadata.Catalog.Monitoring.csproj
+++ b/src/NuGet.Services.Metadata.Catalog.Monitoring/NuGet.Services.Metadata.Catalog.Monitoring.csproj
@@ -172,7 +172,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.SearchService/Web.config
+++ b/src/NuGet.Services.SearchService/Web.config
@@ -40,14 +40,6 @@
         <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="NuGet.Services.ServiceBus" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.71.0.0" newVersion="2.71.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="NuGet.Services.Contracts" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.71.0.0" newVersion="2.71.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
       </dependentAssembly>

--- a/src/NuGet.Services.V3/NuGet.Services.V3.csproj
+++ b/src/NuGet.Services.V3/NuGet.Services.V3.csproj
@@ -72,7 +72,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Common.Job">
-      <Version>4.3.0-dev-3555917</Version>
+      <Version>4.3.0-dev-3613868</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/CatalogTests/CatalogTests.csproj
+++ b/tests/CatalogTests/CatalogTests.csproj
@@ -337,7 +337,7 @@
       <Version>4.10.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/NgTests/NgTests.csproj
+++ b/tests/NgTests/NgTests.csproj
@@ -190,10 +190,10 @@
       <Version>4.10.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/NuGet.Services.AzureSearch.FunctionalTests.csproj
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/NuGet.Services.AzureSearch.FunctionalTests.csproj
@@ -76,7 +76,7 @@
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.72.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
       <Version>5.0.0-preview1.5707</Version>

--- a/tests/NuGet.Services.AzureSearch.Tests/DatabaseAuxiliaryDataFetcherFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/DatabaseAuxiliaryDataFetcherFacts.cs
@@ -130,6 +130,7 @@ namespace NuGet.Services.AzureSearch
             public DbSet<PackageDeprecation> Deprecations { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
             public DbSet<PackageVulnerability> Vulnerabilities { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
             public DbSet<VulnerablePackageVersionRange> VulnerableRanges { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public DbSet<PackageRename> PackageRenames { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
             public bool Disposed { get; private set; }
 


### PR DESCRIPTION
This brings in the NoWarn and the 3.0.0.0 assembly version for ServerCommon assemblies.