### PR TITLE
[Advanced Search] Add sorting & filtering to the search service (#794)

### DIFF
--- a/src/NuGet.Services.AzureSearch/SearchService/AzureSearchService.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AzureSearchService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Services.AzureSearch.Wrappers;
 using NuGetGallery;
@@ -34,6 +35,15 @@ namespace NuGet.Services.AzureSearch.SearchService
         {
             if (request.IgnoreFilter)
             {
+                if (request.PackageType != null && request.PackageType.Any())
+                {
+                    throw new InvalidSearchRequestException("Can't apply the packageType filter on the Hijack index");
+                }
+                else if (request.SortBy == V2SortBy.TotalDownloadsAsc || request.SortBy == V2SortBy.TotalDownloadsDesc)
+                {
+                    throw new InvalidSearchRequestException("Can't sortBy downloads on the Hijack index");
+                }
+
                 return await UseHijackIndexAsync(request);
             }
             else

--- a/src/NuGet.Services.AzureSearch/SearchService/IndexOperationBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IndexOperationBuilder.cs
@@ -50,7 +50,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         public IndexOperation V2SearchWithSearchIndex(V2SearchRequest request)
         {
-            if (HasInvalidParameters(request, packageType: null))
+            if (HasInvalidParameters(request, request.PackageType))
             {
                 return IndexOperation.Empty();
             }
@@ -58,7 +58,8 @@ namespace NuGet.Services.AzureSearch.SearchService
             var parsed = _textBuilder.ParseV2Search(request);
 
             IndexOperation indexOperation;
-            if (TryGetSearchDocumentByKey(request, parsed, out indexOperation))
+            if (request.PackageType == null
+                && TryGetSearchDocumentByKey(request, parsed, out indexOperation))
             {
                 return indexOperation;
             }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchRequest.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchRequest.cs
@@ -9,5 +9,6 @@ namespace NuGet.Services.AzureSearch.SearchService
         public bool CountOnly { get; set; }
         public V2SortBy SortBy { get; set; }
         public bool LuceneQuery { get; set; }
+        public string PackageType { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V2SortBy.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V2SortBy.cs
@@ -12,5 +12,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         SortableTitleDesc,
         CreatedAsc,
         CreatedDesc,
+        TotalDownloadsAsc,
+        TotalDownloadsDesc,
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchParametersBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchParametersBuilder.cs
@@ -30,10 +30,12 @@ namespace NuGet.Services.AzureSearch.SearchService
         private static readonly List<string> ScoreDesc = new List<string> { Score + Desc, IndexFields.Created + Desc }; // Highest score first ("most relevant"), then newest
         private static readonly List<string> LastEditedDesc = new List<string> { IndexFields.LastEdited + Desc, IndexFields.Created + Desc }; // Most recently edited first, then newest
         private static readonly List<string> PublishedDesc = new List<string> { IndexFields.Published + Desc, IndexFields.Created + Desc }; // Most recently published first, then newest
-        private static readonly List<string> SortableTitleAsc = new List<string> { IndexFields.SortableTitle + Asc, IndexFields.Created + Asc }; // First title by lex order first, then newest
-        private static readonly List<string> SortableTitleDesc = new List<string> { IndexFields.SortableTitle + Desc, IndexFields.Created + Desc }; // Last title by lex order first, then oldest
+        private static readonly List<string> SortableTitleAsc = new List<string> { IndexFields.SortableTitle + Asc, IndexFields.Created + Asc }; // First title by lex order first, then oldest
+        private static readonly List<string> SortableTitleDesc = new List<string> { IndexFields.SortableTitle + Desc, IndexFields.Created + Desc }; // Last title by lex order first, then newest
         private static readonly List<string> CreatedAsc = new List<string> { IndexFields.Created + Asc }; // Newest first
         private static readonly List<string> CreatedDesc = new List<string> { IndexFields.Created + Desc }; // Oldest first
+        private static readonly List<string> TotalDownloadsAsc = new List<string> { IndexFields.Search.TotalDownloadCount + Asc, IndexFields.Created + Asc }; // Least downloads first, then oldest
+        private static readonly List<string> TotalDownloadsDesc = new List<string> { IndexFields.Search.TotalDownloadCount + Desc, IndexFields.Created + Desc}; // Most downloads first, then newest
 
         public SearchParameters LastCommitTimestamp()
         {
@@ -74,7 +76,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
             else
             {
-                ApplySearchIndexFilter(searchParameters, request, isDefaultSearch, packageType: null);
+                ApplySearchIndexFilter(searchParameters, request, isDefaultSearch, request.PackageType);
             }
 
             return searchParameters;
@@ -201,6 +203,12 @@ namespace NuGet.Services.AzureSearch.SearchService
                     break;
                 case V2SortBy.CreatedDesc:
                     orderBy = CreatedDesc;
+                    break;
+                case V2SortBy.TotalDownloadsAsc:
+                    orderBy = TotalDownloadsAsc;
+                    break;
+                case V2SortBy.TotalDownloadsDesc:
+                    orderBy = TotalDownloadsDesc;
                     break;
                 default:
                     throw new ArgumentException($"The provided {nameof(V2SortBy)} is not supported.", nameof(sortBy));

--- a/src/NuGet.Services.SearchService/Controllers/SearchController.cs
+++ b/src/NuGet.Services.SearchService/Controllers/SearchController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -22,12 +22,15 @@ namespace NuGet.Services.SearchService.Controllers
 
         private static readonly IReadOnlyDictionary<string, V2SortBy> SortBy = new Dictionary<string, V2SortBy>(StringComparer.OrdinalIgnoreCase)
         {
+            { "relevance", V2SortBy.Popularity },
             { "lastEdited", V2SortBy.LastEditedDesc },
             { "published", V2SortBy.PublishedDesc },
             { "title-asc", V2SortBy.SortableTitleAsc },
             { "title-desc", V2SortBy.SortableTitleDesc },
             { "created-asc", V2SortBy.CreatedAsc },
             { "created-desc", V2SortBy.CreatedDesc },
+            { "totalDownloads-asc", V2SortBy.TotalDownloadsAsc },
+            { "totalDownloads-desc", V2SortBy.TotalDownloadsDesc },
         };
 
         private readonly IAuxiliaryDataCache _auxiliaryDataCache;
@@ -81,6 +84,7 @@ namespace NuGet.Services.SearchService.Controllers
             string q = null,
             string sortBy = null,
             bool? luceneQuery = true,
+            string packageType = null,
             bool? debug = false)
         {
             await EnsureInitializedAsync();
@@ -96,6 +100,7 @@ namespace NuGet.Services.SearchService.Controllers
                 Query = q,
                 SortBy = GetSortBy(sortBy),
                 LuceneQuery = luceneQuery ?? true,
+                PackageType = packageType,
                 ShowDebug = debug ?? false,
             };
 

--- a/tests/BasicSearchTests.FunctionalTests.Core/Models/V2SearchResultEntry.cs
+++ b/tests/BasicSearchTests.FunctionalTests.Core/Models/V2SearchResultEntry.cs
@@ -1,5 +1,8 @@
-﻿using Newtonsoft.Json;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
+using Newtonsoft.Json;
 
 namespace BasicSearchTests.FunctionalTests.Core.Models
 {

--- a/tests/BasicSearchTests.FunctionalTests.Core/TestSupport/V2SearchBuilder.cs
+++ b/tests/BasicSearchTests.FunctionalTests.Core/TestSupport/V2SearchBuilder.cs
@@ -22,6 +22,8 @@ namespace BasicSearchTests.FunctionalTests.Core.TestSupport
 
         public bool? LuceneQuery { get; set; }
 
+        public string PackageType { get; set; }
+
         public V2SearchBuilder() : base("/search/query?") { }
 
         protected override NameValueCollection GetQueryString()
@@ -55,6 +57,11 @@ namespace BasicSearchTests.FunctionalTests.Core.TestSupport
             if (LuceneQuery.HasValue)
             {
                 queryString["luceneQuery"] = LuceneQuery.ToString();
+            }
+
+            if (PackageType != null)
+            {
+                queryString["packageType"] = PackageType;
             }
 
             return queryString;

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/V3SearchProtocolTests.cs
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/V3SearchProtocolTests.cs
@@ -86,17 +86,17 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
         [MemberData(nameof(TakeResults))]
         public async Task TakeReturnsExactResults(int take)
         {
-            var results = await V3SearchAsync(new V3SearchBuilder { Query = "json", Take = take });
+            var results = await V3SearchAsync(new V3SearchBuilder { Query = "", Take = take });
 
             Assert.NotNull(results);
-            Assert.True(results.TotalHits > take);
+            Assert.True(results.TotalHits >= results.Data.Count);
             Assert.True(results.Data.Count == take, $"The search result did not return the expected {take} results");
         }
 
         [Fact]
         public async Task SkipDoesSkipThePackagesInResult()
         {
-            var searchTerm = "json";
+            var searchTerm = "";
             var skip = 5;
             var resultsWithoutSkip = await V3SearchAsync(new V3SearchBuilder { Query = searchTerm, Take = 10 });
             var resultsWithSkip = await V3SearchAsync(new V3SearchBuilder { Query = searchTerm, Skip = skip, Take = 10 - skip });

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/AzureSearchServiceFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/AzureSearchServiceFacts.cs
@@ -59,6 +59,30 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             [Fact]
+            public async Task ShouldThrowOnInvalidAdvancedSearchOnHijackIndex()
+            {
+                _v2Request.IgnoreFilter = true;
+                _v2Request.SortBy = V2SortBy.TotalDownloadsAsc;
+                await Assert.ThrowsAsync<InvalidSearchRequestException>(async () =>
+                 {
+                     await _target.V2SearchAsync(_v2Request);
+                 });
+
+                _v2Request.SortBy = V2SortBy.TotalDownloadsDesc;
+                await Assert.ThrowsAsync<InvalidSearchRequestException>(async () =>
+                {
+                    await _target.V2SearchAsync(_v2Request);
+                });
+
+                _v2Request.SortBy = V2SortBy.Popularity; // This is valid
+                _v2Request.PackageType = "dotnettool"; // This should make the request crash
+                await Assert.ThrowsAsync<InvalidSearchRequestException>(async () =>
+                {
+                    await _target.V2SearchAsync(_v2Request);
+                });
+            }
+
+            [Fact]
             public async Task SearchIndexAndGetOperation()
             {
                 _v2Request.IgnoreFilter = false;

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/IndexOperationBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/IndexOperationBuilderFacts.cs
@@ -120,6 +120,27 @@ namespace NuGet.Services.AzureSearch.SearchService
                 TextBuilder.Verify(x => x.Build(ParsedQuery), Times.Once);
                 ParametersBuilder.Verify(x => x.V2Search(V2SearchRequest, It.IsAny<bool>()), Times.Once);
             }
+
+            [Fact]
+            public void ReturnsEmptyQueryForInvalidPackageType()
+            {
+                V2SearchRequest.PackageType = "invalid package type";
+
+                var actual = Build();
+
+                Assert.Equal(IndexOperationType.Empty, actual.Type);
+            }
+
+            [Fact]
+            public void BuildsSearchOperationForSingleValidPackageIdAndPackageType()
+            {
+                V2SearchRequest.PackageType = "Dependency";
+                ParsedQuery.Grouping[QueryField.PackageId] = new HashSet<string>(new[] { Id });
+
+                var actual = Build();
+
+                Assert.Equal(IndexOperationType.Search, actual.Type);
+            }
         }
 
         public class V2SearchWithHijackIndex : Facts

--- a/tests/NuGet.Services.SearchService.Tests/Controllers/SearchControllerFacts.cs
+++ b/tests/NuGet.Services.SearchService.Tests/Controllers/SearchControllerFacts.cs
@@ -152,6 +152,7 @@ namespace NuGet.Services.SearchService.Controllers
                 Assert.Null(lastRequest.Query);
                 Assert.True(lastRequest.LuceneQuery);
                 Assert.False(lastRequest.ShowDebug);
+                Assert.Null(lastRequest.PackageType);
             }
 
             [Fact]
@@ -173,7 +174,8 @@ namespace NuGet.Services.SearchService.Controllers
                     q: null,
                     sortBy: null,
                     luceneQuery: null,
-                    debug: null);
+                    debug: null,
+                    packageType: null);
 
                 _searchService.Verify(x => x.V2SearchAsync(It.IsAny<V2SearchRequest>()), Times.Once);
                 Assert.NotNull(lastRequest);
@@ -186,6 +188,7 @@ namespace NuGet.Services.SearchService.Controllers
                 Assert.Null(lastRequest.Query);
                 Assert.True(lastRequest.LuceneQuery);
                 Assert.False(lastRequest.ShowDebug);
+                Assert.Null(lastRequest.PackageType);
             }
 
             [Fact]
@@ -207,7 +210,8 @@ namespace NuGet.Services.SearchService.Controllers
                     q: "windows azure storage",
                     sortBy: "lastEdited",
                     luceneQuery: true,
-                    debug: true);
+                    debug: true,
+                    packageType: "dotnettool");
 
                 _searchService.Verify(x => x.V2SearchAsync(It.IsAny<V2SearchRequest>()), Times.Once);
                 Assert.NotNull(lastRequest);
@@ -220,6 +224,7 @@ namespace NuGet.Services.SearchService.Controllers
                 Assert.Equal("windows azure storage", lastRequest.Query);
                 Assert.True(lastRequest.LuceneQuery);
                 Assert.True(lastRequest.ShowDebug);
+                Assert.Equal("dotnettool", lastRequest.PackageType);
             }
 
             [Theory]
@@ -243,6 +248,10 @@ namespace NuGet.Services.SearchService.Controllers
             [InlineData("Created-asc", V2SortBy.CreatedAsc)]
             [InlineData("CREATED-desc", V2SortBy.CreatedDesc)]
             [InlineData("Created-desc", V2SortBy.CreatedDesc)]
+            [InlineData("totalDownloads", V2SortBy.Popularity)]
+            [InlineData("totalDownloads-asc", V2SortBy.TotalDownloadsAsc)]
+            [InlineData("totalDownloads-desc", V2SortBy.TotalDownloadsDesc)]
+            [InlineData("TotalDownloads-desc", V2SortBy.TotalDownloadsDesc)]
             public async Task ParsesSortBy(string sortBy, V2SortBy expected)
             {
                 await _target.V2SearchAsync(sortBy: sortBy);


### PR DESCRIPTION
* Add sort by downloads WIP

* Add sort by download in response builder

Use the auxiliary file to sort by downloads before returning a response

* Add Asc and Desc sorting for downloads

* Add functional tests for AdvancedSearch sorting

* Add unit tests for AdvancedSearch sorting

* Fix sorting variable in AdvancedSearch

* Add filtering parameter to AdvancedSearch

* Update comment on SearchReponseBuilder

* Add thenBy newest

* Fix tests for sorting order

* Simplified test cases for SearchResponseBuilder

* Fix tests

* Not using Random anymore for tests

* reverting packageType change

* Fix test styling

* Remove unused import

* Add packagetype parameter to V2 endpoint

* Add exceptions if invalid advanced search on Hijack index

* Add SearchController tests for packageType filter

* Add SearchParametersBuilder tests for packageType filter

* Add IndexOperationBuilder tests for packageType filter

* Add functional tests for package type filter

* V2 search now throws error 400 when using A-S on Hijack

* Update test case to catch the correct exception type