### PR TITLE
[Package Renames 3] Load popularity transfers from database

### DIFF
--- a/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/AzureSearchTelemetryService.cs
@@ -189,6 +189,17 @@ namespace NuGet.Services.AzureSearch
                 });
         }
 
+        public void TrackReadLatestPopularityTransfersFromDatabase(int outgoingTransfers, TimeSpan elapsed)
+        {
+            _telemetryClient.TrackMetric(
+                Prefix + "ReadLatestPopularityTransfersFromDatabase",
+                elapsed.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { "OutgoingTransfers", outgoingTransfers.ToString() }
+                });
+        }
+
         public void TrackPopularityTransfersSetComparison(int oldCount, int newCount, int changeCount, TimeSpan elapsed)
         {
             _telemetryClient.TrackMetric(

--- a/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
+++ b/src/NuGet.Services.AzureSearch/IAzureSearchTelemetryService.cs
@@ -22,6 +22,7 @@ namespace NuGet.Services.AzureSearch
         void TrackReadLatestOwnersFromDatabase(int packageIdCount, TimeSpan elapsed);
         void TrackPopularityTransfersSetComparison(int oldCount, int newCount, int changeCount, TimeSpan elapsed);
         void TrackReadLatestIndexedPopularityTransfers(int outgoingTransfers, TimeSpan elapsed);
+        void TrackReadLatestPopularityTransfersFromDatabase(int outgoingTransfers, TimeSpan elapsed);
         void TrackReadLatestVerifiedPackagesFromDatabase(int packageIdCount, TimeSpan elapsed);
         IDisposable TrackReplaceLatestIndexedOwners(int packageIdCount);
         IDisposable TrackUploadOwnerChangeHistory(int packageIdCount);

--- a/src/NuGet.Services.AzureSearch/IDatabaseAuxiliaryDataFetcher.cs
+++ b/src/NuGet.Services.AzureSearch/IDatabaseAuxiliaryDataFetcher.cs
@@ -25,6 +25,13 @@ namespace NuGet.Services.AzureSearch
         Task<SortedDictionary<string, SortedSet<string>>> GetPackageIdToOwnersAsync();
 
         /// <summary>
+        /// Fetch a mapping of package IDs to set of replacement package IDs for each renamed packages that transfer
+        /// popularity in the gallery database.
+        /// </summary>
+        /// <returns></returns>
+        Task<SortedDictionary<string, SortedSet<string>>> GetPackageIdToPopularityTransfersAsync();
+
+        /// <summary>
         /// Fetch the set of all verified package IDs.
         /// </summary>
         Task<HashSet<string>> GetVerifiedPackagesAsync();


### PR DESCRIPTION
The `db2azuresearch` and `auxiliary2azuresearch` jobs needs to get the latest popularity transfers from the database.

⚠ This change is not unit testable as it interacts with a database. This will be covered by end-to-end tests and monitoring.

Previous changes: https://github.com/NuGet/NuGet.Services.Metadata/pull/765 and https://github.com/NuGet/NuGet.Services.Metadata/pull/766.
Part of https://github.com/nuget/nugetgallery/issues/7898
