### PR TITLE
[Hotfix] Allow the MonitoringProcessor worker count to be configured

### DIFF
--- a/src/Catalog/PackageDownloader.cs
+++ b/src/Catalog/PackageDownloader.cs
@@ -14,7 +14,7 @@ namespace NuGet.Services.Metadata.Catalog
 {
     public class PackageDownloader
     {
-        private const int BufferSize = 8192;
+        private const int BufferSize = 80 * 1024;
 
         private readonly HttpClient _httpClient;
         private readonly ILogger _logger;

--- a/src/Ng/Arguments.cs
+++ b/src/Ng/Arguments.cs
@@ -162,6 +162,11 @@ namespace Ng
         /// When the queue is empty or processing a message fails, wait this long before polling more.
         /// </summary>
         public const string QueueDelaySeconds = "queueDelaySeconds";
+
+        /// <summary>
+        /// The number of parallel workers for <see cref="Jobs.MonitoringProcessorJob"/>.
+        /// </summary>
+        public const string WorkerCount = "workerCount";
         #endregion
 
         #region KeyVault


### PR DESCRIPTION
There are many large packages in the queue and the disk is getting hammered via `PackageDownloader` which used the a temp file instead of in memory buffer.