### PR TITLE
Add retry to HttpReadCursor

### DIFF
--- a/src/Catalog/HttpReadCursor.cs
+++ b/src/Catalog/HttpReadCursor.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
+using NuGet.Services.Metadata.Catalog.Helpers;
 
 namespace NuGet.Services.Metadata.Catalog
 {
@@ -33,29 +34,37 @@ namespace NuGet.Services.Metadata.Catalog
 
         public override async Task LoadAsync(CancellationToken cancellationToken)
         {
-            HttpMessageHandler handler = (_handlerFunc != null) ? _handlerFunc() : new WebRequestHandler { AllowPipelining = true };
-
-            using (HttpClient client = new HttpClient(handler))
-            using (HttpResponseMessage response = await client.GetAsync(_address, cancellationToken))
-            {
-                Trace.TraceInformation("HttpReadCursor.Load {0}", response.StatusCode);
-
-                if (_defaultValue != null && response.StatusCode == HttpStatusCode.NotFound)
+            await Retry.IncrementalAsync(
+                async () =>
                 {
-                    Value = _defaultValue.Value;
-                }
-                else
-                {
-                    response.EnsureSuccessStatusCode();
+                    HttpMessageHandler handler = (_handlerFunc != null) ? _handlerFunc() : new WebRequestHandler { AllowPipelining = true };
 
-                    string json = await response.Content.ReadAsStringAsync();
+                    using (HttpClient client = new HttpClient(handler))
+                    using (HttpResponseMessage response = await client.GetAsync(_address, cancellationToken))
+                    {
+                        Trace.TraceInformation("HttpReadCursor.Load {0}", response.StatusCode);
 
-                    JObject obj = JObject.Parse(json);
-                    Value = obj["value"].ToObject<DateTime>();
-                }
-            }
+                        if (_defaultValue != null && response.StatusCode == HttpStatusCode.NotFound)
+                        {
+                            Value = _defaultValue.Value;
+                        }
+                        else
+                        {
+                            response.EnsureSuccessStatusCode();
 
-            Trace.TraceInformation("HttpReadCursor.Load: {0}", this);
+                            string json = await response.Content.ReadAsStringAsync();
+
+                            JObject obj = JObject.Parse(json);
+                            Value = obj["value"].ToObject<DateTime>();
+                        }
+                    }
+
+                    Trace.TraceInformation("HttpReadCursor.Load: {0}", this);
+                },
+                ex => ex is HttpRequestException,
+                maxRetries: 5,
+                initialWaitInterval: TimeSpan.Zero,
+                waitIncrement: TimeSpan.FromSeconds(10));
         }
     }
 }


### PR DESCRIPTION
See details on https://github.com/NuGet/NuGetGallery/issues/8062. This helps one transient issue but the other exception occurred event with Azure Blob Storage SDK retries. This does not completely solve this issue but improves the situation.

I chose a bit higher of a retry number since this is a back-end job so it can tolerate some more delays as retries are made as oppose to, say, a web service.

[Best viewed by hiding whitespace.](https://github.com/NuGet/NuGet.Services.Metadata/pull/789/files?diff=unified&w=1)