### PR TITLE
Add TagsCustomAnalyzer To BaseMetadataDocument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.suo
 *.user
 *.sln.docstates
+.idea
 
 # Build results
 [Dd]ebug/

--- a/src/NuGet.Services.AzureSearch/Analysis/TagsCustomAnalyzer.cs
+++ b/src/NuGet.Services.AzureSearch/Analysis/TagsCustomAnalyzer.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Azure.Search.Models;
+
+namespace NuGet.Services.AzureSearch
+{
+    /// <summary>
+    /// Support for tag case-insensitive exact matching on a field with trimming
+    /// in an Azure Search index.
+    ///
+    /// Note: will not split on special characters like -,_,$,etc. This is important
+    /// and allows developers to hyphenate their tags. It will trim excess whitespace
+    /// from the end of each tag.
+    ///
+    /// Tokenization will also exclude duplicates from the indexing process.
+    /// </summary>
+    public static class TagsCustomAnalyzer
+    {
+        public const string Name = "nuget_tags_analyzer";
+
+        public static readonly CustomAnalyzer Instance = new CustomAnalyzer(
+            Name,
+            TokenizerName.Keyword,
+            new List<TokenFilterName>
+            {
+                TokenFilterName.Lowercase,
+                TokenFilterName.Trim,
+                TokenFilterName.Unique
+            });
+    }
+}

--- a/src/NuGet.Services.AzureSearch/IndexBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/IndexBuilder.cs
@@ -115,6 +115,7 @@ namespace NuGet.Services.AzureSearch
                     DescriptionAnalyzer.Instance,
                     ExactMatchCustomAnalyzer.Instance,
                     PackageIdCustomAnalyzer.Instance,
+                    TagsCustomAnalyzer.Instance
                 },
                 Tokenizers = new List<Tokenizer>
                 {

--- a/src/NuGet.Services.AzureSearch/Models/BaseMetadataDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/BaseMetadataDocument.cs
@@ -72,6 +72,7 @@ namespace NuGet.Services.AzureSearch
         public string Summary { get; set; }
 
         [IsSearchable]
+        [Analyzer(TagsCustomAnalyzer.Name)]
         public string[] Tags { get; set; }
 
         [IsSearchable]

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Analysis\IdentifierCustomTokenFilter.cs" />
     <Compile Include="Analysis\PackageIdCustomAnalyzer.cs" />
     <Compile Include="Analysis\PackageIdCustomTokenizer.cs" />
+    <Compile Include="Analysis\TagsCustomAnalyzer.cs" />
     <Compile Include="Analysis\TruncateCustomTokenFilter.cs" />
     <Compile Include="Auxiliary2AzureSearch\UpdateDownloadsCommand.cs" />
     <Compile Include="Auxiliary2AzureSearch\UpdateVerifiedPackagesCommand.cs" />


### PR DESCRIPTION
This allows users of NuGet to find tags with special characters
that may be important to the tag itself. For example you would
be able to find a tag of 'dotnet-tool' now, when you previously
could not.

 https://github.com/NuGet/NuGetGallery/issues/4878