### PR TITLE
Add BatchPusherResult to surface package IDs that failed

### DIFF
--- a/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/UpdateDownloadsCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/UpdateDownloadsCommand.cs
@@ -352,9 +352,8 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
                 batchPusher.EnqueueIndexActions(indexActions.Id, indexActions.Value);
             }
 
-            // Note that this method can throw a storage exception if one of the version lists has been modified during
-            // the execution of this job loop.
-            await batchPusher.FinishAsync();
+            var finishResult = await batchPusher.TryFinishAsync();
+            finishResult.EnsureNoFailures();
 
             // Restart the timer AFTER the push is completed to err on the side of caution.
             timeSinceLastPush.Restart();

--- a/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/UpdateOwnersCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/UpdateOwnersCommand.cs
@@ -121,12 +121,12 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
 
                 batchPusher.EnqueueIndexActions(changes.Id, indexActions);
 
-                // Note that this method can throw a storage exception if one of the version lists has been modified
-                // during the execution of this job loop.
-                await batchPusher.PushFullBatchesAsync();
+                var fullBatchesResult = await batchPusher.TryPushFullBatchesAsync();
+                fullBatchesResult.EnsureNoFailures();
             }
 
-            await batchPusher.FinishAsync();
+            var finishResult = await batchPusher.TryFinishAsync();
+            finishResult.EnsureNoFailures();
         }
     }
 }

--- a/src/NuGet.Services.AzureSearch/BatchPusher.cs
+++ b/src/NuGet.Services.AzureSearch/BatchPusher.cs
@@ -13,6 +13,7 @@ using Microsoft.Azure.Search.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Rest.Azure;
+using NuGet.Packaging;
 using NuGet.Services.AzureSearch.Wrappers;
 
 namespace NuGet.Services.AzureSearch
@@ -93,27 +94,30 @@ namespace NuGet.Services.AzureSearch
             _versionListDataResults.Add(packageId, indexActions.VersionListDataResult);
         }
 
-        public async Task PushFullBatchesAsync()
+        public async Task<BatchPusherResult> TryPushFullBatchesAsync()
         {
-            await PushBatchesAsync(onlyFull: true);
+            return await TryPushBatchesAsync(onlyFull: true);
         }
 
-        public async Task FinishAsync()
+        public async Task<BatchPusherResult> TryFinishAsync()
         {
-            await PushBatchesAsync(onlyFull: false);
+            return await TryPushBatchesAsync(onlyFull: false);
         }
 
-        private async Task PushBatchesAsync(bool onlyFull)
+        private async Task<BatchPusherResult> TryPushBatchesAsync(bool onlyFull)
         {
-            await PushBatchesAsync(_hijackIndexClient, _hijackActions, onlyFull);
-            await PushBatchesAsync(_searchIndexClient, _searchActions, onlyFull);
+            var failedPackageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            failedPackageIds.AddRange(await PushBatchesAsync(_hijackIndexClient, _hijackActions, onlyFull));
+            failedPackageIds.AddRange(await PushBatchesAsync(_searchIndexClient, _searchActions, onlyFull));
+            return new BatchPusherResult(failedPackageIds);
         }
 
-        private async Task PushBatchesAsync(
+        private async Task<HashSet<string>> PushBatchesAsync(
             ISearchIndexClientWrapper indexClient,
             Queue<IdAndValue<IndexAction<KeyedDocument>>> actions,
             bool onlyFull)
         {
+            var failedPackageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             while ((onlyFull && actions.Count >= _options.Value.AzureSearchBatchSize)
                 || (!onlyFull && actions.Count > 0))
             {
@@ -136,7 +140,7 @@ namespace NuGet.Services.AzureSearch
 
                 if (allFinished.Any())
                 {
-                    await UpdateVersionListsAsync(allFinished);
+                    failedPackageIds.AddRange(await UpdateVersionListsAsync(allFinished));
                 }
             }
 
@@ -152,6 +156,8 @@ namespace NuGet.Services.AzureSearch
                     .Except(_versionListDataResults.Keys)
                     .Any(),
                 "There are some reference counts without version list data results.");
+
+            return failedPackageIds;
         }
 
         private async Task IndexAsync(
@@ -255,14 +261,14 @@ namespace NuGet.Services.AzureSearch
             }
         }
 
-        private async Task UpdateVersionListsAsync(List<IdAndValue<ResultAndAccessCondition<VersionListData>>> allFinished)
+        private async Task<HashSet<string>> UpdateVersionListsAsync(List<IdAndValue<ResultAndAccessCondition<VersionListData>>> allFinished)
         {
             if (_developmentOptions.Value.DisableVersionListWriters)
             {
                 _logger.LogWarning(
                     "Skipped updating {VersionListCount} version lists.",
                     allFinished.Count);
-                return;
+                return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             }
 
             var versionListIdSample = allFinished
@@ -278,6 +284,7 @@ namespace NuGet.Services.AzureSearch
                 versionListIdSample);
 
             var work = new ConcurrentBag<IdAndValue<ResultAndAccessCondition<VersionListData>>>(allFinished);
+            var failedPackageIds = new ConcurrentQueue<string>();
             using (_telemetryService.TrackVersionListsUpdated(allFinished.Count, workerCount))
             {
                 var tasks = Enumerable
@@ -287,17 +294,26 @@ namespace NuGet.Services.AzureSearch
                         await Task.Yield();
                         while (work.TryTake(out var finished))
                         {
-                            // This method can throw a storage exception if the version list has changed.
-                            await _versionListDataClient.ReplaceAsync(
+                            var success = await _versionListDataClient.TryReplaceAsync(
                                 finished.Id,
                                 finished.Value.Result,
                                 finished.Value.AccessCondition);
+
+                            if (!success)
+                            {
+                                failedPackageIds.Enqueue(finished.Id);
+                            }
                         }
                     })
                     .ToList();
                 await Task.WhenAll(tasks);
 
-                _logger.LogInformation("Done updating {VersionListCount} version lists.", allFinished.Count);
+                _logger.LogInformation(
+                    "Done updating {VersionListCount} version lists. {FailureCount} version lists failed.",
+                    allFinished.Count - failedPackageIds.Count,
+                    failedPackageIds.Count);
+
+                return failedPackageIds.ToHashSet(StringComparer.OrdinalIgnoreCase);
             }
         }
 

--- a/src/NuGet.Services.AzureSearch/BatchPusherResult.cs
+++ b/src/NuGet.Services.AzureSearch/BatchPusherResult.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class BatchPusherResult
+    {
+        public BatchPusherResult() : this(new HashSet<string>())
+        {
+        }
+
+        public BatchPusherResult(HashSet<string> failedPackageIds)
+        {
+            FailedPackageIds = failedPackageIds;
+        }
+
+        /// <summary>
+        /// Package IDs that failed due to access condition on the version list.
+        /// </summary>
+        public HashSet<string> FailedPackageIds { get; }
+
+        public void EnsureNoFailures()
+        {
+            if (FailedPackageIds.Any())
+            {
+                throw new InvalidOperationException(
+                    "The index operations for the following package IDs failed due to version list concurrency: "
+                    + string.Join(", ", FailedPackageIds));
+            }
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/AzureSearchCollectorLogic.cs
+++ b/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/AzureSearchCollectorLogic.cs
@@ -84,7 +84,8 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
                 try
                 {
-                    await batchPusher.FinishAsync();
+                    var finishResult = await batchPusher.TryFinishAsync();
+                    finishResult.EnsureNoFailures();
                 }
                 catch (InvalidOperationException ex) when (allowFixUp)
                 {

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchCommand.cs
@@ -250,11 +250,13 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                     if (!indexActions.IsEmpty)
                     {
                         batchPusher.EnqueueIndexActions(work.PackageId, indexActions);
-                        await batchPusher.PushFullBatchesAsync();
+                        var fullBatchesResult = await batchPusher.TryPushFullBatchesAsync();
+                        fullBatchesResult.EnsureNoFailures();
                     }
                 }
 
-                await batchPusher.FinishAsync();
+                var finishResult = await batchPusher.TryFinishAsync();
+                finishResult.EnsureNoFailures();
             }
             catch (Exception ex)
             {

--- a/src/NuGet.Services.AzureSearch/IBatchPusher.cs
+++ b/src/NuGet.Services.AzureSearch/IBatchPusher.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.WindowsAzure.Storage;
 
 namespace NuGet.Services.AzureSearch
 {
@@ -26,15 +25,15 @@ namespace NuGet.Services.AzureSearch
         /// <see cref="EnqueueIndexActions(string, IndexActions)"/>. If there is not enough data to create a full batch,
         /// it is not pushed by this method (until enough additional data is enqueued to make a full batch). When all of
         /// the index actions for a specific package ID completed (pushed to Azure Search), the corresponding version
-        /// list is also updated. Hijack index changes are applied before search index changes.
+        /// list is also updated. Hijack index changes are applied before search index changes. Any failures are
+        /// returned in the result.
         /// </summary>
-        /// <exception cref="StorageException">Thrown if the one of the version lists has changed.</exception>
-        Task PushFullBatchesAsync();
+        Task<BatchPusherResult> TryPushFullBatchesAsync();
 
         /// <summary>
-        /// Same as <see cref="PushFullBatchesAsync"/> but if there is a partial batch remaining, it is also pushed.
+        /// Same as <see cref="TryPushFullBatchesAsync"/> but if there is a partial batch remaining, it is also pushed.
+        /// Any failures are returned in the result.
         /// </summary>
-        /// <exception cref="StorageException">Thrown if the one of the version lists has changed.</exception>
-        Task FinishAsync();
+        Task<BatchPusherResult> TryFinishAsync();
     }
 }

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -75,6 +75,7 @@
     <Compile Include="AzureSearchJobDevelopmentConfiguration.cs" />
     <Compile Include="AzureSearchScoringConfiguration.cs" />
     <Compile Include="BaseDocumentBuilder.cs" />
+    <Compile Include="BatchPusherResult.cs" />
     <Compile Include="Catalog2AzureSearch\DocumentFixUp.cs" />
     <Compile Include="Catalog2AzureSearch\DocumentFixUpEvaluator.cs" />
     <Compile Include="Catalog2AzureSearch\IDocumentFixUpEvaluator.cs" />

--- a/src/NuGet.Services.AzureSearch/SearchService/IAuxiliaryData.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IAuxiliaryData.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-
 namespace NuGet.Services.AzureSearch.SearchService
 {
     public interface IAuxiliaryData

--- a/src/NuGet.Services.AzureSearch/VersionList/IVersionListDataClient.cs
+++ b/src/NuGet.Services.AzureSearch/VersionList/IVersionListDataClient.cs
@@ -17,6 +17,17 @@ namespace NuGet.Services.AzureSearch
     public interface IVersionListDataClient
     {
         Task<ResultAndAccessCondition<VersionListData>> ReadAsync(string id);
-        Task ReplaceAsync(string id, VersionListData data, IAccessCondition accessCondition);
+
+        /// <summary>
+        /// Replace the version list of the provided package ID. May return false due to access condition (i.e. 412
+        /// Precondition Failed in Azure Blob Storage). May throw exceptions unrelated to access condition failures.
+        /// False will be returned if another caller has modified the version list thus invalidating the access
+        /// condition.
+        /// </summary>
+        /// <param name="id">The package ID.</param>
+        /// <param name="data">The data of the version list to be written.</param>
+        /// <param name="accessCondition">The access condition for the write operation.</param>
+        /// <returns>True if the access condition is accepted. False if the access condition fails.</returns>
+        Task<bool> TryReplaceAsync(string id, VersionListData data, IAccessCondition accessCondition);
     }
 }

--- a/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Integration/PopularityTransferIntegrationTests.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Integration/PopularityTransferIntegrationTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.Search.Models;

--- a/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/AzureSearchCollectorLogicFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Catalog2AzureSearch/AzureSearchCollectorLogicFacts.cs
@@ -126,7 +126,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                     x => x.EnqueueIndexActions(It.IsAny<string>(), It.IsAny<IndexActions>()),
                     Times.Exactly(2));
 
-                _batchPusher.Verify(x => x.FinishAsync(), Times.Once);
+                _batchPusher.Verify(x => x.TryFinishAsync(), Times.Once);
             }
 
             [Fact]
@@ -198,7 +198,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                     x => x.EnqueueIndexActions(It.IsAny<string>(), It.IsAny<IndexActions>()),
                     Times.Exactly(2));
 
-                _batchPusher.Verify(x => x.FinishAsync(), Times.Once);
+                _batchPusher.Verify(x => x.TryFinishAsync(), Times.Once);
             }
 
             [Fact]
@@ -249,7 +249,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
                 var otherException = new ArgumentException("Not so fast, buddy.");
                 _batchPusher
-                    .Setup(x => x.FinishAsync())
+                    .Setup(x => x.TryFinishAsync())
                     .ThrowsAsync(otherException);
 
                 var ex = await Assert.ThrowsAsync<ArgumentException>(
@@ -262,7 +262,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                         It.IsAny<ConcurrentBag<IdAndValue<IndexActions>>>(),
                         It.IsAny<InvalidOperationException>()),
                     Times.Never);
-                _batchPusher.Verify(x => x.FinishAsync(), Times.Once);
+                _batchPusher.Verify(x => x.TryFinishAsync(), Times.Once);
             }
 
             [Fact]
@@ -281,7 +281,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
                 var otherException = new InvalidOperationException("Not so fast, buddy.");
                 _batchPusher
-                    .Setup(x => x.FinishAsync())
+                    .Setup(x => x.TryFinishAsync())
                     .ThrowsAsync(otherException);
 
                 var ex = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -294,7 +294,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                         It.IsAny<ConcurrentBag<IdAndValue<IndexActions>>>(),
                         It.IsAny<InvalidOperationException>()),
                     Times.Once);
-                _batchPusher.Verify(x => x.FinishAsync(), Times.Once);
+                _batchPusher.Verify(x => x.TryFinishAsync(), Times.Once);
             }
 
             [Fact]
@@ -313,7 +313,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
                 var otherException = new InvalidOperationException("Not so fast, buddy.");
                 _batchPusher
-                    .Setup(x => x.FinishAsync())
+                    .Setup(x => x.TryFinishAsync())
                     .ThrowsAsync(otherException);
                 _fixUpEvaluator
                     .Setup(x => x.TryFixUpAsync(
@@ -332,7 +332,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                         It.IsAny<ConcurrentBag<IdAndValue<IndexActions>>>(),
                         It.IsAny<InvalidOperationException>()),
                     Times.Once);
-                _batchPusher.Verify(x => x.FinishAsync(), Times.Exactly(2));
+                _batchPusher.Verify(x => x.TryFinishAsync(), Times.Exactly(2));
             }
 
             [Fact]
@@ -362,7 +362,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
                 var otherException = new InvalidOperationException("Not so fast, buddy.");
                 _batchPusher
-                    .Setup(x => x.FinishAsync())
+                    .Setup(x => x.TryFinishAsync())
                     .ThrowsAsync(otherException);
                 _fixUpEvaluator
                     .Setup(x => x.TryFixUpAsync(
@@ -411,6 +411,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                 _logger = output.GetLogger<AzureSearchCollectorLogic>();
                 _utilityLogger = output.GetLogger<CommitCollectorUtility>();
 
+                _batchPusher.SetReturnsDefault(Task.FromResult(new BatchPusherResult()));
                 _utilityOptions.Setup(x => x.Value).Returns(() => _utilityConfig);
                 _utilityConfig.MaxConcurrentCatalogLeafDownloads = 1;
                 _collectorOptions.Setup(x => x.Value).Returns(() => _collectorConfig);

--- a/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/Db2AzureSearchCommandFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/Db2AzureSearchCommandFacts.cs
@@ -90,6 +90,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                     new ResultAndAccessCondition<VersionListData>(
                         new VersionListData(new Dictionary<string, VersionPropertiesData>()),
                         AccessConditionWrapper.GenerateEmptyCondition())));
+            _batchPusher.SetReturnsDefault(Task.FromResult(new BatchPusherResult()));
             _catalogClient
                 .Setup(x => x.GetIndexAsync(It.IsAny<string>()))
                 .ReturnsAsync(new CatalogIndex());
@@ -192,8 +193,8 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                 new[] { "A", "B", "C", "D", "E" },
                 keys);
 
-            _batchPusher.Verify(x => x.PushFullBatchesAsync(), Times.Exactly(5));
-            _batchPusher.Verify(x => x.FinishAsync(), Times.Once);
+            _batchPusher.Verify(x => x.TryPushFullBatchesAsync(), Times.Exactly(5));
+            _batchPusher.Verify(x => x.TryFinishAsync(), Times.Once);
         }
 
         [Fact]


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/8051. This does not fix the issue but lays the groundwork for callers to retry in this case. The plan is for the `Auxiliary2AzureSearch` `UpdateDownloadsCommand` to be clever (only retry failed IDs) and everything else to just retry everything (easier to implement). The download update is the longest running use of `BatchPusher` so that's why I picked that.

After this PR, jobs will still crash from HTTP 412. This PR is just setting up for future changes. I don't want the PRs to be too big.