### PR TITLE
Add retries to jobs that use BatchPusher

### DIFF
--- a/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/UpdateOwnersCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/UpdateOwnersCommand.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -80,7 +81,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
                 _logger.LogInformation(
                     "Starting {Count} workers pushing owners changes to Azure Search.",
                     _options.Value.MaxConcurrentBatches);
-                await ParallelAsync.Repeat(() => WorkAsync(changesBag), _options.Value.MaxConcurrentBatches);
+                await ParallelAsync.Repeat(() => WorkAndRetryAsync(changesBag), _options.Value.MaxConcurrentBatches);
                 _logger.LogInformation("All of the owner changes have been pushed to Azure Search.");
 
                 // Persist in storage the list of all package IDs that have owner changes. This allows debugging and future
@@ -99,13 +100,37 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
             }
         }
 
-        private async Task WorkAsync(ConcurrentBag<IdAndValue<string[]>> changesBag)
+        private async Task WorkAndRetryAsync(ConcurrentBag<IdAndValue<string[]>> changesBag)
         {
             await Task.Yield();
 
+            WorkResult result;
+            var attempt = 0;
+            do
+            {
+                attempt++;
+                result = await WorkAsync(changesBag);
+                changesBag = result.Attempted;
+            }
+            while (!result.Success && attempt < 3);
+
+            result
+                .Results
+                .Where(x => !x.Success)
+                .Aggregate(new BatchPusherResult(), (a, b) => a.Merge(b))
+                .EnsureSuccess();
+        }
+
+        private async Task<WorkResult> WorkAsync(ConcurrentBag<IdAndValue<string[]>> changesBag)
+        {
             var batchPusher = _batchPusherFactory();
+            var attempted = new ConcurrentBag<IdAndValue<string[]>>();
+            var results = new List<BatchPusherResult>();
+
             while (changesBag.TryTake(out var changes))
             {
+                attempted.Add(changes);
+
                 // Note that the owner list passed in can be empty (e.g. if the last owner was deleted or removed from
                 // the package registration).
                 var indexActions = await _searchIndexActionBuilder.UpdateAsync(
@@ -121,12 +146,24 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
 
                 batchPusher.EnqueueIndexActions(changes.Id, indexActions);
 
-                var fullBatchesResult = await batchPusher.TryPushFullBatchesAsync();
-                fullBatchesResult.EnsureNoFailures();
+                results.Add(await batchPusher.TryPushFullBatchesAsync());
             }
 
-            var finishResult = await batchPusher.TryFinishAsync();
-            finishResult.EnsureNoFailures();
+            results.Add(await batchPusher.TryFinishAsync());
+            return new WorkResult(attempted, results);
+        }
+
+        private class WorkResult
+        {
+            public WorkResult(ConcurrentBag<IdAndValue<string[]>> attempted, List<BatchPusherResult> results)
+            {
+                Attempted = attempted;
+                Results = results;
+            }
+
+            public bool Success => Results.All(x => x.Success);
+            public ConcurrentBag<IdAndValue<string[]>> Attempted { get; }
+            public List<BatchPusherResult> Results { get; }
         }
     }
 }

--- a/src/NuGet.Services.AzureSearch/BatchPusher.cs
+++ b/src/NuGet.Services.AzureSearch/BatchPusher.cs
@@ -106,18 +106,18 @@ namespace NuGet.Services.AzureSearch
 
         private async Task<BatchPusherResult> TryPushBatchesAsync(bool onlyFull)
         {
-            var failedPackageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var failedPackageIds = new List<string>();
             failedPackageIds.AddRange(await PushBatchesAsync(_hijackIndexClient, _hijackActions, onlyFull));
             failedPackageIds.AddRange(await PushBatchesAsync(_searchIndexClient, _searchActions, onlyFull));
             return new BatchPusherResult(failedPackageIds);
         }
 
-        private async Task<HashSet<string>> PushBatchesAsync(
+        private async Task<List<string>> PushBatchesAsync(
             ISearchIndexClientWrapper indexClient,
             Queue<IdAndValue<IndexAction<KeyedDocument>>> actions,
             bool onlyFull)
         {
-            var failedPackageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var failedPackageIds = new List<string>();
             while ((onlyFull && actions.Count >= _options.Value.AzureSearchBatchSize)
                 || (!onlyFull && actions.Count > 0))
             {

--- a/src/NuGet.Services.AzureSearch/BatchPusherResult.cs
+++ b/src/NuGet.Services.AzureSearch/BatchPusherResult.cs
@@ -9,13 +9,13 @@ namespace NuGet.Services.AzureSearch
 {
     public class BatchPusherResult
     {
-        public BatchPusherResult() : this(new HashSet<string>())
+        public BatchPusherResult() : this(Array.Empty<string>())
         {
         }
 
-        public BatchPusherResult(HashSet<string> failedPackageIds)
+        public BatchPusherResult(IEnumerable<string> failedPackageIds)
         {
-            FailedPackageIds = failedPackageIds;
+            FailedPackageIds = failedPackageIds.ToHashSet(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -23,14 +23,23 @@ namespace NuGet.Services.AzureSearch
         /// </summary>
         public HashSet<string> FailedPackageIds { get; }
 
-        public void EnsureNoFailures()
+        public bool Success => !FailedPackageIds.Any();
+
+        public void EnsureSuccess()
         {
-            if (FailedPackageIds.Any())
+            if (!Success)
             {
                 throw new InvalidOperationException(
                     "The index operations for the following package IDs failed due to version list concurrency: "
-                    + string.Join(", ", FailedPackageIds));
+                    + string.Join(", ", FailedPackageIds.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)));
             }
+        }
+
+        public BatchPusherResult Merge(BatchPusherResult other)
+        {
+            return new BatchPusherResult(FailedPackageIds
+                .Concat(other.FailedPackageIds)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/AzureSearchCollectorLogic.cs
+++ b/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/AzureSearchCollectorLogic.cs
@@ -58,13 +58,33 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
 
         public async Task OnProcessBatchAsync(IEnumerable<CatalogCommitItem> items)
         {
-            await ProcessItemsAsync(items, allowFixUp: true);
+            var itemList = items.ToList();
+            var attempt = 0;
+            var success = false;
+            while (!success)
+            {
+                attempt++;
+                var result = await ProcessItemsAsync(itemList, allowRetry: attempt < 3);
+                success = result.Success;
+                itemList = result.Items;
+            }
         }
 
-        private async Task ProcessItemsAsync(IEnumerable<CatalogCommitItem> items, bool allowFixUp)
+        /// <summary>
+        /// Processes the provided list of catalog items while handling known retriable errors. It is this method's
+        /// responsibility to throw an exception if the operation is unsuccessful and <paramref name="allowRetry"/> is
+        /// <c>false</c>, even if the failure is generally retriable. Failure to do so could lead to an infinite loop
+        /// in the caller.
+        /// </summary>
+        /// <param name="itemList">The item list to use for the Azure Search updates.</param>
+        /// <param name="allowRetry">
+        /// False to make any error encountered bubble out as an exception. True if retriable errors should returned a
+        /// result with <see cref="ProcessItemsResult.Success"/> set to <c>false</c>.
+        /// </param>
+        /// <returns>The result, including success boolean and the next item list to use for a retry.</returns>
+        private async Task<ProcessItemsResult> ProcessItemsAsync(List<CatalogCommitItem> itemList, bool allowRetry)
         {
-            var itemList = items.ToList();
-            var latestItems = _utility.GetLatestPerIdentity(items);
+            var latestItems = _utility.GetLatestPerIdentity(itemList);
             var allWork = _utility.GroupById(latestItems);
 
             using (_telemetryService.TrackCatalog2AzureSearchProcessBatch(itemList.Count, latestItems.Count, allWork.Count))
@@ -85,9 +105,16 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                 try
                 {
                     var finishResult = await batchPusher.TryFinishAsync();
-                    finishResult.EnsureNoFailures();
+                    if (allowRetry && !finishResult.Success)
+                    {
+                        _logger.LogWarning("Retrying catalog batch due to access condition failures on package IDs: {Ids}", finishResult.FailedPackageIds);
+                        return new ProcessItemsResult(success: false, items: itemList);
+                    }
+
+                    finishResult.EnsureSuccess();
+                    return new ProcessItemsResult(success: true, items: itemList);
                 }
-                catch (InvalidOperationException ex) when (allowFixUp)
+                catch (InvalidOperationException ex) when (allowRetry)
                 {
                     var result = await _fixUpEvaluator.TryFixUpAsync(itemList, allIndexActions, ex);
                     if (!result.Applicable)
@@ -95,9 +122,26 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
                         throw;
                     }
 
-                    await ProcessItemsAsync(result.ItemList, allowFixUp: false);
+                    _logger.LogWarning("Retrying catalog batch due to Azure Search bug fix-up.");
+                    return new ProcessItemsResult(success: false, items: result.ItemList);
                 }
             }
+        }
+
+        private class ProcessItemsResult
+        {
+            public ProcessItemsResult(bool success, List<CatalogCommitItem> items)
+            {
+                Success = success;
+                Items = items ?? throw new ArgumentNullException(nameof(items));
+            }
+
+            public bool Success { get; }
+
+            /// <summary>
+            /// The item list to used for the next iteration.
+            /// </summary>
+            public List<CatalogCommitItem> Items { get; }
         }
 
         private async Task<ConcurrentBag<IdAndValue<IndexActions>>> ProcessWorkAsync(

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchCommand.cs
@@ -251,12 +251,12 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                     {
                         batchPusher.EnqueueIndexActions(work.PackageId, indexActions);
                         var fullBatchesResult = await batchPusher.TryPushFullBatchesAsync();
-                        fullBatchesResult.EnsureNoFailures();
+                        fullBatchesResult.EnsureSuccess();
                     }
                 }
 
                 var finishResult = await batchPusher.TryFinishAsync();
-                finishResult.EnsureNoFailures();
+                finishResult.EnsureSuccess();
             }
             catch (Exception ex)
             {

--- a/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/UpdateDownloadsCommandFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/UpdateDownloadsCommandFacts.cs
@@ -127,6 +127,70 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
             }
 
             [Fact]
+            public async Task RetriesFailedPackageIds()
+            {
+                Config.MaxConcurrentVersionListWriters = 1;
+                Changes["PackageA"] = 1;
+                Changes["PackageB"] = 2;
+                BatchPusher
+                    .SetupSequence(x => x.TryFinishAsync())
+                    .ReturnsAsync(new BatchPusherResult(new[] { "PackageB" }))
+                    .ReturnsAsync(new BatchPusherResult());
+
+                await Target.ExecuteAsync();
+
+                VerifyCompletedTelemetry(JobOutcome.Success);
+                VerifyAllIdsAreProcessed(new[] { "PackageA", "PackageB", "PackageB" });
+                IndexActionBuilder.Verify(
+                    x => x.UpdateAsync(
+                        "PackageA",
+                        It.IsAny<Func<SearchFilters, KeyedDocument>>()),
+                    Times.Once);
+                IndexActionBuilder.Verify(
+                    x => x.UpdateAsync(
+                        "PackageB",
+                        It.IsAny<Func<SearchFilters, KeyedDocument>>()),
+                    Times.Exactly(2));
+                BatchPusher.Verify(
+                    x => x.EnqueueIndexActions(It.IsAny<string>(), It.IsAny<IndexActions>()),
+                    Times.Exactly(3));
+                BatchPusher.Verify(x => x.TryFinishAsync(), Times.Exactly(2));
+                BatchPusher.Verify(x => x.TryPushFullBatchesAsync(), Times.Never);
+            }
+
+            [Fact]
+            public async Task EventuallyFailsIfBatchPusherNeverSucceeds()
+            {
+                Config.MaxConcurrentVersionListWriters = 1;
+                Changes["PackageA"] = 1;
+                Changes["PackageB"] = 2;
+                BatchPusher
+                    .Setup(x => x.TryFinishAsync())
+                    .ReturnsAsync(new BatchPusherResult(new[] { "PackageB" }));
+
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => Target.ExecuteAsync());
+
+                Assert.Equal("The index operations for the following package IDs failed due to version list concurrency: PackageB", ex.Message);
+                VerifyCompletedTelemetry(JobOutcome.Failure);
+                VerifyAllIdsAreProcessed(new[] { "PackageA", "PackageB", "PackageB", "PackageB" });
+                IndexActionBuilder.Verify(
+                    x => x.UpdateAsync(
+                        "PackageA",
+                        It.IsAny<Func<SearchFilters, KeyedDocument>>()),
+                    Times.Once);
+                IndexActionBuilder.Verify(
+                    x => x.UpdateAsync(
+                        "PackageB",
+                        It.IsAny<Func<SearchFilters, KeyedDocument>>()),
+                    Times.Exactly(3));
+                BatchPusher.Verify(
+                    x => x.EnqueueIndexActions(It.IsAny<string>(), It.IsAny<IndexActions>()),
+                    Times.Exactly(4));
+                BatchPusher.Verify(x => x.TryFinishAsync(), Times.Exactly(3));
+                BatchPusher.Verify(x => x.TryPushFullBatchesAsync(), Times.Never);
+            }
+
+            [Fact]
             public async Task FailureIsRecordedInTelemetry()
             {
                 var expected = new InvalidOperationException("Something bad!");
@@ -605,10 +669,15 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
             public void VerifyAllIdsAreProcessed(int changeCount)
             {
                 var changedIds = Changes.Keys.OrderBy(x => x).ToArray();
+                Assert.Equal(changeCount, changedIds.Length);
+                VerifyAllIdsAreProcessed(changedIds);
+            }
+
+            public void VerifyAllIdsAreProcessed(string[] changedIds)
+            {
                 var processedIds = ProcessedIds.OrderBy(x => x).ToArray();
                 var pushedIds = PushedIds.OrderBy(x => x).ToArray();
 
-                Assert.Equal(changeCount, changedIds.Length);
                 Assert.Equal(changedIds, processedIds);
                 Assert.Equal(changedIds, pushedIds);
             }


### PR DESCRIPTION
This allows 412s to be handled gracefully in most cases.
Address https://github.com/NuGet/NuGetGallery/issues/8051
Follow-up to https://github.com/NuGet/NuGet.Services.Metadata/pull/788