### PR TITLE
Sort the @type array before comparing

### DIFF
--- a/src/NuGet.Jobs.RegistrationComparer/Normalizers.cs
+++ b/src/NuGet.Jobs.RegistrationComparer/Normalizers.cs
@@ -207,7 +207,12 @@ namespace NuGet.Jobs.RegistrationComparer
             path => path == string.Empty,
         };
 
-        private static readonly IReadOnlyList<ArrayNormalizer> DefaultUnsortedArrays = new List<ArrayNormalizer>();
+        private static readonly IReadOnlyList<ArrayNormalizer> DefaultUnsortedArrays = new List<ArrayNormalizer>
+        {
+            new ArrayNormalizer(
+                a => IsPropertyName(a.Path, "@type"),
+                (a, b) => StringComparer.Ordinal.Compare((string)a, (string)b)),
+        };
 
         private static readonly IReadOnlyList<ArrayNormalizer> IndexAndPageUnsortedArrays = new List<ArrayNormalizer>(DefaultUnsortedArrays)
         {


### PR DESCRIPTION
The `@type` property at this URL is in an unexpected order:
https://api.nuget.org/v3/registration4-gz-semver2/solidrpc.openapi.azfunctions/index.json

Seems to be a rare possibility from JSON-LD.