### PR TITLE
Fix functional tests

### DIFF
--- a/tests/BasicSearchTests.FunctionalTests.Core/TestSupport/RetryHandler.cs
+++ b/tests/BasicSearchTests.FunctionalTests.Core/TestSupport/RetryHandler.cs
@@ -22,6 +22,8 @@ namespace BasicSearchTests.FunctionalTests.Core.TestSupport
             HttpResponseMessage response = null;
             for (int i = 0; i < MaxRetries; i++)
             {
+                response?.Dispose();
+
                 response = await base.SendAsync(request, cancellationToken);
                 // One of the test validates that we get a 404 for a route, don't block on NotFound Http status code either.
                 if (response.IsSuccessStatusCode || response.StatusCode == System.Net.HttpStatusCode.NotFound)

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/V2SearchProtocolTests.cs
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/V2SearchProtocolTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -584,7 +584,7 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
                     case DateTime _:
                         return DateTime.Compare((DateTime)x1, (DateTime)x2) >= 0;
                     case string _:
-                        return string.Compare(x1.ToString(), x2.ToString()) >= 0;
+                        return string.Compare(x1.ToString(), x2.ToString(), StringComparison.OrdinalIgnoreCase) >= 0;
                     case long _:
                         return (long)x1 >= (long) x2;
                     default:


### PR DESCRIPTION
This PR fixes functional tests targeting the search service that were failing. 
Changes:

- Not disposing the response object made the HttpClient [behave weirdly](https://stackoverflow.com/questions/14095545/net-httpclient-hangs-after-several-requests-unless-fiddler-is-active)
- Since the search service orders results in a case-insensitive way, we need to check them in a case-insensitive way