### PR TITLE
Retry HTTP 412 when reading blobs in AuxiliaryFileClient

### DIFF
--- a/src/Catalog/HttpReadCursor.cs
+++ b/src/Catalog/HttpReadCursor.cs
@@ -61,7 +61,7 @@ namespace NuGet.Services.Metadata.Catalog
 
                     Trace.TraceInformation("HttpReadCursor.Load: {0}", this);
                 },
-                ex => ex is HttpRequestException,
+                ex => ex is HttpRequestException || ex is TaskCanceledException,
                 maxRetries: 5,
                 initialWaitInterval: TimeSpan.Zero,
                 waitIncrement: TimeSpan.FromSeconds(10));


### PR DESCRIPTION
A 412 can happen if the downloads.v1.json gets written while the blob is being read
Also retry on an timeout from reading an HTTP-based cursor

I saw both of these errors in DEV.

Best viewed by with [whitespace hidden](https://github.com/NuGet/NuGet.Services.Metadata/pull/795/files?diff=unified&w=1).

Address https://github.com/NuGet/NuGetGallery/issues/8076