### PR TITLE
Add build hook for internal dependencies

### DIFF
--- a/sign.thirdparty.props
+++ b/sign.thirdparty.props
@@ -4,6 +4,7 @@
     <ThirdPartyBinaries Include="AnglicanGeek.MarkdownMailer.dll" />
     <ThirdPartyBinaries Include="Autofac.dll" />
     <ThirdPartyBinaries Include="Autofac.Extensions.DependencyInjection.dll" />
+    <ThirdPartyBinaries Include="Autofac.Integration.WebApi.dll" />
     <ThirdPartyBinaries Include="Dapper.StrongName.dll" />
     <ThirdPartyBinaries Include="dotNetRDF.dll" />
     <ThirdPartyBinaries Include="Elmah.dll" />

--- a/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
+++ b/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
@@ -292,7 +292,7 @@
       <Version>4.4.5-dev-3612899</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.74.0</Version>
+      <Version>2.75.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.json-ld.net">
       <Version>1.0.6</Version>
@@ -309,7 +309,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.74.0</Version>
+      <Version>2.75.0</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>

--- a/src/Ng/Ng.csproj
+++ b/src/Ng/Ng.csproj
@@ -164,16 +164,16 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.74.0</Version>
+      <Version>2.75.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.74.0</Version>
+      <Version>2.75.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.74.0</Version>
+      <Version>2.75.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.74.0</Version>
+      <Version>2.75.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Sinks.File">
       <Version>4.0.0</Version>

--- a/src/NuGet.Services.Metadata.Catalog.Monitoring/NuGet.Services.Metadata.Catalog.Monitoring.csproj
+++ b/src/NuGet.Services.Metadata.Catalog.Monitoring/NuGet.Services.Metadata.Catalog.Monitoring.csproj
@@ -172,7 +172,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.74.0</Version>
+      <Version>2.75.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.SearchService/NuGet.Services.SearchService.csproj
+++ b/src/NuGet.Services.SearchService/NuGet.Services.SearchService.csproj
@@ -1,5 +1,6 @@
 ﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\..\sign.thirdparty.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -114,31 +115,8 @@
     <SignType Condition="'$(SignType)' == ''">none</SignType>
   </PropertyGroup>
   <Import Project="$(SignPath)\sign.targets" Condition="Exists('$(SignPath)\sign.targets')" />
-  <ItemGroup>
-    <ThirdPartyBinaries Include="AnglicanGeek.MarkdownMailer.dll" Visible="false" />
-    <ThirdPartyBinaries Include="Autofac.dll" Visible="false" />
-    <ThirdPartyBinaries Include="Autofac.Extensions.DependencyInjection.dll" Visible="false" />
-    <ThirdPartyBinaries Include="Autofac.Integration.WebApi.dll" Visible="false" />
-    <ThirdPartyBinaries Include="Dapper.StrongName.dll" Visible="false" />
-    <ThirdPartyBinaries Include="dotNetRDF.dll" Visible="false" />
-    <ThirdPartyBinaries Include="Elmah.dll" Visible="false" />
-    <ThirdPartyBinaries Include="HtmlAgilityPack.dll" Visible="false" />
-    <ThirdPartyBinaries Include="ICSharpCode.SharpZipLib.dll" Visible="false" />
-    <ThirdPartyBinaries Include="json-ld.net.StrongName.dll" Visible="false" />
-    <ThirdPartyBinaries Include="Markdig.dll" Visible="false" />
-    <ThirdPartyBinaries Include="MarkdownSharp.dll" Visible="false" />
-    <ThirdPartyBinaries Include="Newtonsoft.Json.dll" Visible="false" />
-    <ThirdPartyBinaries Include="Serilog.dll" Visible="false" />
-    <ThirdPartyBinaries Include="Serilog.Enrichers.Environment.dll" Visible="false" />
-    <ThirdPartyBinaries Include="Serilog.Enrichers.Process.dll" Visible="false" />
-    <ThirdPartyBinaries Include="Serilog.Extensions.Logging.dll" Visible="false" />
-    <ThirdPartyBinaries Include="Serilog.Sinks.ApplicationInsights.dll" Visible="false" />
-    <ThirdPartyBinaries Include="Serilog.Sinks.Console.dll" Visible="false" />
-    <ThirdPartyBinaries Include="Serilog.Sinks.File.dll" Visible="false" />
-    <ThirdPartyBinaries Include="SerilogTraceListener.dll" Visible="false" />
-    <ThirdPartyBinaries Include="VDS.Common.dll" Visible="false" />
-  </ItemGroup>
   <Import Project="$(SignPath)\sign.microbuild.targets" Condition="Exists('$(SignPath)\sign.microbuild.targets')" />
+  <Import Project="$(NuGetBuildExtensions)" Condition="'$(NuGetBuildExtensions)' != '' And Exists('$(NuGetBuildExtensions)')" />
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
   <ProjectExtensions>

--- a/src/NuGet.Services.SearchService/Web.config
+++ b/src/NuGet.Services.SearchService/Web.config
@@ -6,7 +6,7 @@
     <httpRuntime targetFramework="4.7.2"/>
   </system.web>
   <system.webServer>
-    <modules>
+    <modules runAllManagedModulesForAllRequests="true">
       <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="integratedMode,managedHandler"/>
       <add name="ApplicationInsightsHttpModule" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler"/>
     </modules>
@@ -23,6 +23,10 @@
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="MessagePack" publicKeyToken="B4A0369545F0A1BE" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0"/>
+      </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-9.3.2.0" newVersion="9.3.2.0"/>

--- a/tests/CatalogTests/CatalogTests.csproj
+++ b/tests/CatalogTests/CatalogTests.csproj
@@ -337,7 +337,7 @@
       <Version>4.10.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.74.0</Version>
+      <Version>2.75.0</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/NgTests/NgTests.csproj
+++ b/tests/NgTests/NgTests.csproj
@@ -190,10 +190,10 @@
       <Version>4.10.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.74.0</Version>
+      <Version>2.75.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.74.0</Version>
+      <Version>2.75.0</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/NuGet.Services.AzureSearch.FunctionalTests.csproj
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/NuGet.Services.AzureSearch.FunctionalTests.csproj
@@ -76,7 +76,7 @@
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.74.0</Version>
+      <Version>2.75.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
       <Version>5.0.0-preview1.5707</Version>


### PR DESCRIPTION
Activate assembly modules and add more base configuration types to DI
Consider 4XX as successfully for telemetry purposes
Add KnownOperation for the V3 search endpoint
Progress on https://github.com/NuGet/Engineering/issues/3020